### PR TITLE
fix(telemetry): don't send raw prompt/response text by default

### DIFF
--- a/docs/python/development/telemetry.mdx
+++ b/docs/python/development/telemetry.mdx
@@ -22,7 +22,7 @@ MCP-use includes an **opt-out telemetry system** that helps us understand how th
 ### Agent Execution Data
 When you use `MCPAgent.run()` or `MCPAgent.stream()`, we collect:
 
-- **Query and response content** (to understand use cases)
+- **Query and response _length_** (character counts, always) — the raw text is **not** collected unless you opt in (see below)
 - **Model provider and name** (e.g., "openai", "gpt-4")
 - **MCP servers connected** (types and count, not specific URLs/paths)
 - **Tools used** (which MCP tools are popular)
@@ -35,10 +35,29 @@ When you use `MCPAgent.run()` or `MCPAgent.stream()`, we collect:
 - **Package download analytics** (via Scarf for distribution insights)
 
 ### What We DON'T Collect
+- **Raw prompt/response content** (only character lengths, unless you opt in — see below)
 - **Personal information** (no names, emails, or identifiers)
 - **Server URLs or file paths** (only connection types)
 - **API keys or credentials** (never transmitted)
 - **IP addresses** (PostHog configured with `disable_geoip=False`)
+
+## Prompt & Response Content
+
+By default, the `mcp_agent_execution` event reports only the **length** of the
+query and response (`query_length`, `response_length`), never the text itself.
+The raw `query` and `response` fields are sent as `null`.
+
+If you want to share the raw content (for example, on a self-hosted PostHog
+instance you control), opt in explicitly:
+
+```bash
+export MCP_USE_TELEMETRY_INCLUDE_CONTENT=true
+```
+
+<Warning>
+Only enable this if you own the telemetry destination or have consent to
+transmit user prompts. This can send end-user data off your machine.
+</Warning>
 
 ## How to Disable Telemetry
 
@@ -91,8 +110,10 @@ Here's what a typical telemetry event looks like:
   "properties": {
     "mcp_use_version": "1.3.0",
     "execution_method": "run",
-    "query": "Help me analyze sales data from the CSV file",
-    "response": "I'll help you analyze the sales data...",
+    "query": null,
+    "query_length": 44,
+    "response": null,
+    "response_length": 38,
     "model_provider": "openai",
     "model_name": "gpt-4",
     "server_count": 2,

--- a/libraries/python/mcp_use/telemetry/events.py
+++ b/libraries/python/mcp_use/telemetry/events.py
@@ -32,7 +32,9 @@ class MCPAgentExecutionEvent(BaseEvent):
     EVENT_NAME: str = field(default="mcp_agent_execution", init=False)
 
     execution_method: str
-    query: str
+    # Raw query text is only populated when MCP_USE_TELEMETRY_INCLUDE_CONTENT is
+    # explicitly enabled; otherwise it is None and only query_length is reported.
+    query: str | None
     query_length: int
     success: bool
     model_provider: str

--- a/libraries/python/mcp_use/telemetry/telemetry.py
+++ b/libraries/python/mcp_use/telemetry/telemetry.py
@@ -138,6 +138,10 @@ class Telemetry:
     def __init__(self):
         telemetry_disabled = os.getenv("MCP_USE_ANONYMIZED_TELEMETRY", "true").lower() == "false"
 
+        # Raw prompt/response text is only sent when the user explicitly opts in.
+        # By default we send only the derived *_length fields, never the content.
+        self._include_content = os.getenv("MCP_USE_TELEMETRY_INCLUDE_CONTENT", "false").lower() == "true"
+
         if telemetry_disabled:
             self._posthog_client = None
             self._scarf_client = None
@@ -358,10 +362,17 @@ class Telemetry:
         conversation_history_length: int | None = None,
     ) -> None:
         """Track comprehensive agent execution"""
+        # Always derive lengths from the real content, but only include the raw
+        # text itself when the user has opted in via MCP_USE_TELEMETRY_INCLUDE_CONTENT.
+        query_length = len(query)
+        response_length = len(response) if response else None
+        if not self._include_content:
+            query = None
+            response = None
         event = MCPAgentExecutionEvent(
             execution_method=execution_method,
             query=query,
-            query_length=len(query),
+            query_length=query_length,
             success=success,
             model_provider=model_provider,
             model_name=model_name,
@@ -379,7 +390,7 @@ class Telemetry:
             tools_used_count=tools_used_count,
             tools_used_names=tools_used_names,
             response=response,
-            response_length=len(response) if response else None,
+            response_length=response_length,
             execution_time_ms=execution_time_ms,
             error_type=error_type,
             conversation_history_length=conversation_history_length,

--- a/libraries/python/mcp_use/telemetry/telemetry.py
+++ b/libraries/python/mcp_use/telemetry/telemetry.py
@@ -365,7 +365,7 @@ class Telemetry:
         # Always derive lengths from the real content, but only include the raw
         # text itself when the user has opted in via MCP_USE_TELEMETRY_INCLUDE_CONTENT.
         query_length = len(query)
-        response_length = len(response) if response else None
+        response_length = len(response) if response is not None else None
         if not self._include_content:
             query = None
             response = None

--- a/libraries/python/tests/unit/test_telemetry_content_optin.py
+++ b/libraries/python/tests/unit/test_telemetry_content_optin.py
@@ -15,7 +15,9 @@ from mcp_use.telemetry.telemetry import Telemetry
 
 
 class TestTelemetryContentOptIn(unittest.TestCase):
-    def _capture_event(self, include_content: bool) -> MCPAgentExecutionEvent:
+    def _capture_event(
+        self, include_content: bool, response: str | None = "my secret response"
+    ) -> MCPAgentExecutionEvent:
         # Telemetry is a closure-based singleton, so drive the instance directly
         # rather than reconstructing it. Force a client present so the
         # requires_telemetry guard doesn't short-circuit capture().
@@ -45,7 +47,7 @@ class TestTelemetryContentOptIn(unittest.TestCase):
                 max_steps_used=1,
                 manage_connector=False,
                 external_history_used=False,
-                response="my secret response",
+                response=response,
             )
         return captured["event"]
 
@@ -66,11 +68,43 @@ class TestTelemetryContentOptIn(unittest.TestCase):
         self.assertEqual(event.query_length, len("my secret prompt"))
         self.assertEqual(event.response_length, len("my secret response"))
 
-    def test_default_env_disables_content(self):
-        # With the env var unset, a freshly-parsed flag must be False.
-        with patch.dict(os.environ, {}, clear=True):
-            flag = os.getenv("MCP_USE_TELEMETRY_INCLUDE_CONTENT", "false").lower() == "true"
-        self.assertFalse(flag)
+    def test_empty_response_keeps_its_length(self):
+        """An empty response is still a response: report length 0, not None."""
+        event = self._capture_event(include_content=False, response="")
+
+        self.assertIsNone(event.response)
+        self.assertEqual(event.response_length, 0)
+
+    def test_absent_response_has_no_length(self):
+        event = self._capture_event(include_content=False, response=None)
+
+        self.assertIsNone(event.response)
+        self.assertIsNone(event.response_length)
+
+    # --- Telemetry.__init__ env parsing -------------------------------------
+    # Telemetry is wrapped in @singleton, so calling Telemetry() returns the
+    # cached instance and never re-runs __init__. Reach the real class through
+    # the instance and initialize a throwaway object to exercise the default.
+    # MCP_USE_ANONYMIZED_TELEMETRY=false keeps __init__ on its early branch, so
+    # no PostHog/Scarf clients are constructed.
+
+    def _init_flag(self, env: dict[str, str]) -> bool:
+        cls = type(Telemetry())
+        with patch.dict(os.environ, {"MCP_USE_ANONYMIZED_TELEMETRY": "false", **env}, clear=True):
+            fresh = object.__new__(cls)
+            cls.__init__(fresh)
+        return fresh._include_content
+
+    def test_include_content_defaults_to_false(self):
+        self.assertFalse(self._init_flag({}))
+
+    def test_include_content_opt_in_via_env(self):
+        self.assertTrue(self._init_flag({"MCP_USE_TELEMETRY_INCLUDE_CONTENT": "true"}))
+        self.assertTrue(self._init_flag({"MCP_USE_TELEMETRY_INCLUDE_CONTENT": "TRUE"}))
+
+    def test_include_content_ignores_other_values(self):
+        self.assertFalse(self._init_flag({"MCP_USE_TELEMETRY_INCLUDE_CONTENT": "false"}))
+        self.assertFalse(self._init_flag({"MCP_USE_TELEMETRY_INCLUDE_CONTENT": "1"}))
 
 
 if __name__ == "__main__":

--- a/libraries/python/tests/unit/test_telemetry_content_optin.py
+++ b/libraries/python/tests/unit/test_telemetry_content_optin.py
@@ -1,0 +1,77 @@
+"""
+Unit tests for telemetry content opt-in.
+
+By default the agent-execution event must NOT carry raw prompt/response text —
+only the derived *_length fields. Setting MCP_USE_TELEMETRY_INCLUDE_CONTENT=true
+opts back in to sending the raw content.
+"""
+
+import os
+import unittest
+from unittest.mock import patch
+
+from mcp_use.telemetry.events import MCPAgentExecutionEvent
+from mcp_use.telemetry.telemetry import Telemetry
+
+
+class TestTelemetryContentOptIn(unittest.TestCase):
+    def _capture_event(self, include_content: bool) -> MCPAgentExecutionEvent:
+        # Telemetry is a closure-based singleton, so drive the instance directly
+        # rather than reconstructing it. Force a client present so the
+        # requires_telemetry guard doesn't short-circuit capture().
+        telemetry = Telemetry()
+        telemetry._posthog_client = object()
+        telemetry._include_content = include_content
+
+        captured: dict[str, MCPAgentExecutionEvent] = {}
+
+        def fake_capture(event, provider="posthog"):
+            captured["event"] = event
+
+        with patch.object(telemetry, "capture", side_effect=fake_capture):
+            telemetry.track_agent_execution(
+                execution_method="run",
+                query="my secret prompt",
+                success=True,
+                model_provider="openai",
+                model_name="gpt-x",
+                server_count=1,
+                server_identifiers=[],
+                total_tools_available=0,
+                tools_available_names=[],
+                max_steps_configured=5,
+                memory_enabled=False,
+                use_server_manager=False,
+                max_steps_used=1,
+                manage_connector=False,
+                external_history_used=False,
+                response="my secret response",
+            )
+        return captured["event"]
+
+    def test_content_redacted_by_default(self):
+        event = self._capture_event(include_content=False)
+
+        self.assertIsNone(event.query)
+        self.assertIsNone(event.response)
+        # Lengths are still derived from the real content.
+        self.assertEqual(event.query_length, len("my secret prompt"))
+        self.assertEqual(event.response_length, len("my secret response"))
+
+    def test_content_included_when_opted_in(self):
+        event = self._capture_event(include_content=True)
+
+        self.assertEqual(event.query, "my secret prompt")
+        self.assertEqual(event.response, "my secret response")
+        self.assertEqual(event.query_length, len("my secret prompt"))
+        self.assertEqual(event.response_length, len("my secret response"))
+
+    def test_default_env_disables_content(self):
+        # With the env var unset, a freshly-parsed flag must be False.
+        with patch.dict(os.environ, {}, clear=True):
+            flag = os.getenv("MCP_USE_TELEMETRY_INCLUDE_CONTENT", "false").lower() == "true"
+        self.assertFalse(flag)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Follow-up to #1836, rescoped per @tonxxd's review. That PR bundled unrelated
bug fixes across the WebSocket connector, prompt builder, and error formatting.
This one is just the telemetry change: 2 source files, 1 test, 1 doc.

## Problem

`mcp_agent_execution` sends the full `query` and `response` strings to PostHog
whenever anonymized telemetry is on (the default). For a library that runs
inside other people's agents, forwarding raw end-user prompts and model
responses to a third party by default is a privacy/compliance concern.

## Change

Raw content becomes opt-in; the analytically-useful length signals stay on by
default.

- `telemetry/events.py` — widen `MCPAgentExecutionEvent.query` to `str | None`
  (`response` already was).
- `telemetry/telemetry.py` — read `MCP_USE_TELEMETRY_INCLUDE_CONTENT` (default
  `false`) once in `__init__`. `track_agent_execution` always derives
  `query_length` / `response_length` from the real content, then nulls out
  `query` / `response` unless opted in.

Default payload:

```json
"query": null,
"query_length": 44,
"response": null,
"response_length": 38
```

Opt back in (e.g. a self-hosted PostHog you own):

```bash
export MCP_USE_TELEMETRY_INCLUDE_CONTENT=true
```

## Testing

- `tests/unit/test_telemetry_content_optin.py` — content redacted by default
  with lengths preserved, content included when opted in, env default resolves
  to `false`.
- Full unit suite: 307 passed. The single failure
  (`test_config.py::test_create_sandboxed_stdio_connector`) reproduces on a
  clean `main` checkout and is unrelated.
- `ruff check` and `ruff format --check` clean.

## Compatibility

No API break. It does change the default telemetry payload — anyone relying on
that content in their own dashboards restores it with the env var. The docs
change is required, not optional: `telemetry.mdx` currently advertises
"Query and response content (to understand use cases)", which this makes untrue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sending raw prompt and response text to PostHog in `mcp_agent_execution` telemetry. The default payload now reports only `query_length` and `response_length` and nulls out `query` and `response`, keeping usage analytics while preventing end-user content from going to a third party by default. An empty response is still counted as a response, so its `response_length` is `0` rather than `null`.

**Migration**
- Set `MCP_USE_TELEMETRY_INCLUDE_CONTENT=true` to send raw content again, e.g. for a self-hosted PostHog.
- The flag is read once in `Telemetry.__init__`, so set the env var before the telemetry instance is created.
- The telemetry docs now describe the new default, since they previously claimed raw content was collected.

<sup>Written for commit fc38f9e2fc70c3bd5694a40bc049daa18fee114d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

