### PR TITLE
docs(cli): client remove takes --json, not --yes

### DIFF
--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -524,7 +524,7 @@ mcp-use client <name> <scope> <action>
 | ---------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `connect <name> <url>` | Verify and save an HTTP(S) MCP server. | `-H, --header`, `--no-oauth`, `--auth-timeout <ms>`, `--protocol <auto\|legacy\|modern>`, `--no-open`, `--json` |
 | `list`                 | List saved servers.                    | `--json`                                                                                                        |
-| `remove <name>`        | Remove a saved server and credentials. | `--yes`                                                                                                         |
+| `remove <name>`        | Remove a saved server and credentials. | `--json`                                                                                                         |
 
 **Per-server scopes:**
 


### PR DESCRIPTION
## Why

The client command table lists `--yes` as the key option for `remove <name>`. Copying that fails:

```
$ mcp-use client remove doomed --yes
Unknown option '--yes'. To specify a positional argument starting with a '-', ...
exit 2
```

`remove` parses no options of its own and never prompts, so there is nothing for `--yes` to skip:

```ts
// packages/cli/src/commands/client.ts:178
async function remove(argv, json) {
  const { positionals } = parseArgs({ args: [...argv], strict: true, options: {} });
```

It does honour the global `--json`, which is what the row should say:

```
$ mcp-use client remove tmp1 --json
{"removed":"tmp1"}
exit 0
```

## `--yes` is real, just not here

It is declared only on `auth logout` (`client.ts:224`), which genuinely calls `confirm(...)`. That row already documents it correctly, so it is untouched:

```
$ mcp-use client s1 auth logout --yes
Logged out s1.
exit 0
```

## Verified both directions

| invocation | exit |
|---|---|
| `client remove <name>` | 0, `Removed <name>.` |
| `client remove <name> --json` | 0, `{"removed":"<name>"}` |
| `client remove <name> --yes` | **2, Unknown option** |
| `client <name> auth logout --yes` | 0, `Logged out <name>.` |

All four run against a live scaffolded server, not read off the help text.

One-word change to one table cell. Same class as the `generate-types` and `client screenshot` corrections in #2352, found the same way: diffing the page against what the binary actually does.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI reference table so `client remove <name>` documents `--json` instead of `--yes`.

The command parses no options of its own and never prompts, so `--yes` fails with "Unknown option"; `--json` works and returns `{"removed":"<name>"}`. `--yes` remains valid on `auth logout`, which prompts for confirmation.

<sup>Written for commit 2345af3ab4874103f8bcbe817965c00c76e6ba5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

