### PR TITLE
docs(typescript): fix CLI flag syntax that silently deploys the wrong directory

### DIFF
--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -467,6 +467,7 @@ mcp-use servers delete srv_abc123 --yes
 **Notes and behavior:**
 
 - `servers update --branch` changes the production branch for future production deploys.
+- `--watch-paths` and `--deploy-branches` are repeatable. Pass the flag once per pattern; a second bare value is read as a positional, not as another pattern.
 - Pass an empty string to `--build-command`, `--start-command`, `--root-dir`, `--watch-paths`, or `--deploy-branches` to clear that setting.
 - `--wait-for-ci` and `--no-wait-for-ci` control whether auto-deploys wait for other check runs before deploying.
 - `servers delete` prompts for confirmation unless `--yes` is set.

--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -257,7 +257,7 @@ mcp-use deploy [options]
 | `--open`                  | Open the deployment in a browser after a successful deploy.                            | Disabled           |
 | `--name <name>`           | Deployment or server name.                                                             | Auto-generated     |
 | `--new`                   | Create a new deployment instead of reusing the linked project.                         | Disabled           |
-| `--env <key=value...>`    | Environment variable assignment. Repeatable.                                           | None               |
+| `--env <key=value>`       | Environment variable assignment. Repeatable.                                           | None               |
 | `--env-file <path>`       | Load environment variables from a `.env` file.                                         | None               |
 | `--branch <name>`         | Branch to deploy. Also scopes env sync to that branch preview environment.             | Current git branch |
 | `--root-dir <path>`       | Root directory inside the repository for monorepos.                                    | Repository root    |
@@ -267,7 +267,7 @@ mcp-use deploy [options]
 | `--build-command <cmd>`   | Build command override.                                                                | Auto-detected      |
 | `--start-command <cmd>`   | Start command override.                                                                | Auto-detected      |
 | `--dockerfile <path>`     | Non-default Dockerfile path, relative to `--root-dir` or repository root.              | None               |
-| `--watch-paths <glob...>` | Only auto-deploy when matching files change. Set on new-server creation for monorepos. | All changes        |
+| `--watch-paths <glob>`    | Only auto-deploy when matching files change. Repeatable. Set on new-server creation for monorepos. | All changes        |
 | `--wait-for-ci`           | Hold GitHub auto-deploys until other check runs pass. Set on new-server creation.      | Disabled           |
 | `--no-github`             | Upload local source without connecting GitHub.                                         | Disabled           |
 
@@ -280,7 +280,7 @@ mcp-use deploy --name my-server --open
 mcp-use deploy --env DATABASE_URL=postgres://... --env API_KEY=secret
 mcp-use deploy --env-file .env.production
 mcp-use deploy --root-dir apps/mcp-server
-mcp-use deploy --root-dir apps/mcp-server --watch-paths "apps/mcp-server/**" "packages/shared/**"
+mcp-use deploy --root-dir apps/mcp-server --watch-paths "apps/mcp-server/**" --watch-paths "packages/shared/**"
 mcp-use deploy --new --name my-server-v2
 mcp-use deploy --org manufact-inc --region EU --yes
 ```
@@ -449,8 +449,8 @@ mcp-use servers <subcommand> [options]
 | --------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `list`                | List servers for an organization.           | `--org <slug-or-id>`, `--limit <n>`, `--skip <n>`                                                                                                                                                                                                      |
 | `get <id-or-slug>`    | Show server details and recent deployments. | `--org <slug-or-id>`                                                                                                                                                                                                                                   |
-| `update <id-or-slug>` | Update server configuration.                | `--branch <name>`, `--name <name>`, `--description <text>`, `--build-command <cmd>`, `--start-command <cmd>`, `--root-dir <path>`, `--watch-paths <glob...>`, `--deploy-branches <glob...>`, `--wait-for-ci`, `--no-wait-for-ci`, `--org <slug-or-id>` |
-| `delete <server-id>`  | Delete a server and its deployments.        | `-y, --yes`, `--org <slug-or-id>`                                                                                                                                                                                                                      |
+| `update <id-or-slug>` | Update server configuration.                | `--branch <name>`, `--name <name>`, `--description <text>`, `--build-command <cmd>`, `--start-command <cmd>`, `--root-dir <path>`, `--watch-paths <glob>`, `--deploy-branches <glob>`, `--wait-for-ci`, `--no-wait-for-ci`, `--org <slug-or-id>` |
+| `delete <server-id>`  | Delete a server and its deployments.        | `--yes`, `--org <slug-or-id>`                                                                                                                                                                                                                      |
 | `env <subcommand>`    | Manage server environment variables.        | See [Server environment commands](#server-environment-commands).                                                                                                                                                                                       |
 
 **Examples:**
@@ -460,7 +460,7 @@ mcp-use servers list
 mcp-use servers get srv_abc123
 mcp-use servers update srv_abc123 --branch main
 mcp-use servers update srv_abc123 --build-command "npm run build"
-mcp-use servers update srv_abc123 --watch-paths "apps/api/**" "packages/shared/**" --deploy-branches "release/*"
+mcp-use servers update srv_abc123 --watch-paths "apps/api/**" --watch-paths "packages/shared/**" --deploy-branches "release/*"
 mcp-use servers delete srv_abc123 --yes
 ```
 


### PR DESCRIPTION
## Why

The v2 CLI reference writes the repeatable `--env`, `--watch-paths` and `--deploy-branches` flags in commander's variadic notation (`<glob...>`) and shows examples that pass several values to a single flag. The CLI parses argv with node's `util.parseArgs`, where `multiple: true` means the flag is **repeatable**, not variadic. Only the first value is read; the rest fall through as positionals.

That breaks the two documented examples in different ways.

**`deploy` silently deploys the wrong directory.** It accepts an optional `[path]` positional, so the second glob is taken as that path:

```console
$ mcp-use deploy --root-dir apps/mcp-server --watch-paths "apps/mcp-server/**" "packages/shared/**"
Not logged in. Run `mcp-use login`.     # exit 1 - parsed fine
```

No error. `packages/shared/**` becomes the deploy path, and the server is configured with one watch path instead of two. Copying this line out of the docs gets you a deploy of the wrong directory with silently wrong trigger config.

**`servers update` fails outright.** It allows exactly one positional:

```console
$ mcp-use servers update srv_abc123 --watch-paths "apps/api/**" "packages/shared/**" --deploy-branches "release/*"
Usage: mcp-use servers update <id-or-slug>     # exit 2
```

## Also: `servers delete` has no `-y`

The table documents `-y, --yes`. `deploy` does define the short flag (`yes: { type: "boolean", short: "y" }`, `deploy.ts:339`), but `servers delete` defines only `yes: { type: "boolean" }` (`servers.ts:203`):

```console
$ mcp-use servers delete srv_abc123 -y
Unknown option '-y'. ...                # exit 2
$ mcp-use servers delete srv_abc123 --yes
Not logged in. Run `mcp-use login`.     # exit 1 - parsed fine
```

## What changed

Six edits in `docs/v2/typescript/api-reference/cli-reference.mdx`:

- `<key=value...>` / `<glob...>` to `<key=value>` / `<glob>`, and the `--watch-paths` row now says "Repeatable." like the `--env` row already did
- both examples repeat the flag instead of listing bare values
- `servers delete` documents `--yes`, not `-y, --yes`

No source changes. The legacy `docs/typescript` reference already uses the repeated-flag form for the `deploy` example and the `--watch-paths` row, so this brings v2 in line with it and with the CLI's own `--help` output.

Verified against a fresh `pnpm build` of the CLI at `77b42e10`'s base; exit codes above are real runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the v2 CLI reference to document repeatable `--env`, `--watch-paths`, and `--deploy-branches` flags correctly, preventing examples from deploying the wrong directory or failing with usage errors.

- Updates the option syntax and examples to repeat each flag, and explains that bare values become positionals.
- Documents `servers delete` with `--yes` only; it does not support `-y`.

<sup>Written for commit c7da257979040c8138c7866c5c447e853e31114d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

