### PR TITLE
docs(client): use the real useMcp state field in the README example

### DIFF
--- a/libraries/typescript/packages/client/README.md
+++ b/libraries/typescript/packages/client/README.md
@@ -70,11 +70,11 @@ try {
 import { useMcp } from "@mcp-use/client/react";
 
 function App() {
-  const { status, tools, callTool } = useMcp({
+  const { state, tools, callTool } = useMcp({
     url: "https://api.example.com/mcp",
   });
 
-  if (status !== "ready") return <p>{status}</p>;
+  if (state !== "ready") return <p>{state}</p>;
 
   return (
     <ul>


### PR DESCRIPTION
`useMcp()` returns `state`, not `status`. The README quick-start destructures `status`, so it is `undefined`, the `!== "ready"` guard never passes, and the tool list never renders.

`UseMcpResult` in `src/react/types.ts` has no `status` field, and `docs/v2/typescript/client/usemcp.mdx` already uses `state` throughout. `tools` and `callTool` in the same example are correct.

Doc-side fix only; the code is right.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `@mcp-use/client` README quick-start so the `useMcp` example actually renders the tool list. The example destructured `status`, but `useMcp` returns `state`, so the `!== "ready"` guard never passed. Docs-only change; the hook code is correct.

<sup>Written for commit 9890353e57e7d03be3f76eea5ff22040f5ffd876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

