### PR TITLE
docs(cli): org use, and logout takes --yes

### DIFF
--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -365,15 +365,20 @@ mcp-use whoami
 **Syntax:**
 
 ```bash
-mcp-use logout
+mcp-use logout [options]
 ```
 
-**Options:** None.
+**Options:**
+
+| Option       | Description                | Default             |
+| ------------ | -------------------------- | ------------------- |
+| `--yes`      | Skip the confirmation prompt. | Prompts          |
+| `--json`     | Emit one machine-readable JSON result. | Human-readable text |
 
 **Examples:**
 
 ```bash
-mcp-use logout
+mcp-use logout --yes
 ```
 
 **Notes and behavior:** The command removes credentials from `~/.mcp-use/config.json`.
@@ -386,7 +391,7 @@ Organization commands control the active Manufact Cloud organization for cloud c
 | ------------- | ------------------------------------------------------- | --------------------- |
 | `org list`    | List organizations available to the authenticated user. | `mcp-use org list`    |
 | `org current` | Show the active organization.                           | `mcp-use org current` |
-| `org switch`  | Select a different active organization interactively.   | `mcp-use org switch`  |
+| `org use`     | Select a different active organization interactively.   | `mcp-use org use`     |
 
 **Notes and behavior:**
 

--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -370,10 +370,10 @@ mcp-use logout [options]
 
 **Options:**
 
-| Option       | Description                | Default             |
-| ------------ | -------------------------- | ------------------- |
-| `--yes`      | Skip the confirmation prompt. | Prompts          |
-| `--json`     | Emit one machine-readable JSON result. | Human-readable text |
+| Option   | Description                                                    | Default             |
+| -------- | -------------------------------------------------------------- | ------------------- |
+| `--yes`  | Skip confirmation. Required for non-interactive and JSON runs. | Prompts on a TTY    |
+| `--json` | Emit one machine-readable JSON result.                         | Human-readable text |
 
 **Examples:**
 
@@ -387,11 +387,11 @@ mcp-use logout --yes
 
 Organization commands control the active Manufact Cloud organization for cloud commands.
 
-| Command       | Purpose                                                 | Syntax                |
-| ------------- | ------------------------------------------------------- | --------------------- |
-| `org list`    | List organizations available to the authenticated user. | `mcp-use org list`    |
-| `org current` | Show the active organization.                           | `mcp-use org current` |
-| `org use`     | Select a different active organization interactively.   | `mcp-use org use`     |
+| Command                  | Purpose                                                 | Syntax                           |
+| ------------------------ | ------------------------------------------------------- | -------------------------------- |
+| `org list`               | List organizations available to the authenticated user. | `mcp-use org list`               |
+| `org current`            | Show the active organization.                           | `mcp-use org current`            |
+| `org use <id-or-slug>`   | Select and persist a different active organization.     | `mcp-use org use <id-or-slug>`   |
 
 **Notes and behavior:**
 


### PR DESCRIPTION
Two more rows checked the same way as #2379 and #2380: run it, and tell a parse failure (exit 2) from a real auth failure (exit 1).

## `org switch` does not exist

```
$ mcp-use org switch my-org
Usage: mcp-use org <list|current|use>     exit 2

$ mcp-use org use my-org
Not logged in. Run `mcp-use login`.       exit 1
```

The third subcommand is `use`. `org list` and `org current` are correct and untouched.

## `logout` is documented as taking no options

The example is a bare `mcp-use logout`, which cannot complete without a TTY, because the command prompts:

```
$ mcp-use logout
Log out? Pass --yes to confirm.           exit 2

$ mcp-use logout --yes
Logged out.                               exit 0
```

It also honours `--json`, which I verified rather than assuming from the other commands:

```
$ mcp-use logout --json --yes
{"loggedOut":true}                        exit 0
```

So the page now lists both options and the example is runnable.

## One thing I checked and did not change

While auditing this section I thought the `servers env` table was wrong too, describing `add`, `update` and `remove` subcommands against a CLI that only has `list`, `set` and `unset`. **It is already correct on `main`.** I was reading a stale local checkout that was 17 commits behind, and #2288 had already fixed exactly that. Mentioning it so nobody re-opens it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the CLI reference so the docs match the binary for `org use` and `logout`.

- Renames `org switch` to `org use` and updates its syntax and purpose.
- Documents `--yes` and `--json` for `logout` and makes the example runnable without a TTY.
- No behavior changes; docs only.

<sup>Written for commit eb4e6ae6067de1ad9b8a6a06ff8b2c4863df9d97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

