### PR TITLE
fix(cli): preserve sensitive flag on env update when --secret is omitted

### DIFF
--- a/libraries/typescript/.changeset/itchy-worms-hear.md
+++ b/libraries/typescript/.changeset/itchy-worms-hear.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Preserve the existing sensitive flag when rotating an environment variable without --secret

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -290,12 +290,14 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
+  const sensitive =
+    values.secret === true ? true : (existing?.sensitive ?? false);
   const body = {
     key,
     value,
     branch: values.branch ?? null,
     environments: values.branch === undefined ? ["production"] : ["preview"],
-    sensitive: values.secret === true,
+    sensitive,
   };
   if (existing === undefined) {
     await api.request<unknown>(
@@ -313,7 +315,7 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     key,
     scope: values.branch === undefined ? "production" : "preview",
     branch: values.branch ?? null,
-    secret: values.secret === true,
+    secret: sensitive,
     updated: existing !== undefined,
   };
   printResult(result, json, `Set ${key}.`);

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -290,8 +290,7 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
-  const sensitive =
-    values.secret === true ? true : (existing?.sensitive ?? false);
+  const sensitive = values.secret === true || (existing?.sensitive ?? false);
   const body = {
     key,
     value,

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -84,6 +84,62 @@ describe("server environment output safety", () => {
       updated: true,
     });
   });
+
+  it("preserves an existing sensitive flag when --secret is not repeated on update", async () => {
+    api.request
+      .mockResolvedValueOnce([{ id: "env_1", key: "TOKEN", sensitive: true }])
+      .mockResolvedValueOnce({
+        id: "env_1",
+        key: "TOKEN",
+        value: "rotated",
+      });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      runServers(["env", "set", "server_1", "TOKEN=rotated", "--json"])
+    ).resolves.toBe(0);
+
+    expect(api.request).toHaveBeenLastCalledWith(
+      "/servers/server_1/env-variables/env_1",
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          key: "TOKEN",
+          value: "rotated",
+          branch: null,
+          environments: ["production"],
+          sensitive: true,
+        }),
+      }
+    );
+  });
+
+  it("does not mark a brand-new variable sensitive by default", async () => {
+    api.request.mockResolvedValueOnce([]).mockResolvedValueOnce({
+      id: "env_2",
+      key: "NEW_VAR",
+      value: "value",
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      runServers(["env", "set", "server_1", "NEW_VAR=value", "--json"])
+    ).resolves.toBe(0);
+
+    expect(api.request).toHaveBeenLastCalledWith(
+      "/servers/server_1/env-variables",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          key: "NEW_VAR",
+          value: "value",
+          branch: null,
+          environments: ["production"],
+          sensitive: false,
+        }),
+      }
+    );
+  });
 });
 
 describe("server human output", () => {


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope
Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes
Fixes a bug where rotating an environment variable's value via `mcp-use servers env set` without repeating `--secret` silently cleared the variable's `sensitive` flag. Previously, `sensitive` on the PATCH/POST body was set purely from `values.secret === true` on that specific invocation, ignoring the variable's existing state. Now, when updating an existing variable and `--secret` is not passed, the existing `sensitive` value is preserved instead of being overwritten to `false`. New variables still default to `sensitive: false` when `--secret` is not passed, which is unchanged behavior.

## Review Readiness
Help maintainers review this quickly:
- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details
1. In `packages/cli/src/commands/servers.ts`, `envSet()` already fetches the existing variable via `listVariables()` before building the request body, but was discarding `existing.sensitive` when constructing `body.sensitive`.
2. Added a `sensitive` variable computed as: `true` if `--secret` was passed, otherwise `existing?.sensitive ?? false` (preserves existing state on update, defaults to `false` for new variables).
3. Also fixed the CLI's printed `result.secret` field, which previously echoed `values.secret === true` (whether the flag was passed on this call) rather than the actual resulting `sensitive` state that was sent to the API. It now reports the real value.
4. No new dependencies added.

---

## TypeScript Checklist
> Complete this section if your PR includes TypeScript changes

### Packages Modified
Check all packages that were modified:
- [ ] `docs`
- [x] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist
Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues (ran via pre-commit hook, which passed)
- [x] Ran `pnpm format` to format code with Prettier (ran via pre-commit hook, which passed)
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)
```bash
mcp-use servers env set srv_abc123 TOKEN=old --secret   # sensitive: true
mcp-use servers env set srv_abc123 TOKEN=rotated        # sensitive: false (silently downgraded)
```

## Example Usage (After)
```bash
mcp-use servers env set srv_abc123 TOKEN=old --secret   # sensitive: true
mcp-use servers env set srv_abc123 TOKEN=rotated        # sensitive: true (preserved)
```

## Documentation Updates
None. This PR fixes runtime behavior only; the `--secret` flag's documented meaning ("marks a value sensitive") is unchanged, this fix makes actual behavior match that description on updates.

## Testing
- Added two unit tests to `packages/cli/tests/commands/servers.test.ts`:
  - Verifies that updating an existing sensitive variable without `--secret` keeps `sensitive: true` in the PATCH body (reproduces the exact bug scenario from the issue).
  - Verifies that a brand-new variable created without `--secret` still defaults to `sensitive: false`.
- Ran `pnpm exec vitest run tests/commands/servers.test.ts` locally: all 8 tests pass (6 existing + 2 new).
- No manual testing against a live cloud API; all testing uses the repo's existing mocked API harness.

## Backwards Compatibility
This is a backward-compatible bug fix. The only behavior change is that updating an existing sensitive variable without `--secret` no longer clears its `sensitive` flag; this brings actual behavior in line with what the `--secret` flag's documentation already describes. No API surface, CLI flags, or exit codes changed. Marked as a patch bump via changeset.

## Related Issues
Closes #2388


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `mcp-use servers env set` so rotating an environment variable's value without repeating `--secret` no longer silently clears its `sensitive` flag. Previously, `sensitive` was set purely from whether `--secret` was passed on that call, ignoring the variable's existing state; now updates preserve the existing value, while new variables still default to `sensitive: false`. Closes #2388.

**Bug Fixes**
- The CLI now preserves the existing `sensitive` value on env updates when `--secret` is omitted.
- The printed `secret` field now reports the actual resulting sensitive state instead of echoing whether the flag was passed.
- Added tests for both update preservation and new-variable default behavior.

<sup>Written for commit a7487ba7683ef923ba6fe537c676203dd8112ecb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



