### PR TITLE
fix(client): rebind the OAuth loopback listener after a failed bind

### DIFF
--- a/libraries/typescript/.changeset/oauth-loopback-rebind-after-failed-bind.md
+++ b/libraries/typescript/.changeset/oauth-loopback-rebind-after-failed-bind.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Rebind the OAuth loopback listener after a failed bind. `startLoopback()` assigned `this.server` before `listen()` resolved, so a bind failure left a server that was never listening; the `if (this.server) return` guard then made every later authorization skip binding and hang until the auth timeout.

--- a/libraries/typescript/packages/client/src/auth/node.ts
+++ b/libraries/typescript/packages/client/src/auth/node.ts
@@ -492,10 +492,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     const server = createHttpServer((req, res) => {
       this.handleCallback(req.url ?? "/", res);
     });
-    // Assign before awaiting the bind so an overlapping call and `dispose()`
-    // both observe the in-flight listener, then drop it if the bind fails: a
-    // server that never listened must not satisfy the guard above, or every
-    // later call short-circuits without ever binding.
+    // Track the server during binding so dispose() can find it.
     this.server = server;
     try {
       await new Promise<void>((resolve, reject) => {

--- a/libraries/typescript/packages/client/src/auth/node.ts
+++ b/libraries/typescript/packages/client/src/auth/node.ts
@@ -492,14 +492,22 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     const server = createHttpServer((req, res) => {
       this.handleCallback(req.url ?? "/", res);
     });
-    this.server = server;
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(this.port, "127.0.0.1", () => {
-        server.removeListener("error", reject);
-        resolve();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(this.port, "127.0.0.1", () => {
+          server.removeListener("error", reject);
+          resolve();
+        });
       });
-    });
+    } catch (err) {
+      // Bind failed (e.g. EADDRINUSE) — don't leave `this.server` pointing at
+      // a server that isn't listening, or every future call short-circuits
+      // on the `if (this.server) return;` guard above without ever binding.
+      server.close();
+      throw err;
+    }
+    this.server = server;
   }
 
   private stopLoopback(): void {

--- a/libraries/typescript/packages/client/src/auth/node.ts
+++ b/libraries/typescript/packages/client/src/auth/node.ts
@@ -492,6 +492,11 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     const server = createHttpServer((req, res) => {
       this.handleCallback(req.url ?? "/", res);
     });
+    // Assign before awaiting the bind so an overlapping call and `dispose()`
+    // both observe the in-flight listener, then drop it if the bind fails: a
+    // server that never listened must not satisfy the guard above, or every
+    // later call short-circuits without ever binding.
+    this.server = server;
     try {
       await new Promise<void>((resolve, reject) => {
         server.once("error", reject);
@@ -501,13 +506,12 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
         });
       });
     } catch (err) {
-      // Bind failed (e.g. EADDRINUSE) — don't leave `this.server` pointing at
-      // a server that isn't listening, or every future call short-circuits
-      // on the `if (this.server) return;` guard above without ever binding.
+      if (this.server === server) {
+        this.server = null;
+      }
       server.close();
       throw err;
     }
-    this.server = server;
   }
 
   private stopLoopback(): void {

--- a/libraries/typescript/packages/client/tests/unit/auth/node-provider.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/node-provider.test.ts
@@ -167,10 +167,13 @@ describe("NodeOAuthClientProvider", () => {
         kvStore: new MemoryKVStore(),
         openBrowser: vi.fn(),
         preferredPort: port,
-        portRange: 1,
+        portRange: 100,
       }
     );
-    expect(provider.callbackPort).toBe(port);
+    // Occupy whatever port reservePort actually settled on rather than the
+    // preferred one: the preferred port may already be taken by an unrelated
+    // process, in which case the provider falls back within the range.
+    const boundPort = provider.callbackPort;
 
     const authorizationUrl = new URL("https://auth.example.com/authorize");
     authorizationUrl.searchParams.set("state", "test-state");
@@ -182,7 +185,7 @@ describe("NodeOAuthClientProvider", () => {
     const occupier = createNetServer();
     await new Promise<void>((resolve, reject) => {
       occupier.once("error", reject);
-      occupier.listen(port, "127.0.0.1", () => {
+      occupier.listen(boundPort, "127.0.0.1", () => {
         occupier.removeListener("error", reject);
         resolve();
       });

--- a/libraries/typescript/packages/client/tests/unit/auth/node-provider.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/auth/node-provider.test.ts
@@ -157,4 +157,64 @@ describe("NodeOAuthClientProvider", () => {
     await expect(legacyCodePromise).resolves.toBe("authorization-code");
     expect(openBrowser).toHaveBeenCalledOnce();
   });
+
+  it("re-binds the loopback listener after a failed bind instead of leaking a dead server handle", async () => {
+    const port = 36_000 + (process.pid % 1_000);
+    const provider = await NodeOAuthClientProvider.create(
+      "https://mcp.example.com/mcp",
+      {
+        authTimeoutMs: 5_000,
+        kvStore: new MemoryKVStore(),
+        openBrowser: vi.fn(),
+        preferredPort: port,
+        portRange: 1,
+      }
+    );
+    expect(provider.callbackPort).toBe(port);
+
+    const authorizationUrl = new URL("https://auth.example.com/authorize");
+    authorizationUrl.searchParams.set("state", "test-state");
+    const launcherUrl = `http://127.0.0.1:${provider.callbackPort}/authorize`;
+
+    // Occupy the reserved loopback port out from under the provider so its
+    // own bind attempt fails with EADDRINUSE, mirroring the reservePort/bind
+    // race the bug report describes.
+    const occupier = createNetServer();
+    await new Promise<void>((resolve, reject) => {
+      occupier.once("error", reject);
+      occupier.listen(port, "127.0.0.1", () => {
+        occupier.removeListener("error", reject);
+        resolve();
+      });
+    });
+    let occupierClosed = false;
+
+    try {
+      await expect(
+        provider.redirectToAuthorization(authorizationUrl)
+      ).rejects.toMatchObject({ code: "EADDRINUSE" });
+
+      // Free the port back up before retrying.
+      await new Promise<void>((resolve, reject) =>
+        occupier.close((error) => {
+          if (error) return reject(error);
+          occupierClosed = true;
+          resolve();
+        })
+      );
+
+      // The port is free again, so this retry must actually bind a fresh
+      // listener rather than silently no-op'ing against the dead handle
+      // left behind by the failed attempt above.
+      await provider.redirectToAuthorization(authorizationUrl);
+
+      const response = await fetch(launcherUrl, { redirect: "manual" });
+      expect(response.status).toBe(302);
+    } finally {
+      provider.dispose();
+      if (!occupierClosed) {
+        occupier.close();
+      }
+    }
+  });
 });


### PR DESCRIPTION
`startLoopback()` assigns `this.server` before `listen()` resolves, so a failed bind leaves a handle that never listened. The guard at the top of the method then makes every later call return early without binding. `stopLoopback()` is the only thing that clears it, and it is unreachable on this path: `this.pending` is created after `await this.startLoopback()`, so neither `resolvePending` nor `rejectPending` runs, and nothing in the repo calls `dispose()`.

The bind can fail because `reservePort()` probes the port free and binds later, leaving a window for something else to take it. The caller then opens a browser against a port with nothing listening and waits out `authTimeoutMs` (default 300000) rather than rebinding.

The added test occupies the port, asserts the first attempt rejects with `EADDRINUSE`, frees it, then requires the retry to serve a real request. Against unfixed source it fails with `ECONNREFUSED` on that retry; it passes with the fix.

`pnpm --filter @mcp-use/client test:run`: 342 passed, 1 skipped. Two failures remain in `browser-entry.test.ts`, which needs a built `dist/` that a fresh checkout lacks. `stdio-errlog` timed out once and passed on re-run, so it looks flaky here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth loopback authorization after a failed port bind, which previously left a dead server handle and caused later attempts to wait until `authTimeoutMs`; failed binds now clean up so retries can listen normally.

**Bug Fixes**
- Keeps the in-flight listener visible to concurrent authorization calls and `dispose()`, then clears and closes it if binding fails.
- Reproduces the `reservePort()` race by occupying the selected port and verifies that a retry serves a callback.
- Adds a patch changeset for `@mcp-use/client`.

<sup>Written for commit cd16b4e5369513fdec5e1e19cfb69223ae344b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

