### PR TITLE
fix(client): hold one client reference across listAllResources pagination

### DIFF
--- a/libraries/typescript/.changeset/olive-donkeys-repeat.md
+++ b/libraries/typescript/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Fix `listAllResources` throwing a raw `TypeError` when a disconnect lands between pages. The pagination loop read `this.client` once per page, so `disconnect()` clearing it mid-listing surfaced `Cannot read properties of null (reading 'listResources')` instead of the transport's own error.

--- a/libraries/typescript/packages/client/src/transport/base.ts
+++ b/libraries/typescript/packages/client/src/transport/base.ts
@@ -734,7 +734,11 @@ export abstract class BaseConnector {
     /** Resources returned across all result pages. */
     resources: any[];
   }> {
-    if (!this.client) {
+    // Held across the pagination loop below: `disconnect()` clears
+    // `this.client`, and re-reading it once per page would throw a raw
+    // TypeError instead of the not-connected error every other method reports.
+    const client = this.client;
+    if (!client) {
       throw new Error("MCP client is not connected");
     }
 
@@ -752,7 +756,7 @@ export abstract class BaseConnector {
 
         do {
           const result: { resources?: any[]; nextCursor?: string } =
-            await this.client!.listResources({ cursor }, options);
+            await client.listResources({ cursor }, options);
           allResources.push(...(result.resources || []));
           cursor = result.nextCursor;
         } while (cursor);

--- a/libraries/typescript/packages/client/src/transport/base.ts
+++ b/libraries/typescript/packages/client/src/transport/base.ts
@@ -735,8 +735,8 @@ export abstract class BaseConnector {
     resources: any[];
   }> {
     // Held across the pagination loop below: `disconnect()` clears
-    // `this.client`, and re-reading it once per page would throw a raw
-    // TypeError instead of the not-connected error every other method reports.
+    // `this.client`, and re-reading it once per page would dereference null
+    // mid-listing instead of failing on the closed transport.
     const client = this.client;
     if (!client) {
       throw new Error("MCP client is not connected");

--- a/libraries/typescript/packages/client/tests/unit/client/list-all-resources-disconnect.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/list-all-resources-disconnect.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { BaseConnector } from "../../../src/transport/base.js";
+
+class TestConnector extends BaseConnector {
+  async connect(): Promise<void> {}
+
+  get publicIdentifier(): Record<string, string> {
+    return { type: "test" };
+  }
+}
+
+/**
+ * `listAllResources` paginates inside a single `executeRequest` closure, so a
+ * `disconnect()` landing between pages used to null the client the closure was
+ * reading, surfacing `Cannot read properties of null` instead of the
+ * transport's own error.
+ */
+describe("listAllResources", () => {
+  it("surfaces the transport error when a disconnect lands between pages", async () => {
+    const connector = new TestConnector() as BaseConnector & {
+      client: unknown;
+      capabilitiesCache: unknown;
+    };
+    connector.capabilitiesCache = { resources: {} };
+
+    let page = 0;
+    let connected = true;
+    connector.client = {
+      async listResources() {
+        if (!connected) throw new Error("Not connected");
+        page += 1;
+        // The second page never arrives: the session is torn down first.
+        connected = false;
+        connector.client = null;
+        return { resources: [{ uri: `resource-${page}` }], nextCursor: "next" };
+      },
+    };
+
+    await expect(connector.listAllResources()).rejects.toThrow("Not connected");
+  });
+});


### PR DESCRIPTION
## Why

`listAllResources` guards on `this.client`, then paginates inside a single `executeRequest` closure that re-reads `this.client` on every page (`base.ts:754`):

```ts
do {
  const result = await this.client!.listResources({ cursor }, options);
  allResources.push(...(result.resources || []));
  cursor = result.nextCursor;
} while (cursor);
```

`disconnect()` calls `cleanupResources()`, which sets `this.client = null` (`base.ts:966`). A teardown landing between two pages therefore makes the next iteration dereference null:

```
TypeError: Cannot read properties of null (reading 'listResources')
```

instead of the not-connected error every other method on the connector reports. The non-null assertion only silences the compiler; it does nothing at runtime.

## Relationship to #2366 and #2367

This is the pagination half of #2366. #2367 fixed the OAuth retry path by re-checking connector state after the interactive wait and before re-invoking the closure. That guard cannot cover this case: the loop never leaves `executeRequest`, so no guard runs between pages. The race also needs no OAuth provider, so it is reachable on every connector, not just HTTP with interactive auth.

I left #2366 alone rather than reopening it, since #2367 addressed what it described.

## The change

Capture the reference in the guard that already exists, and use it in the loop:

```diff
-    if (!this.client) {
+    const client = this.client;
+    if (!client) {
       throw new Error("MCP client is not connected");
     }
...
-            await this.client!.listResources({ cursor }, options);
+            await client.listResources({ cursor }, options);
```

Behaviour is unchanged while connected. The reference is read once at a point where it is known to be set, so a disconnect mid-listing now surfaces whatever the closed transport reports instead of a null dereference. `this.client` is only ever assigned in `connect()` (`stdio.ts:181`, `http.ts:716`) and nulled in `cleanupResources()`, so nothing swaps the instance underneath a live request, including across an OAuth retry.

I did not touch the other twelve `this.client!` closures. Each is invoked once with no await between the guard and the call, and the retry path that could re-invoke them is already guarded by #2367, so there is nothing to fix there.

## Test

One test, `packages/client/tests/unit/client/list-all-resources-disconnect.test.ts`. It drives a two-page listing whose first page tears the session down, and asserts the transport's own error comes out.

Reverting `base.ts` and rerunning it gives:

```
AssertionError: expected [Function] to throw error including 'Not connected'
  but got 'Cannot read properties of null (readi…'
Received: "Cannot read properties of null (reading 'listResources')"
```

## Validation

From `libraries/typescript/packages/client`:

- `vitest run tests/unit/client/list-all-resources-disconnect.test.ts` — 1 passed
- `vitest run` — 218 passed. One file, `tests/unit/view-renderer.test.ts`, fails to start locally on a dangling `@csstools/css-calc` symlink in my pnpm store; it is unrelated to this diff and green in CI.
- `tsc --noEmit -p tsconfig.json` — clean

From `libraries/typescript`:

- `eslint` and `prettier --check` on both changed files — clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `listAllResources` so a disconnect between pages no longer throws a raw `TypeError`. It now keeps one client reference across pagination, allowing the closed transport’s error to surface instead; connected behavior is unchanged.

- Adds a regression test for the disconnect race.
- Adds a patch changeset for `@mcp-use/client`.

<sup>Written for commit 208fc1bbc9e83690ebdc82867f6a5389b30adb8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

