### PR TITLE
fix(python): correct required-field detection for structured output

### DIFF
--- a/libraries/python/mcp_use/agents/mcpagent.py
+++ b/libraries/python/mcp_use/agents/mcpagent.py
@@ -596,7 +596,7 @@ class MCPAgent:
 
         try:
             for field_name, field_info in output_schema.model_fields.items():
-                required = not hasattr(field_info, "default") or field_info.default is None
+                required = field_info.is_required()
                 if required:
                     value = getattr(structured_result, field_name, None)
                     if value is None or (isinstance(value, str) and not value.strip()):
@@ -616,7 +616,7 @@ class MCPAgent:
         try:
             for field_name, field_info in output_schema.model_fields.items():
                 description = getattr(field_info, "description", "") or field_name
-                required = not hasattr(field_info, "default") or field_info.default is None
+                required = field_info.is_required()
                 schema_fields.append(f"- {field_name}: {description} {'(required)' if required else '(optional)'}")
 
             schema_description = "\n".join(schema_fields)
@@ -889,7 +889,7 @@ class MCPAgent:
                     schema_fields = []
                     for field_name, field_info in output_schema.model_fields.items():
                         description = getattr(field_info, "description", "") or field_name
-                        required = not hasattr(field_info, "default") or field_info.default is None
+                        required = field_info.is_required()
                         schema_fields.append(
                             f"- {field_name}: {description} " + ("(required)" if required else "(optional)")
                         )

--- a/libraries/python/tests/unit/test_agent.py
+++ b/libraries/python/tests/unit/test_agent.py
@@ -2,11 +2,13 @@
 Unit tests for the MCPAgent class.
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain_core.agents import AgentFinish
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from pydantic import BaseModel, Field
 
 from mcp_use.agents.mcpagent import MCPAgent
 from mcp_use.client import MCPClient
@@ -383,3 +385,61 @@ class TestMCPAgentStreamEvents:
         assert any(isinstance(message, AIMessage) and message.content == ai_message.content for message in history), (
             "Final AI message should be stored by stream_events()"
         )
+
+
+class _StructuredOutputSchema(BaseModel):
+    """Schema with one genuinely required field and one explicitly optional field."""
+
+    title: str = Field(description="A required title")
+    note: str | None = Field(default=None, description="An optional note")
+
+
+class TestMCPAgentStructuredOutputRequiredFields:
+    """Regression tests for required-vs-optional field detection on pydantic output schemas.
+
+    A required pydantic field has ``default = PydanticUndefined`` (not ``None``), so the old
+    ``not hasattr(field_info, "default") or field_info.default is None`` check inverted the
+    result: required fields read as optional and ``Optional[x] = None`` fields read as required.
+    """
+
+    def _agent(self):
+        llm = MagicMock()
+        llm._llm_type = "test-provider"
+        llm._identifying_params = {"model": "test-model"}
+        return MCPAgent(llm=llm, client=MagicMock(spec=MCPClient))
+
+    def test_enhance_query_marks_fields_correctly(self):
+        agent = self._agent()
+
+        enhanced = agent._enhance_query_with_schema("do the thing", _StructuredOutputSchema)
+
+        assert "title: A required title (required)" in enhanced
+        assert "note: An optional note (optional)" in enhanced
+
+    @pytest.mark.asyncio
+    async def test_attempt_structured_output_rejects_missing_required_field(self):
+        agent = self._agent()
+        structured_llm = MagicMock()
+
+        async def _ainvoke(_prompt):
+            return SimpleNamespace(title=None, note=None)
+
+        structured_llm.ainvoke = _ainvoke
+
+        with pytest.raises(ValueError, match="Required field 'title'"):
+            await agent._attempt_structured_output("raw", structured_llm, _StructuredOutputSchema, "schema")
+
+    @pytest.mark.asyncio
+    async def test_attempt_structured_output_allows_missing_optional_field(self):
+        agent = self._agent()
+        structured_llm = MagicMock()
+
+        async def _ainvoke(_prompt):
+            return SimpleNamespace(title="A title", note=None)
+
+        structured_llm.ainvoke = _ainvoke
+
+        result = await agent._attempt_structured_output("raw", structured_llm, _StructuredOutputSchema, "schema")
+
+        assert result.title == "A title"
+        assert result.note is None


### PR DESCRIPTION
Closes #2090.

### Problem

`FieldInfo` in pydantic v2 always has a `.default` attribute, so the required-field check

```python
required = not hasattr(field_info, "default") or field_info.default is None
```

collapses to `field_info.default is None`. That inverts the result:

| Declaration | Actual `.default` | Old check | Correct |
|---|---|---|---|
| `title: str` (required) | `PydanticUndefined` | optional | required |
| `note: str \| None = None` (optional) | `None` | required | optional |

Consequences in `MCPAgent` structured output:

- A genuinely required field that comes back missing/empty is **not** flagged, so incomplete structured output passes validation silently.
- An `Optional[x] = None` field that comes back empty is flagged as a missing required field and triggers the structured-output retry loop unnecessarily.
- The schema hints sent to the model (`_enhance_query_with_schema` and the `stream` schema description) label required/optional backwards.

### Fix

Replace all **three** occurrences with pydantic's own `FieldInfo.is_required()`:

- `_attempt_structured_output` (validation that raises → retry)
- `_enhance_query_with_schema` (schema hints for the model)
- the `stream` loop's schema-description builder — this one is not listed in the issue but has the identical bug

`is_required()` has been on `FieldInfo` since pydantic 2.0 and the library already pins `pydantic>=2.11,<3`.

### Tests

Added `TestMCPAgentStructuredOutputRequiredFields` in `tests/unit/test_agent.py`, using a schema with one required field and one `str | None = None` field:

- `_enhance_query_with_schema` labels the required field `(required)` and the optional field `(optional)`
- `_attempt_structured_output` raises when the required field is missing
- `_attempt_structured_output` returns normally when only the optional field is missing

All three fail on `main` and pass with this change. Full `tests/unit` suite passes; `ruff check` / `ruff format` clean; `ty check` reports no new diagnostics.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes required-field detection for pydantic v2 structured output in `MCPAgent` so missing required fields are rejected instead of passing silently, and optional `None` fields no longer trigger the retry loop. Applies `FieldInfo.is_required()` across all three affected code paths and adds regression tests for both cases. Closes #2090.

<sup>Written for commit 2b8e34b77a42825c4e4cc0a97897ea38c90b9143. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

