### PR TITLE
docs: correct two README claims that contradict the code

### DIFF
--- a/libraries/typescript/packages/create-mcp-use-app/README.md
+++ b/libraries/typescript/packages/create-mcp-use-app/README.md
@@ -341,7 +341,7 @@ Use the MCP server with any MCP-compatible client:
 
 ```typescript
 import { MCPClient } from "@mcp-use/client";
-import { MCPAgent } from "@mcp-use/agent";
+import { MCPAgent } from "@mcp-use/agent/langchain";
 import { ChatOpenAI } from "@langchain/openai";
 
 const client = new MCPClient({

--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -63,7 +63,7 @@ For detailed usage instructions and guides, visit [mcp-use.com/docs/inspector](h
 | **📁 Resource Browser**    | View and copy resource URIs with syntax highlighting                    |
 | **🧩 Skills Explorer**     | Browse, verify, and preview Skills over MCP files                        |
 | **💬 Prompt Manager**      | Test and manage prompts with argument templates                         |
-| **🌐 Universal Support**   | Works with HTTP/SSE server connections                               |
+| **🌐 Universal Support**   | Works with Streamable HTTP server connections                           |
 | **🎨 Widget Support**      | Full support for MCP-UI and OpenAI Apps SDK widgets                     |
 | **🔑 BYOK Chat**           | Bring Your Own Key chat interface for testing conversational flows      |
 | **📚 Skill-aware Chat**    | Test progressive skill loading with removable per-chat context          |


### PR DESCRIPTION
Two README lines that state something the code does not do. One commit each.

**Inspector feature table** claims "Works with HTTP/SSE server connections". `ConnectionSettingsForm.tsx:159` hardcodes `transportType: "http"` with the comment "HTTP only - SSE is deprecated", and this same README says "The Inspector supports Streamable HTTP only" a few sections down. #2363 corrected the WebSocket half of that row and left the SSE half.

**create-mcp-use-app quick-start** imports `MCPAgent` from `@mcp-use/agent` and passes `llm: new ChatOpenAI()`. The root entry types `llm` as `string | ProviderConfig`, so the snippet does not typecheck; the LangChain `MCPAgent` is the one that takes a model instance. The agent package README pairs `ChatOpenAI` with `@mcp-use/agent/langchain`, which is what this changes it to.

Docs-side only, no code touched. Prettier reports both files clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects two README claims that contradicted the code.

- Inspector feature table now says "Streamable HTTP" instead of "HTTP/SSE"; the connection panel hardcodes `transportType: "http"` and SSE is deprecated.
- `create-mcp-use-app` quick-start now imports `MCPAgent` from `@mcp-use/agent/langchain` so the example typechecks when passing a `ChatOpenAI` instance.

<sup>Written for commit c23516855467fc2389c4f597e96fedede58b7cd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

