### PR TITLE
fix(python): preserve streamable HTTP initialization result

### DIFF
--- a/libraries/python/mcp_use/client/connectors/http.py
+++ b/libraries/python/mcp_use/client/connectors/http.py
@@ -136,6 +136,14 @@ class HttpConnector(BaseConnector):
             logger.debug("Already connected to MCP implementation")
             return
 
+        # A reconnect uses a new transport, so discard initialization state from the dropped session.
+        self._initialized = False
+        self._streamable_initialize_result = None
+        self.capabilities = None
+        self._tools = None
+        self._resources = None
+        self._prompts = None
+
         # Handle OAuth if needed
         if self._oauth:
             try:

--- a/libraries/python/mcp_use/client/connectors/http.py
+++ b/libraries/python/mcp_use/client/connectors/http.py
@@ -11,7 +11,7 @@ import httpx
 from mcp import ClientSession
 from mcp.client.session import ElicitationFnT, ListRootsFnT, LoggingFnT, MessageHandlerFnT, SamplingFnT
 from mcp.shared.exceptions import McpError
-from mcp.types import Root
+from mcp.types import InitializeResult, Root
 
 from mcp_use.client.auth.oauth import BearerAuth, OAuth, OAuthClientProvider
 from mcp_use.client.connectors.base import BaseConnector
@@ -80,6 +80,7 @@ class HttpConnector(BaseConnector):
         self._auth: httpx.Auth | None = None
         self._oauth: OAuth | None = None
         self.verify = verify
+        self._streamable_initialize_result: InitializeResult | None = None
 
         # Handle authentication
         if auth is not None:
@@ -205,7 +206,6 @@ class HttpConnector(BaseConnector):
                 # If we get here, streamable HTTP works
                 self.client_session = test_client
                 self.transport_type = "streamable HTTP"
-                self._initialized = True  # Mark as initialized since we just called initialize()
 
                 # Populate tools, resources, and prompts since we've initialized
                 server_capabilities = result.capabilities
@@ -230,6 +230,10 @@ class HttpConnector(BaseConnector):
                     self._prompts = prompts_result.prompts if prompts_result else []
                 else:
                     self._prompts = []
+
+                self._streamable_initialize_result = result
+                self.capabilities = server_capabilities
+                self._initialized = True  # Mark as initialized since we just called initialize()
 
             # Only McpError is raised from client's initialization because
             # exceptions are handled internally.
@@ -325,6 +329,17 @@ class HttpConnector(BaseConnector):
         self._connection_manager = connection_manager
         self._connected = True
         logger.debug(f"Successfully connected to MCP implementation via {self.transport_type}: {self.base_url}")
+
+    async def _cleanup_resources(self) -> None:
+        """Clean up HTTP resources and discard any cached probe result."""
+        await super()._cleanup_resources()
+        self._streamable_initialize_result = None
+
+    async def initialize(self) -> InitializeResult | None:
+        """Return the Streamable HTTP probe result without repeating the handshake."""
+        if self._initialized and self._streamable_initialize_result is not None:
+            return self._streamable_initialize_result
+        return await super().initialize()
 
     def _build_httpx_factory(self):
         verify = self.verify

--- a/libraries/python/tests/unit/test_http_connector.py
+++ b/libraries/python/tests/unit/test_http_connector.py
@@ -224,6 +224,11 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         self.assertEqual(len(self.connector._resources), 1)
         self.assertEqual(len(self.connector._prompts), 1)
 
+        # The connection probe is the one and only initialization handshake.
+        self.assertIs(self.connector.capabilities, mock_init_result.capabilities)
+        self.assertIs(await self.connector.initialize(), mock_init_result)
+        mock_client_session_instance.initialize.assert_called_once()
+
     @patch("mcp_use.client.connectors.http.StreamableHttpConnectionManager")
     async def test_sse_connect_already_connected(self, mock_cm_class, _):
         """Test connecting when already connected."""

--- a/libraries/python/tests/unit/test_http_connector.py
+++ b/libraries/python/tests/unit/test_http_connector.py
@@ -229,6 +229,78 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         self.assertIs(await self.connector.initialize(), mock_init_result)
         mock_client_session_instance.initialize.assert_called_once()
 
+    @patch("mcp_use.client.connectors.http.SseConnectionManager")
+    @patch("mcp_use.client.connectors.http.StreamableHttpConnectionManager")
+    @patch("mcp_use.client.connectors.http.ClientSession")
+    async def test_reconnect_sse_fallback_reinitializes_session(
+        self, mock_client_session_class, mock_streamable_cm_class, mock_sse_cm_class, _
+    ):
+        """Test that SSE fallback does not reuse initialization state from a dropped streamable session."""
+        old_result = MagicMock(name="old_result")
+        old_capabilities = MagicMock(name="old_capabilities", tools=True, resources=True, prompts=True)
+        old_result.capabilities = old_capabilities
+        old_tools = [MagicMock(spec=Tool)]
+        old_resources = [MagicMock(spec=Resource)]
+        old_prompts = [MagicMock(spec=Prompt)]
+        self.connector._initialized = True
+        self.connector._streamable_initialize_result = old_result
+        self.connector.capabilities = old_capabilities
+        self.connector._tools = old_tools
+        self.connector._resources = old_resources
+        self.connector._prompts = old_prompts
+        self.connector._connected = False
+
+        mock_streamable_cm_instance = MagicMock()
+        mock_streamable_cm_instance.start = AsyncMock(return_value=("read_stream", "write_stream"))
+        mock_streamable_cm_instance.close = AsyncMock()
+        mock_streamable_cm_class.return_value = mock_streamable_cm_instance
+
+        mock_sse_cm_instance = MagicMock()
+        mock_sse_cm_instance.start = AsyncMock(return_value=("sse_read_stream", "sse_write_stream"))
+        mock_sse_cm_class.return_value = mock_sse_cm_instance
+
+        streamable_client = MagicMock()
+        streamable_client.__aenter__ = AsyncMock()
+        streamable_client.__aexit__ = AsyncMock()
+        streamable_client.initialize = AsyncMock(side_effect=McpError(ErrorData(code=1, message="Connection closed")))
+
+        sse_client = MagicMock()
+        sse_client.__aenter__ = AsyncMock()
+        sse_client.__aexit__ = AsyncMock()
+        sse_client.initialize = AsyncMock()
+        fresh_result = MagicMock(name="fresh_result")
+        fresh_capabilities = MagicMock(name="fresh_capabilities", tools=True, resources=True, prompts=True)
+        fresh_result.capabilities = fresh_capabilities
+        sse_client.initialize.return_value = fresh_result
+        fresh_tools = [MagicMock(spec=Tool)]
+        fresh_resources = [MagicMock(spec=Resource)]
+        fresh_prompts = [MagicMock(spec=Prompt)]
+        sse_client.list_tools = AsyncMock(return_value=MagicMock(tools=fresh_tools))
+        sse_client.list_resources = AsyncMock(return_value=MagicMock(resources=fresh_resources))
+        sse_client.list_prompts = AsyncMock(return_value=MagicMock(prompts=fresh_prompts))
+        mock_client_session_class.side_effect = [streamable_client, sse_client]
+
+        await self.connector.connect()
+
+        self.assertFalse(self.connector._initialized)
+        self.assertIsNone(self.connector._streamable_initialize_result)
+        self.assertIsNone(self.connector.capabilities)
+        self.assertIsNone(self.connector._tools)
+        self.assertIsNone(self.connector._resources)
+        self.assertIsNone(self.connector._prompts)
+
+        result = await self.connector.initialize()
+
+        self.assertIs(result, fresh_result)
+        sse_client.initialize.assert_awaited_once()
+        self.assertIs(self.connector.capabilities, fresh_capabilities)
+        self.assertEqual(self.connector._tools, fresh_tools)
+        self.assertEqual(self.connector._resources, fresh_resources)
+        self.assertEqual(self.connector._prompts, fresh_prompts)
+        self.assertIsNot(self.connector._tools, old_tools)
+        self.assertIsNot(self.connector._resources, old_resources)
+        self.assertIsNot(self.connector._prompts, old_prompts)
+
     @patch("mcp_use.client.connectors.http.StreamableHttpConnectionManager")
     async def test_sse_connect_already_connected(self, mock_cm_class, _):
         """Test connecting when already connected."""


### PR DESCRIPTION
## Scope

- [x] Python

## Problem

For Streamable HTTP, `HttpConnector.connect()` performs the MCP initialization handshake as a transport probe. It then marks the connector initialized and populates cached lists, but discards the successful `InitializeResult`. A later `MCPSession.initialize()` therefore returns `None`, and connector capabilities are unavailable.

## Fix

- Cache the successful Streamable HTTP `InitializeResult` and capabilities during `connect()`.
- Return that cached result from `initialize()` without a second wire handshake.
- Clear the cache during connector cleanup.
- Add regression coverage to the existing Streamable HTTP connector test.

## Validation

- [x] `ruff format --check mcp_use/client/connectors/http.py tests/unit/test_http_connector.py`
- [x] `ruff check mcp_use/client/connectors/http.py tests/unit/test_http_connector.py`
- [x] `python -m unittest tests.unit.test_http_connector -v` — 21 passed
- [x] `git diff --check`
- [x] Checked for existing open PRs addressing this behavior.

## Documentation

No documentation change is needed: this restores the existing initialization contract without changing the public API.

## Backwards Compatibility

Fully backwards compatible. This restores the expected initialization result and capability availability after a successful Streamable HTTP connection.

## Related Issues

None found.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Streamable HTTP initialization so the successful handshake result is preserved and returned from `initialize()` instead of being lost. Capabilities are now available after connect, no second wire handshake is performed, and reconnects no longer reuse stale initialization state.

- Caches the probe `InitializeResult` and capabilities during `connect()`, and clears them during connector cleanup.
- Resets initialization state at the start of `connect()`, so an SSE fallback after a dropped Streamable HTTP session starts fresh.
- Adds regression coverage for the cached result, reconnect reset, and SSE fallback path.

<sup>Written for commit 9597be3674520dc3ef448c22412d8313ae7cd103. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

