### PR TITLE
fix(create-mcp-use-app): drop the dead --no-git flag from help

### DIFF
--- a/libraries/typescript/.changeset/scaffold-drop-dead-no-git-flag.md
+++ b/libraries/typescript/.changeset/scaffold-drop-dead-no-git-flag.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-use-app": patch
+---
+
+Remove `--no-git` from the help output. Scaffolding stopped initializing a git repository in #820, and nothing has read the flag since, so the line described behaviour the tool no longer had.

--- a/libraries/typescript/packages/create-mcp-use-app/src/index.ts
+++ b/libraries/typescript/packages/create-mcp-use-app/src/index.ts
@@ -758,7 +758,6 @@ Options:
   --no-install              Skip installing dependencies
   --skills                  Install skills for all agents
   --no-skills               Skip installing skills
-  --no-git                  Skip initializing a git repository
   --dev                     Use workspace dependencies for development
   --sdk-version <version>   Pin mcp-use to an npm version or dist-tag (e.g. canary, 1.34.0)
   --npm                     Use npm as package manager


### PR DESCRIPTION
`create-mcp-use-app --help` lists `--no-git   Skip initializing a git repository`, but nothing reads that flag. `parseArgs` declares no `git` option, and with `strict: false` an unknown flag is accepted and dropped, so `--no-git` behaves exactly like omitting it. The neighbouring `--no-install` and `--no-skills` are real, both read via `argv.includes(...)` at lines 81 and 87.

a62db703 (#820) removed `tryGitInit` and its `options.git` call site to avoid scanning `node_modules`, and left the help line behind. This drops the line rather than restoring the behaviour, since that removal was deliberate.

Checks, run in `libraries/typescript`: `pnpm --filter create-mcp-use-app lint` clean, `test` 28/28 passing, `build` succeeds, and prettier reports no issues on the committed file.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the dead `--no-git` option from `create-mcp-use-app --help`. Git initialization was already removed, so the flag had no effect and only advertised unsupported behavior.

<sup>Written for commit c7f562e46dd4e4c4c75fc637b7126d2f3d14ee87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

