### PR TITLE
fix(python): await async telemetry calls

### DIFF
--- a/libraries/python/mcp_use/telemetry/telemetry.py
+++ b/libraries/python/mcp_use/telemetry/telemetry.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import os
 import platform
@@ -53,6 +54,51 @@ def telemetry(event_name: str, additional_properties: dict[str, Any] | None = No
     """Decorator to automatically track feature usage"""
 
     def decorator(func: Callable) -> Callable:
+        def capture_event(self, start_time: float, success: bool, error_type: str | None) -> None:
+            telemetry_client = None
+            if hasattr(self, "telemetry"):
+                telemetry_client = self.telemetry
+            elif hasattr(self, "_telemetry"):
+                telemetry_client = self._telemetry
+            else:
+                telemetry_client = Telemetry()
+
+            if telemetry_client:
+                telemetry_client.capture(
+                    event=GenericTelemetryEvent(
+                        EVENT_NAME=event_name,
+                        **{
+                            **(additional_properties or {}),
+                            "success": success,
+                            "execution_time_ms": int((time.time() - start_time) * 1000),
+                            "error_type": error_type,
+                        },
+                    )
+                )
+
+        if inspect.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(self, *args, **kwargs):
+                record_telemetry = getattr(self, "_record_telemetry", None)
+                if record_telemetry is not None and not record_telemetry:
+                    return await func(self, *args, **kwargs)
+
+                start_time = time.time()
+                success = True
+                error_type = None
+
+                try:
+                    return await func(self, *args, **kwargs)
+                except Exception as e:
+                    success = False
+                    error_type = type(e).__name__
+                    raise
+                finally:
+                    capture_event(self, start_time, success, error_type)
+
+            return async_wrapper
+
         @wraps(func)
         def wrapper(self, *args, **kwargs):
             # Check if telemetry is disabled on this instance
@@ -72,28 +118,7 @@ def telemetry(event_name: str, additional_properties: dict[str, Any] | None = No
                 error_type = type(e).__name__
                 raise
             finally:
-                execution_time_ms = int((time.time() - start_time) * 1000)
-
-                telemetry = None
-                if hasattr(self, "telemetry"):
-                    telemetry = self.telemetry
-                elif hasattr(self, "_telemetry"):
-                    telemetry = self._telemetry
-                else:
-                    telemetry = Telemetry()
-
-                if telemetry:
-                    telemetry.capture(
-                        event=GenericTelemetryEvent(
-                            EVENT_NAME=event_name,
-                            **{
-                                **(additional_properties or {}),
-                                "success": success,
-                                "execution_time_ms": execution_time_ms,
-                                "error_type": error_type,
-                            },
-                        )
-                    )
+                capture_event(self, start_time, success, error_type)
 
         return wrapper
 

--- a/libraries/python/mcp_use/telemetry/telemetry.py
+++ b/libraries/python/mcp_use/telemetry/telemetry.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import logging
 import os
@@ -90,6 +91,10 @@ def telemetry(event_name: str, additional_properties: dict[str, Any] | None = No
 
                 try:
                     return await func(self, *args, **kwargs)
+                except asyncio.CancelledError as e:
+                    success = False
+                    error_type = type(e).__name__
+                    raise
                 except Exception as e:
                     success = False
                     error_type = type(e).__name__

--- a/libraries/python/tests/unit/test_telemetry_decorator.py
+++ b/libraries/python/tests/unit/test_telemetry_decorator.py
@@ -1,0 +1,82 @@
+import asyncio
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from mcp_use.telemetry.telemetry import telemetry
+
+
+class TelemetryProbe:
+    def __init__(self, record_telemetry: bool = True) -> None:
+        self._record_telemetry = record_telemetry
+        self.telemetry = MagicMock()
+
+    @telemetry("async_success")
+    async def wait_for(self, gate: asyncio.Event) -> str:
+        await gate.wait()
+        return "done"
+
+    @telemetry("async_failure")
+    async def fail(self) -> None:
+        await asyncio.sleep(0)
+        raise ValueError("boom")
+
+    @telemetry("sync_success")
+    def sync_value(self) -> str:
+        return "done"
+
+
+@pytest.mark.asyncio
+async def test_async_telemetry_is_captured_after_completion() -> None:
+    probe = TelemetryProbe()
+    gate = asyncio.Event()
+
+    with patch("mcp_use.telemetry.telemetry.time.time", side_effect=[10.0, 10.25]):
+        task = asyncio.create_task(probe.wait_for(gate))
+        await asyncio.sleep(0)
+
+        probe.telemetry.capture.assert_not_called()
+        gate.set()
+        assert await task == "done"
+
+    event = probe.telemetry.capture.call_args.kwargs["event"]
+    assert event.EVENT_NAME == "async_success"
+    assert event.success is True
+    assert event.execution_time_ms == 250
+    assert event.error_type is None
+
+
+@pytest.mark.asyncio
+async def test_async_telemetry_captures_awaited_failure() -> None:
+    probe = TelemetryProbe()
+
+    with pytest.raises(ValueError, match="boom"):
+        await probe.fail()
+
+    event = probe.telemetry.capture.call_args.kwargs["event"]
+    assert event.EVENT_NAME == "async_failure"
+    assert event.success is False
+    assert event.error_type == "ValueError"
+
+
+@pytest.mark.asyncio
+async def test_disabled_async_telemetry_still_awaits_function() -> None:
+    probe = TelemetryProbe(record_telemetry=False)
+    gate = asyncio.Event()
+    gate.set()
+
+    assert await probe.wait_for(gate) == "done"
+    probe.telemetry.capture.assert_not_called()
+
+
+def test_sync_telemetry_behavior_is_preserved() -> None:
+    probe = TelemetryProbe()
+
+    assert inspect.iscoroutinefunction(probe.wait_for)
+    assert probe.sync_value() == "done"
+    assert not inspect.iscoroutinefunction(probe.sync_value)
+
+    event = probe.telemetry.capture.call_args.kwargs["event"]
+    assert event.EVENT_NAME == "sync_success"
+    assert event.success is True

--- a/libraries/python/tests/unit/test_telemetry_decorator.py
+++ b/libraries/python/tests/unit/test_telemetry_decorator.py
@@ -22,6 +22,10 @@ class TelemetryProbe:
         await asyncio.sleep(0)
         raise ValueError("boom")
 
+    @telemetry("async_cancelled")
+    async def wait_forever(self) -> None:
+        await asyncio.Event().wait()
+
     @telemetry("sync_success")
     def sync_value(self) -> str:
         return "done"
@@ -32,7 +36,8 @@ async def test_async_telemetry_is_captured_after_completion() -> None:
     probe = TelemetryProbe()
     gate = asyncio.Event()
 
-    with patch("mcp_use.telemetry.telemetry.time.time", side_effect=[10.0, 10.25]):
+    with patch("mcp_use.telemetry.telemetry.time") as mock_time:
+        mock_time.time.side_effect = [10.0, 10.25]
         task = asyncio.create_task(probe.wait_for(gate))
         await asyncio.sleep(0)
 
@@ -58,6 +63,22 @@ async def test_async_telemetry_captures_awaited_failure() -> None:
     assert event.EVENT_NAME == "async_failure"
     assert event.success is False
     assert event.error_type == "ValueError"
+
+
+@pytest.mark.asyncio
+async def test_async_telemetry_captures_cancellation() -> None:
+    probe = TelemetryProbe()
+    task = asyncio.create_task(probe.wait_forever())
+    await asyncio.sleep(0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    event = probe.telemetry.capture.call_args.kwargs["event"]
+    assert event.EVENT_NAME == "async_cancelled"
+    assert event.success is False
+    assert event.error_type == "CancelledError"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Type of change

- [x] Python
- [ ] TypeScript
- [ ] Documentation
- [ ] Other

## Summary

The shared `@telemetry` decorator currently wraps coroutine functions with a synchronous wrapper. Calling any decorated async method therefore records a successful, near-zero-duration event as soon as the coroutine object is created, before its body runs. Exceptions raised while awaiting the coroutine are never captured.

This change uses `inspect.iscoroutinefunction` to preserve an async wrapper for coroutine functions, awaits the call before emitting telemetry, and keeps the existing synchronous path unchanged. It also preserves `_record_telemetry=False` while still awaiting and returning the async result.

The impact is shared rather than call-site-specific: current main has 23 async methods using this decorator across the client, sessions, connectors, OAuth, middleware, and server manager.

## Before

- async telemetry is emitted before execution completes
- awaited failures are reported as successful calls
- execution time measures coroutine creation, not execution

## After

- telemetry is emitted after the await completes
- awaited exceptions record `success=False` and the exception type
- elapsed time includes the coroutine execution
- decorated async methods remain recognizable as coroutine functions

## Testing

- `uv run pytest -q tests/unit/test_telemetry_decorator.py` - 4 passed
- `uv run pytest -q tests/unit` - 309 passed (with the `dev` and `e2b` extras)
- `uv run ruff check .` - passed
- `uv run ruff format --check .` - 229 files already formatted
- `uv run ty check mcp_use/telemetry/telemetry.py tests/unit/test_telemetry_decorator.py` - passed

The repository-wide `ty check mcp_use` baseline currently reports 168 diagnostics in unrelated files; the touched files pass directly.

## Risk and compatibility

This uses only the standard library and does not change event fields. Synchronous decorated methods retain their existing behavior. The intentional behavior change is that telemetry for async methods is now emitted at completion rather than coroutine creation.

Closes #2091

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `@telemetry` decorator so async methods emit telemetry after execution completes instead of when the coroutine is created.

- Async wrappers now await the call before recording; previously, telemetry captured a near-zero duration before the body ran.
- Awaited exceptions and `CancelledError` are captured with `success=False` and the exception type, then re-raised.
- `_record_telemetry=False` still skips telemetry while awaiting and returning the async result.
- Synchronous decorated methods keep their existing behavior.
- Adds unit tests covering async success, failure, cancellation, disabled telemetry, and sync paths.

<sup>Written for commit 569debdaa0bc21231def2b68f8885c6ef2e21e23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

