### PR TITLE
ci: check out the requested ref in the tunnel test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -839,6 +839,8 @@ jobs:
         working-directory: libraries/typescript
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
       - uses: pnpm/action-setup@v4
         with:
           version: 11.13.1


### PR DESCRIPTION
`typescript-test-tunnel` is the only job in `ci.yml` whose `actions/checkout` omits `ref`. The other 17 active checkout steps pass `ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}`.

That matters on the fork-PR path. `approve-fork-pr.yml` calls this workflow with the promoted fork commit, and `ref` is a required `workflow_call` input. Every job honours it except `typescript/tunnel`, which falls back to `github.sha` from the caller's context, so that check can report green without building the PR's code.

Not a regression: the step arrived without `ref` in 668a3121, when the tunnel package was added. #2384 bumps the same line to `checkout@v7` and still leaves `ref` unset.

Verified locally: after the change all 18 active checkout steps carry the `ref` expression, and the workflow parses with 20 jobs. I did not run the tunnel job itself, so this is verified by inspection of the workflow, not by observing a fork-PR run.

Scope: two added lines in `.github/workflows/ci.yml`. No changeset, CI only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the TypeScript tunnel test job check out the requested ref for `workflow_call` runs instead of falling back to `github.sha`. Fork PR checks now build and test the promoted fork commit rather than potentially testing the caller's code.

<sup>Written for commit d82198c2dcce3a556915fa437c91311a35a5ff83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

