### PR TITLE
fix(inspector): release the upstream stream on Express client disconnect

### DIFF
--- a/libraries/typescript/.changeset/inspector-express-release-stream-on-disconnect.md
+++ b/libraries/typescript/.changeset/inspector-express-release-stream-on-disconnect.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Release the upstream stream when an Express client disconnects mid-response. The Express adapter's proxy loop had no abort wiring, so a client that went away during a long-lived SSE response left the loop writing to a dead socket and the upstream connection open until it ended on its own.

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -184,10 +184,26 @@ function createExpressInspectorMiddleware(
       return;
     }
 
-    const request = expressRequestToFetchRequest(req, url);
+    let finished = false;
+    const abort = new AbortController();
+    res.on("close", () => {
+      if (!finished) {
+        abort.abort();
+      }
+    });
+    if (res.destroyed === true) {
+      abort.abort();
+    }
+
+    const request = expressRequestToFetchRequest(req, url, abort.signal);
     void fetch(request)
-      .then((fetchResponse) => writeFetchResponse(res, fetchResponse))
-      .catch(next);
+      .then((fetchResponse) =>
+        writeFetchResponse(res, fetchResponse, abort.signal)
+      )
+      .catch(next)
+      .finally(() => {
+        finished = true;
+      });
   };
 }
 
@@ -208,11 +224,13 @@ function firstHeaderValue(value: string | string[] | undefined): string {
 
 function expressRequestToFetchRequest(
   req: Request,
-  url: URL
+  url: URL,
+  signal: AbortSignal
 ): globalThis.Request {
   const init: RequestInit & { duplex?: "half" } = {
     method: req.method,
     headers: req.headers as HeadersInit,
+    signal,
   };
 
   if (req.method !== "GET" && req.method !== "HEAD") {
@@ -244,7 +262,8 @@ function bodyToRequestBody(body: unknown): BodyInit {
 
 async function writeFetchResponse(
   res: Response,
-  fetchResponse: globalThis.Response
+  fetchResponse: globalThis.Response,
+  signal: AbortSignal
 ): Promise<void> {
   res.status(fetchResponse.status);
   fetchResponse.headers.forEach((value, key) => {
@@ -258,13 +277,33 @@ async function writeFetchResponse(
     return;
   }
 
+  // The MCP proxy serves long-lived SSE responses. Without this, a client
+  // disconnecting mid-stream (res "close") left this loop pumping the
+  // upstream body into a dead socket forever, so the upstream response was
+  // never released. Mirrors the abort wiring in packages/server/node-bridge.ts.
   const reader = fetchResponse.body.getReader();
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    res.write(value);
+  const cancelReader = () => {
+    void reader.cancel().catch(() => {
+      // Best-effort: the reader may already be closed or errored.
+    });
+  };
+  if (signal.aborted) {
+    cancelReader();
+  } else {
+    signal.addEventListener("abort", cancelReader, { once: true });
   }
-  res.end();
+
+  try {
+    while (!signal.aborted) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (signal.aborted) break;
+      res.write(value);
+    }
+  } finally {
+    signal.removeEventListener("abort", cancelReader);
+    res.end();
+  }
 }
 
 function isMountableApp(

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -200,7 +200,14 @@ function createExpressInspectorMiddleware(
       .then((fetchResponse) =>
         writeFetchResponse(res, fetchResponse, abort.signal)
       )
-      .catch(next)
+      .catch((error) => {
+        // The client going away aborts the outbound fetch and the body
+        // read. That is a completed request, not an Express error.
+        if (abort.signal.aborted) {
+          return;
+        }
+        next(error);
+      })
       .finally(() => {
         finished = true;
       });

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -202,8 +202,14 @@ function createExpressInspectorMiddleware(
       )
       .catch((error) => {
         // The client going away aborts the outbound fetch and the body
-        // read. That is a completed request, not an Express error.
-        if (abort.signal.aborted) {
+        // read. That is a completed request, not an Express error. Require
+        // both the abort and an AbortError, so a genuine failure that races
+        // the disconnect still reaches Express.
+        if (
+          abort.signal.aborted &&
+          error instanceof Error &&
+          error.name === "AbortError"
+        ) {
           return;
         }
         next(error);

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -301,6 +301,7 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
           headers,
           body: currentBody,
           redirect: "manual",
+          signal: c.req.raw.signal,
         });
         const location = response.headers.get("location");
         if (!(response.status >= 300 && response.status < 400 && location)) {

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -344,7 +344,20 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
       // The client disconnected before the upstream responded, so the abort
       // we now propagate to the outbound fetch rejects here. That is the
       // expected shutdown path, and nothing is left to read a body.
-      if (error instanceof Error && error.name === "AbortError") {
+      //
+      // fetch rejects with signal.reason verbatim, and the reason is not
+      // ours to choose. The Express adapter aborts with no argument, so
+      // there it is a DOMException named AbortError, but @hono/node-server
+      // aborts with a plain string, so an Error test alone would miss every
+      // disconnect on the standalone inspector. Accept the reason itself,
+      // and keep the name arm for the serialized-reason path where identity
+      // does not hold.
+      const { signal } = c.req.raw;
+      if (
+        signal.aborted &&
+        (error === signal.reason ||
+          (error instanceof Error && error.name === "AbortError"))
+      ) {
         return new Response(null, { status: 499 });
       }
 

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -341,6 +341,13 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
 
+      // The client disconnected before the upstream responded, so the abort
+      // we now propagate to the outbound fetch rejects here. That is the
+      // expected shutdown path, and nothing is left to read a body.
+      if (error instanceof Error && error.name === "AbortError") {
+        return new Response(null, { status: 499 });
+      }
+
       // Get targetUrl for better error logging
       const targetUrl = c.req.header("X-Target-URL");
 

--- a/libraries/typescript/packages/inspector/tests/unit/mount-inspector.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mount-inspector.test.ts
@@ -4,6 +4,26 @@ import http from "node:http";
 import { describe, expect, it } from "vitest";
 import { mountInspector } from "../../src/server/index.js";
 
+// Bound a wait without leaving the timer pending when the wait wins:
+// a live timer keeps the vitest worker alive for its full duration.
+async function raceWithTimeout(
+  promise: Promise<void>,
+  ms: number,
+  message: string
+): Promise<void> {
+  let handle: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      promise,
+      new Promise<void>((_resolve, reject) => {
+        handle = setTimeout(() => reject(new Error(message)), ms);
+      }),
+    ]);
+  } finally {
+    if (handle) clearTimeout(handle);
+  }
+}
+
 describe("mountInspector", () => {
   it("returns a Fetch handler with a fully local, prefix-scoped Inspector", async () => {
     const inspector = mountInspector({
@@ -302,24 +322,88 @@ describe("mountInspector", () => {
 
       // A fixed middleware releases the upstream promptly; an unfixed one
       // never does, so bound the wait instead of hanging the suite.
-      await Promise.race([
+      await raceWithTimeout(
         upstreamClosed,
-        new Promise<void>((_resolve, reject) =>
-          setTimeout(
-            () =>
-              reject(
-                new Error(
-                  "upstream connection was not released after client disconnect"
-                )
-              ),
-            3000
-          )
-        ),
-      ]);
+        3000,
+        "upstream connection was not released after client disconnect"
+      );
 
       expect(upstreamRequestClosed).toBe(true);
     } finally {
       if (upstreamInterval) clearInterval(upstreamInterval);
+      controller?.abort();
+      server.closeAllConnections();
+      upstream.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  }, 10000);
+
+  it("releases the upstream when the client disconnects before response headers", async () => {
+    // The upstream accepts the request and never responds, so the abort
+    // has to travel through the outbound fetch itself. Cancelling the
+    // response reader cannot help here: there is no response yet.
+    let upstreamRequestClosed = false;
+    let resolveUpstreamClosed: () => void = () => {};
+    const upstreamClosed = new Promise<void>((resolve) => {
+      resolveUpstreamClosed = resolve;
+    });
+    let sawRequest: () => void = () => {};
+    const requestArrived = new Promise<void>((resolve) => {
+      sawRequest = resolve;
+    });
+
+    const upstream = http.createServer((req) => {
+      sawRequest();
+      req.on("close", () => {
+        upstreamRequestClosed = true;
+        resolveUpstreamClosed();
+      });
+      // Deliberately never write a status line or headers.
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, resolve));
+
+    const app = express();
+    mountInspector(app, { basePath: "/mcp", oauthProxyAllowLoopback: true });
+    const server = app.listen(0);
+
+    let controller: AbortController | undefined;
+    try {
+      const upstreamAddress = upstream.address();
+      const appAddress = server.address();
+      if (
+        !upstreamAddress ||
+        typeof upstreamAddress === "string" ||
+        !appAddress ||
+        typeof appAddress === "string"
+      ) {
+        throw new Error("Test servers did not bind TCP ports");
+      }
+      const upstreamOrigin = `http://127.0.0.1:${upstreamAddress.port}`;
+      const appOrigin = `http://127.0.0.1:${appAddress.port}`;
+
+      controller = new AbortController();
+      const pending = fetch(`${appOrigin}/mcp/inspector/api/proxy`, {
+        headers: { "x-target-url": `${upstreamOrigin}/stream` },
+        signal: controller.signal,
+      }).catch(() => undefined);
+
+      // Only abort once the upstream is actually holding the request open.
+      await raceWithTimeout(
+        requestArrived,
+        3000,
+        "upstream never received the proxied request"
+      );
+      controller.abort();
+      await pending;
+
+      await raceWithTimeout(
+        upstreamClosed,
+        3000,
+        "upstream connection was not released after a pre-header disconnect"
+      );
+      expect(upstreamRequestClosed).toBe(true);
+    } finally {
       controller?.abort();
       server.closeAllConnections();
       upstream.closeAllConnections();

--- a/libraries/typescript/packages/inspector/tests/unit/mount-inspector.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mount-inspector.test.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { Hono } from "hono";
+import http from "node:http";
 import { describe, expect, it } from "vitest";
 import { mountInspector } from "../../src/server/index.js";
 
@@ -233,4 +234,97 @@ describe("mountInspector", () => {
       });
     }
   });
+
+  it("releases the upstream stream when the Express client disconnects mid-response", async () => {
+    // Upstream MCP-style SSE server: writes an initial chunk immediately, then
+    // keeps the connection open indefinitely with periodic pings, and reports
+    // when the *inbound* request (the proxy's fetch to it) is closed.
+    let upstreamRequestClosed = false;
+    let resolveUpstreamClosed: () => void = () => {};
+    const upstreamClosed = new Promise<void>((resolve) => {
+      resolveUpstreamClosed = resolve;
+    });
+    let upstreamInterval: ReturnType<typeof setInterval> | undefined;
+
+    const upstream = http.createServer((req, res) => {
+      res.writeHead(200, {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+      });
+      res.write(": ping\n\n");
+      upstreamInterval = setInterval(() => {
+        res.write(": ping\n\n");
+      }, 20);
+      req.on("close", () => {
+        upstreamRequestClosed = true;
+        resolveUpstreamClosed();
+      });
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, resolve));
+
+    const app = express();
+    // Loopback opt-in: this test proxies to its own 127.0.0.1 SSE server.
+    mountInspector(app, { basePath: "/mcp", oauthProxyAllowLoopback: true });
+    const server = app.listen(0);
+
+    let controller: AbortController | undefined;
+    try {
+      const upstreamAddress = upstream.address();
+      const appAddress = server.address();
+      if (
+        !upstreamAddress ||
+        typeof upstreamAddress === "string" ||
+        !appAddress ||
+        typeof appAddress === "string"
+      ) {
+        throw new Error("Test servers did not bind TCP ports");
+      }
+      const upstreamOrigin = `http://127.0.0.1:${upstreamAddress.port}`;
+      const appOrigin = `http://127.0.0.1:${appAddress.port}`;
+
+      controller = new AbortController();
+      const response = await fetch(`${appOrigin}/mcp/inspector/api/proxy`, {
+        headers: { "x-target-url": `${upstreamOrigin}/stream` },
+        signal: controller.signal,
+      });
+      expect(response.status).toBe(200);
+      if (!response.body) {
+        throw new Error("Proxied response had no body");
+      }
+
+      // Prove the stream is actually flowing end-to-end before disconnecting.
+      const reader = response.body.getReader();
+      const first = await reader.read();
+      expect(first.done).toBe(false);
+
+      // Simulate the Express client disconnecting mid-stream.
+      controller.abort();
+
+      // A fixed middleware releases the upstream promptly; an unfixed one
+      // never does, so bound the wait instead of hanging the suite.
+      await Promise.race([
+        upstreamClosed,
+        new Promise<void>((_resolve, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new Error(
+                  "upstream connection was not released after client disconnect"
+                )
+              ),
+            3000
+          )
+        ),
+      ]);
+
+      expect(upstreamRequestClosed).toBe(true);
+    } finally {
+      if (upstreamInterval) clearInterval(upstreamInterval);
+      controller?.abort();
+      server.closeAllConnections();
+      upstream.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  }, 10000);
 });


### PR DESCRIPTION
The Express adapter's proxy loop exits only on upstream EOF, and no signal reaches the outbound `fetch`. When a client disconnects mid-response the loop keeps calling `reader.read()` and `res.write()` against a dead socket, and the upstream connection stays open until it ends on its own. The MCP proxy serves long-lived SSE, so that wait is not bounded.

`packages/server/src/node-bridge.ts` already handles this: it wires an `AbortController` to the response's `close` event, checks `res.destroyed`, and threads the signal into the request. This applies the same pattern to `createExpressInspectorMiddleware` and cancels the reader when the signal fires. The Hono path is unaffected, since it returns the `Response` directly rather than pumping it.

The added test mounts the adapter on a real Express listener, proxies to a local SSE server, reads one chunk to confirm the stream is flowing, then aborts the client and asserts the upstream observes `close` within 3s.

`pnpm --filter @mcp-use/inspector test:unit`: 262 passed with 1 failing before the change, 263 passing after. The failure is the new test, reporting `upstream connection was not released after client disconnect`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases the upstream MCP/SSE connection when an Express client disconnects mid-response. Previously, the proxy kept reading and writing until upstream EOF; it now propagates cancellation through the outbound fetch and reader while preserving genuine upstream failures for Express error handling.

- Treats expected disconnects as completed requests: Hono returns 499 for the matching abort reason, and Express does not forward it as an error.
- Ends downstream responses only after clean upstream completion; aborted or failed streams are not marked successful, and buffered proxy reads are awaited.
- Adds coverage for disconnects before headers and mid-stream, upstream failures, and aborted buffered bodies.

<sup>Written for commit d848b606246126ee574ca6490f07b02d14c4a50e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

