### PR TITLE
docs(cli): drop the two deploy flags that do not exist

### DIFF
--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -256,8 +256,6 @@ mcp-use deploy [options]
 | ------------------------- | -------------------------------------------------------------------------------------- | ------------------ |
 | `--open`                  | Open the deployment in a browser after a successful deploy.                            | Disabled           |
 | `--name <name>`           | Deployment or server name.                                                             | Auto-generated     |
-| `--port <port>`           | Server port used by the deployed process.                                              | `3000`             |
-| `--runtime <runtime>`     | Runtime, either `node` or `python`.                                                    | Auto-detected      |
 | `--new`                   | Create a new deployment instead of reusing the linked project.                         | Disabled           |
 | `--env <key=value...>`    | Environment variable assignment. Repeatable.                                           | None               |
 | `--env-file <path>`       | Load environment variables from a `.env` file.                                         | None               |

--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -279,7 +279,6 @@ mcp-use deploy --no-github
 mcp-use deploy --name my-server --open
 mcp-use deploy --env DATABASE_URL=postgres://... --env API_KEY=secret
 mcp-use deploy --env-file .env.production
-mcp-use deploy --runtime python
 mcp-use deploy --root-dir apps/mcp-server
 mcp-use deploy --root-dir apps/mcp-server --watch-paths "apps/mcp-server/**" "packages/shared/**"
 mcp-use deploy --new --name my-server-v2


### PR DESCRIPTION
## Why

The `deploy` option table lists `--port` and `--runtime`. Neither is accepted:

```
$ mcp-use deploy --port 3000
Unknown option '--port'.      exit 2

$ mcp-use deploy --runtime node
Unknown option '--runtime'.   exit 2
```

`deploy`'s `parseArgs` declares exactly:

```
org, name, branch, root-dir, region, env, env-file, build-command,
start-command, dockerfile, watch-paths, wait-for-ci, no-github,
new, open, yes, json, help
```

There is nowhere for `port` or `runtime` to land.

## Every other row checked, and one thing worth noting

I ran all 18 documented flags individually. The other 16 all parse and reach the auth check at exit 1. That includes **`-y`**, whose short form does work on `deploy` even though the equivalent on `deployments delete` does not, so I have left `-y, --yes` alone here. Asymmetric, but real, which is why I tested rather than assuming symmetry with #2379.

`--new` looked like a failure at first, exit 2 with `Create a new cloud server for this project?`. That is a confirmation prompt, not a parse error, so it stays.

## Scope

`--port` remains in the `dev` and `start` tables, where it is genuine. My first attempt at this patch matched `--port <port>` across the whole file and would have deleted those two valid rows as well; the assertion in my edit script caught it before anything was written.

Two lines removed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the `--port` and `--runtime` flags from the `deploy` command's option table and its examples because the CLI rejects both options. Verified the remaining 16 flags parse correctly, including `-y, --yes`, which works on `deploy` even though it doesn't on `deployments delete`. `--port` stays in the `dev` and `start` tables, as well as the `--runtime python` example, where they're valid.

<sup>Written for commit 5061a6c9a9cf5740fb94d29ac1ebf0bbf47e5807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

