### PR TITLE
fix(python): allow connection managers to restart after stop

### DIFF
--- a/libraries/python/mcp_use/client/task_managers/base.py
+++ b/libraries/python/mcp_use/client/task_managers/base.py
@@ -67,6 +67,10 @@ class ConnectionManager(Generic[T], ABC):
         Raises:
             Exception: If connection cannot be established.
         """
+        # Ensure any in-progress task or cleanup completes before restarting
+        if self._task is not None and not self._done_event.is_set():
+            await self.stop()
+
         # Reset state
         self._ready_event.clear()
         self._done_event.clear()

--- a/libraries/python/mcp_use/client/task_managers/base.py
+++ b/libraries/python/mcp_use/client/task_managers/base.py
@@ -70,6 +70,7 @@ class ConnectionManager(Generic[T], ABC):
         # Reset state
         self._ready_event.clear()
         self._done_event.clear()
+        self._stop_event.clear()
         self._exception = None
 
         # Create a task to establish and maintain the connection

--- a/libraries/python/tests/unit/test_connection_manager_timeout.py
+++ b/libraries/python/tests/unit/test_connection_manager_timeout.py
@@ -68,6 +68,25 @@ class TestConnectionManagerTimeout:
         assert manager.close_call_count == 2
 
     @pytest.mark.asyncio
+    async def test_start_while_stop_in_progress_serializes_cleanly(self):
+        manager = MockConnectionManager(close_delay=0.05)
+        await manager.start()
+
+        # Initiate stop in the background
+        stop_task = asyncio.create_task(manager.stop())
+        await asyncio.sleep(0.01)
+
+        # Start should serialize behind stop and establish fresh valid connection
+        connection = await manager.start()
+        await stop_task
+        assert connection == "test_connection"
+        assert manager._connection is not None
+        assert manager.close_call_count == 1
+
+        await manager.stop()
+        assert manager.close_call_count == 2
+
+    @pytest.mark.asyncio
     async def test_stop_with_default_timeout(self):
         manager = MockConnectionManager(close_delay=0.1)
         await manager.start()

--- a/libraries/python/tests/unit/test_connection_manager_timeout.py
+++ b/libraries/python/tests/unit/test_connection_manager_timeout.py
@@ -49,6 +49,25 @@ class TestConnectionManagerTimeout:
         assert manager.close_called
 
     @pytest.mark.asyncio
+    async def test_start_after_stop_restarts_connection(self):
+        manager = MockConnectionManager()
+
+        await manager.start()
+        await manager.stop()
+        assert manager.close_call_count == 1
+
+        connection = await manager.start()
+        assert connection == "test_connection"
+
+        await asyncio.sleep(0)
+        assert manager._task is not None
+        assert not manager._task.done()
+        assert manager.close_call_count == 1
+
+        await manager.stop()
+        assert manager.close_call_count == 2
+
+    @pytest.mark.asyncio
     async def test_stop_with_default_timeout(self):
         manager = MockConnectionManager(close_delay=0.1)
         await manager.start()


### PR DESCRIPTION
## Language / Project Scope

- [x] Python

## Changes

`ConnectionManager.start()` resets its readiness and completion events, but previously left `_stop_event` set after `stop()`. Reusing a manager therefore started a task that immediately shut itself down and raised `RuntimeError("Connection was not established")`.

- Clear the prior stop signal as part of `start()` state reset.
- Add a regression test for `start() → stop() → start()`, verifying the second connection stays active until it is explicitly stopped.

## Review Readiness

- [x] Scoped to one lifecycle bug
- [x] No unrelated formatting, generated files, or bulk rewrites
- [x] Checked for existing PRs addressing this restart behavior

## Python Checklist

- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [x] Added regression coverage
- [x] No documentation update is needed

## Testing

- `python -m pytest tests/unit/test_connection_manager_timeout.py tests/unit/test_websocket_connection_manager.py -q` — 23 passed
- `ruff format --check mcp_use/client/task_managers/base.py tests/unit/test_connection_manager_timeout.py`
- `ruff check mcp_use/client/task_managers/base.py tests/unit/test_connection_manager_timeout.py`
- `git diff --check`
- Manual lifecycle probe: the second `start()` returns a live connection and closes only on the second `stop()`.

## Backwards Compatibility

Backwards compatible. This restores reuse of a connection manager after its documented stop lifecycle; first-start and stop behavior are unchanged.

## Related Issues

None found.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ConnectionManager` restart so a manager can be reused after `stop()`. Previously a second `start()` created a task that immediately shut down and raised `RuntimeError("Connection was not established")`; now the restarted connection stays active until stopped, and first-start/stop behavior is unchanged. `start()` also awaits any in-progress task or stop cleanup before resetting state, so restarting during a stop in progress serializes cleanly and establishes a fresh connection.

<sup>Written for commit da34b6e8cfd3a4b7b08ca54b00c32f6e1bd7e097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

