### PR TITLE
fix(python): collect all connector discovery pages

### DIFF
--- a/libraries/python/mcp_use/client/connectors/base.py
+++ b/libraries/python/mcp_use/client/connectors/base.py
@@ -267,8 +267,7 @@ class BaseConnector(ABC):
         if self.capabilities.tools:
             # Get available tools directly from client session
             try:
-                tools_result = await self.client_session.list_tools()
-                self._tools = tools_result.tools if tools_result else []
+                self._tools = await self._collect_paginated("list_tools", "tools")
             except Exception as e:
                 logger.error(f"Error listing tools for connector {self.public_identifier}: {e}")
                 self._tools = []
@@ -278,8 +277,7 @@ class BaseConnector(ABC):
         if self.capabilities.resources:
             # Get available resources directly from client session
             try:
-                resources_result = await self.client_session.list_resources()
-                self._resources = resources_result.resources if resources_result else []
+                self._resources = await self._collect_paginated("list_resources", "resources")
             except Exception as e:
                 logger.error(f"Error listing resources for connector {self.public_identifier}: {e}")
                 self._resources = []
@@ -289,8 +287,7 @@ class BaseConnector(ABC):
         if self.capabilities.prompts:
             # Get available prompts directly from client session
             try:
-                prompts_result = await self.client_session.list_prompts()
-                self._prompts = prompts_result.prompts if prompts_result else []
+                self._prompts = await self._collect_paginated("list_prompts", "prompts")
             except Exception as e:
                 logger.error(f"Error listing prompts for connector {self.public_identifier}: {e}")
                 self._prompts = []
@@ -440,6 +437,29 @@ class BaseConnector(ABC):
                     "Connection to MCP server has been lost. Auto-reconnection is disabled. Please reconnect manually."
                 )
 
+    async def _collect_paginated(self, method_name: str, items_attribute: str) -> list[Any]:
+        """Collect every page returned by an MCP list operation."""
+        if not self.client_session:
+            raise RuntimeError("MCP client is not connected")
+
+        fetch_page = getattr(self.client_session, method_name)
+        items: list[Any] = []
+        cursor: str | None = None
+        seen_cursors: set[str] = set()
+
+        while True:
+            page = await fetch_page() if cursor is None else await fetch_page(cursor)
+            items.extend(getattr(page, items_attribute))
+
+            next_cursor = getattr(page, "nextCursor", None)
+            if not isinstance(next_cursor, str) or not next_cursor:
+                return items
+            if next_cursor in seen_cursors:
+                raise RuntimeError(f"{method_name} returned repeated pagination cursor {next_cursor!r}")
+
+            seen_cursors.add(next_cursor)
+            cursor = next_cursor
+
     @telemetry("connector_call_tool")
     async def call_tool(
         self,
@@ -490,9 +510,8 @@ class BaseConnector(ABC):
 
         logger.debug("Listing tools")
         try:
-            result = await self.client_session.list_tools()
-            self._tools = result.tools
-            return result.tools
+            self._tools = await self._collect_paginated("list_tools", "tools")
+            return self._tools
         except McpError as e:
             logger.error(f"Error listing tools for connector {self.public_identifier}: {e}")
             return []
@@ -510,9 +529,8 @@ class BaseConnector(ABC):
 
         logger.debug("Listing resources")
         try:
-            result = await self.client_session.list_resources()
-            self._resources = result.resources
-            return result.resources
+            self._resources = await self._collect_paginated("list_resources", "resources")
+            return self._resources
         except McpError as e:
             logger.warning(f"Error listing resources for connector {self.public_identifier}: {e}")
             return []
@@ -538,9 +556,8 @@ class BaseConnector(ABC):
 
         logger.debug("Listing prompts")
         try:
-            result = await self.client_session.list_prompts()
-            self._prompts = result.prompts
-            return result.prompts
+            self._prompts = await self._collect_paginated("list_prompts", "prompts")
+            return self._prompts
         except McpError as e:
             logger.error(f"Error listing prompts for connector {self.public_identifier}: {e}")
             return []

--- a/libraries/python/mcp_use/client/connectors/base.py
+++ b/libraries/python/mcp_use/client/connectors/base.py
@@ -449,13 +449,27 @@ class BaseConnector(ABC):
 
         while True:
             page = await fetch_page() if cursor is None else await fetch_page(cursor)
-            items.extend(getattr(page, items_attribute))
+            if page is None:
+                return items
+
+            page_items = getattr(page, items_attribute, None)
+            if page_items is None:
+                return items
+            items.extend(page_items)
 
             next_cursor = getattr(page, "nextCursor", None)
-            if not isinstance(next_cursor, str) or not next_cursor:
+            if next_cursor is None:
+                return items
+            if not isinstance(next_cursor, str):
+                logger.warning(
+                    f"{method_name} returned non-string pagination cursor {next_cursor!r}; stopping pagination"
+                )
                 return items
             if next_cursor in seen_cursors:
-                raise RuntimeError(f"{method_name} returned repeated pagination cursor {next_cursor!r}")
+                logger.warning(
+                    f"{method_name} returned repeated pagination cursor {next_cursor!r}; stopping pagination"
+                )
+                return items
 
             seen_cursors.add(next_cursor)
             cursor = next_cursor

--- a/libraries/python/mcp_use/client/connectors/base.py
+++ b/libraries/python/mcp_use/client/connectors/base.py
@@ -446,14 +446,23 @@ class BaseConnector(ABC):
         items: list[Any] = []
         cursor: str | None = None
         seen_cursors: set[str] = set()
+        missing_page_items = object()
 
         while True:
             page = await fetch_page() if cursor is None else await fetch_page(cursor)
             if page is None:
+                logger.warning(f"{method_name} returned no page; stopping pagination")
                 return items
 
-            page_items = getattr(page, items_attribute, None)
+            page_items = getattr(page, items_attribute, missing_page_items)
+            if page_items is missing_page_items:
+                logger.warning(f"{method_name} returned page missing {items_attribute!r}; stopping pagination")
+                return items
             if page_items is None:
+                logger.warning(f"{method_name} returned page with None {items_attribute!r}; stopping pagination")
+                return items
+            if not isinstance(page_items, list):
+                logger.warning(f"{method_name} returned non-list {items_attribute!r}; stopping pagination")
                 return items
             items.extend(page_items)
 

--- a/libraries/python/mcp_use/client/connectors/http.py
+++ b/libraries/python/mcp_use/client/connectors/http.py
@@ -212,22 +212,19 @@ class HttpConnector(BaseConnector):
 
                 if server_capabilities.tools:
                     # Get available tools directly from client session
-                    tools_result = await self.client_session.list_tools()
-                    self._tools = tools_result.tools if tools_result else []
+                    self._tools = await self._collect_paginated("list_tools", "tools")
                 else:
                     self._tools = []
 
                 if server_capabilities.resources:
                     # Get available resources directly from client session
-                    resources_result = await self.client_session.list_resources()
-                    self._resources = resources_result.resources if resources_result else []
+                    self._resources = await self._collect_paginated("list_resources", "resources")
                 else:
                     self._resources = []
 
                 if server_capabilities.prompts:
                     # Get available prompts directly from client session
-                    prompts_result = await self.client_session.list_prompts()
-                    self._prompts = prompts_result.prompts if prompts_result else []
+                    self._prompts = await self._collect_paginated("list_prompts", "prompts")
                 else:
                     self._prompts = []
 

--- a/libraries/python/tests/unit/test_http_connector.py
+++ b/libraries/python/tests/unit/test_http_connector.py
@@ -484,7 +484,7 @@ class TestHttpConnectorOperations(IsolatedAsyncioTestCase):
         self.connector.client_session.list_tools.assert_has_awaits([call(), call("")])
         self.assertEqual(self.connector.client_session.list_tools.await_count, 2)
 
-    async def test_list_tools_stops_on_later_none_page_preserving_items(self, _):
+    async def test_list_tools_stops_on_later_none_page_preserving_items(self, mock_logger):
         """A missing later page should preserve the items collected so far."""
         first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
         self.connector.client_session.list_tools.side_effect = [
@@ -498,8 +498,9 @@ class TestHttpConnectorOperations(IsolatedAsyncioTestCase):
         self.assertEqual(self.connector._tools, [first_tool])
         self.connector.client_session.list_tools.assert_has_awaits([call(), call("tools-page-2")])
         self.assertEqual(self.connector.client_session.list_tools.await_count, 2)
+        mock_logger.warning.assert_called_once_with("list_tools returned no page; stopping pagination")
 
-    async def test_list_tools_stops_on_later_missing_collection_preserving_items(self, _):
+    async def test_list_tools_stops_on_later_missing_collection_preserving_items(self, mock_logger):
         """A later page without the collection attribute should preserve prior items."""
         first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
         self.connector.client_session.list_tools.side_effect = [
@@ -513,8 +514,9 @@ class TestHttpConnectorOperations(IsolatedAsyncioTestCase):
         self.assertEqual(self.connector._tools, [first_tool])
         self.connector.client_session.list_tools.assert_has_awaits([call(), call("tools-page-2")])
         self.assertEqual(self.connector.client_session.list_tools.await_count, 2)
+        mock_logger.warning.assert_called_once_with("list_tools returned page missing 'tools'; stopping pagination")
 
-    async def test_list_tools_stops_on_later_none_collection_preserving_items(self, _):
+    async def test_list_tools_stops_on_later_none_collection_preserving_items(self, mock_logger):
         """A later page with a None collection should preserve prior items."""
         first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
         self.connector.client_session.list_tools.side_effect = [
@@ -528,6 +530,23 @@ class TestHttpConnectorOperations(IsolatedAsyncioTestCase):
         self.assertEqual(self.connector._tools, [first_tool])
         self.connector.client_session.list_tools.assert_has_awaits([call(), call("tools-page-2")])
         self.assertEqual(self.connector.client_session.list_tools.await_count, 2)
+        mock_logger.warning.assert_called_once_with("list_tools returned page with None 'tools'; stopping pagination")
+
+    async def test_list_tools_stops_on_non_list_collection_preserving_items(self, mock_logger):
+        """A later page with a non-list collection should preserve prior items."""
+        first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
+        self.connector.client_session.list_tools.side_effect = [
+            ListToolsResult(tools=[first_tool], nextCursor="tools-page-2"),
+            MagicMock(tools=("not", "a", "list")),
+        ]
+
+        result = await self.connector.list_tools()
+
+        self.assertEqual(result, [first_tool])
+        self.assertEqual(self.connector._tools, [first_tool])
+        self.connector.client_session.list_tools.assert_has_awaits([call(), call("tools-page-2")])
+        self.assertEqual(self.connector.client_session.list_tools.await_count, 2)
+        mock_logger.warning.assert_called_once_with("list_tools returned non-list 'tools'; stopping pagination")
 
     async def test_list_tools_stops_on_non_string_cursor_preserving_items(self, mock_logger):
         """A non-string cursor should warn and preserve the current page's items."""

--- a/libraries/python/tests/unit/test_http_connector.py
+++ b/libraries/python/tests/unit/test_http_connector.py
@@ -468,6 +468,102 @@ class TestHttpConnectorOperations(IsolatedAsyncioTestCase):
         self.assertEqual(self.connector._tools, [first_tool, second_tool])
         self.connector.client_session.list_tools.assert_has_awaits([call(), call("tools-page-2")])
 
+    async def test_list_tools_follows_empty_cursor(self, _):
+        """An empty string is a valid cursor and should fetch the next page."""
+        first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
+        second_tool = Tool(name="second", inputSchema={"type": "object", "properties": {}})
+        self.connector.client_session.list_tools.side_effect = [
+            ListToolsResult(tools=[first_tool], nextCursor=""),
+            ListToolsResult(tools=[second_tool]),
+        ]
+
+        result = await self.connector.list_tools()
+
+        self.assertEqual(result, [first_tool, second_tool])
+        self.assertEqual(self.connector._tools, [first_tool, second_tool])
+        self.connector.client_session.list_tools.assert_has_awaits([call(), call("")])
+        self.assertEqual(self.connector.client_session.list_tools.await_count, 2)
+
+    async def test_list_tools_stops_on_later_none_page_preserving_items(self, _):
+        """A missing later page should preserve the items collected so far."""
+        first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
+        self.connector.client_session.list_tools.side_effect = [
+            ListToolsResult(tools=[first_tool], nextCursor="tools-page-2"),
+            None,
+        ]
+
+        result = await self.connector.list_tools()
+
+        self.assertEqual(result, [first_tool])
+        self.assertEqual(self.connector._tools, [first_tool])
+        self.connector.client_session.list_tools.assert_has_awaits([call(), call("tools-page-2")])
+        self.assertEqual(self.connector.client_session.list_tools.await_count, 2)
+
+    async def test_list_tools_stops_on_later_missing_collection_preserving_items(self, _):
+        """A later page without the collection attribute should preserve prior items."""
+        first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
+        self.connector.client_session.list_tools.side_effect = [
+            ListToolsResult(tools=[first_tool], nextCursor="tools-page-2"),
+            object(),
+        ]
+
+        result = await self.connector.list_tools()
+
+        self.assertEqual(result, [first_tool])
+        self.assertEqual(self.connector._tools, [first_tool])
+        self.connector.client_session.list_tools.assert_has_awaits([call(), call("tools-page-2")])
+        self.assertEqual(self.connector.client_session.list_tools.await_count, 2)
+
+    async def test_list_tools_stops_on_later_none_collection_preserving_items(self, _):
+        """A later page with a None collection should preserve prior items."""
+        first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
+        self.connector.client_session.list_tools.side_effect = [
+            ListToolsResult(tools=[first_tool], nextCursor="tools-page-2"),
+            MagicMock(tools=None),
+        ]
+
+        result = await self.connector.list_tools()
+
+        self.assertEqual(result, [first_tool])
+        self.assertEqual(self.connector._tools, [first_tool])
+        self.connector.client_session.list_tools.assert_has_awaits([call(), call("tools-page-2")])
+        self.assertEqual(self.connector.client_session.list_tools.await_count, 2)
+
+    async def test_list_tools_stops_on_non_string_cursor_preserving_items(self, mock_logger):
+        """A non-string cursor should warn and preserve the current page's items."""
+        first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
+        self.connector.client_session.list_tools.return_value = MagicMock(tools=[first_tool], nextCursor=123)
+
+        result = await self.connector.list_tools()
+
+        self.assertEqual(result, [first_tool])
+        self.assertEqual(self.connector._tools, [first_tool])
+        self.connector.client_session.list_tools.assert_awaited_once_with()
+        mock_logger.warning.assert_called_once_with(
+            "list_tools returned non-string pagination cursor 123; stopping pagination"
+        )
+
+    async def test_list_tools_stops_on_repeated_cursor_preserving_page_items(self, mock_logger):
+        """A cursor cycle should return all fetched items and emit one warning."""
+        first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
+        second_tool = Tool(name="second", inputSchema={"type": "object", "properties": {}})
+        third_tool = Tool(name="third", inputSchema={"type": "object", "properties": {}})
+        self.connector.client_session.list_tools.side_effect = [
+            ListToolsResult(tools=[first_tool], nextCursor="tools-page-2"),
+            ListToolsResult(tools=[second_tool], nextCursor="tools-page-3"),
+            ListToolsResult(tools=[third_tool], nextCursor="tools-page-2"),
+        ]
+
+        result = await self.connector.list_tools()
+
+        self.assertEqual(result, [first_tool, second_tool, third_tool])
+        self.assertEqual(self.connector._tools, [first_tool, second_tool, third_tool])
+        self.connector.client_session.list_tools.assert_has_awaits([call(), call("tools-page-2"), call("tools-page-3")])
+        self.assertEqual(self.connector.client_session.list_tools.await_count, 3)
+        mock_logger.warning.assert_called_once_with(
+            "list_tools returned repeated pagination cursor 'tools-page-2'; stopping pagination"
+        )
+
     async def test_list_resources_collects_all_pages(self, _):
         """Resource discovery should follow nextCursor until every page is collected."""
         first_resource = Resource(uri="file:///first.txt", name="first")

--- a/libraries/python/tests/unit/test_http_connector.py
+++ b/libraries/python/tests/unit/test_http_connector.py
@@ -7,7 +7,16 @@ from unittest import IsolatedAsyncioTestCase
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 from mcp import McpError
-from mcp.types import EmptyResult, ErrorData, Prompt, Resource, Tool
+from mcp.types import (
+    EmptyResult,
+    ErrorData,
+    ListPromptsResult,
+    ListResourcesResult,
+    ListToolsResult,
+    Prompt,
+    Resource,
+    Tool,
+)
 
 from mcp_use.client.auth.bearer import BearerAuth
 from mcp_use.client.connectors.http import HttpConnector
@@ -180,8 +189,14 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         mock_client_session_instance.initialize.return_value = mock_init_result
 
         # Add mocks for list_tools, list_resources, and list_prompts since HttpConnector calls these
-        mock_client_session_instance.list_tools = AsyncMock()
-        mock_client_session_instance.list_tools.return_value = MagicMock(tools=[MagicMock(spec=Tool)])
+        first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
+        second_tool = Tool(name="second", inputSchema={"type": "object", "properties": {}})
+        mock_client_session_instance.list_tools = AsyncMock(
+            side_effect=[
+                ListToolsResult(tools=[first_tool], nextCursor="tools-page-2"),
+                ListToolsResult(tools=[second_tool]),
+            ]
+        )
         mock_client_session_instance.list_resources = AsyncMock()
         mock_client_session_instance.list_resources.return_value = MagicMock(resources=[MagicMock(spec=Resource)])
         mock_client_session_instance.list_prompts = AsyncMock()
@@ -211,7 +226,7 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         mock_client_session_instance.initialize.assert_called_once()
 
         # Verify tools/resources/prompts were populated during connect
-        mock_client_session_instance.list_tools.assert_called_once()
+        mock_client_session_instance.list_tools.assert_has_awaits([call(), call("tools-page-2")])
         mock_client_session_instance.list_resources.assert_called_once()
         mock_client_session_instance.list_prompts.assert_called_once()
 
@@ -220,7 +235,7 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         self.assertEqual(self.connector._connection_manager, mock_cm_instance)
         self.assertTrue(self.connector._connected)
         self.assertTrue(self.connector._initialized)
-        self.assertEqual(len(self.connector._tools), 1)
+        self.assertEqual(self.connector._tools, [first_tool, second_tool])
         self.assertEqual(len(self.connector._resources), 1)
         self.assertEqual(len(self.connector._prompts), 1)
 
@@ -361,6 +376,39 @@ class TestHttpConnectorOperations(IsolatedAsyncioTestCase):
         self.assertEqual(len(self.connector._resources), 1)
         self.assertEqual(len(self.connector._prompts), 1)
 
+    async def test_initialize_collects_all_discovery_pages(self, _):
+        """Initialization should cache every tools, resources, and prompts page."""
+        mock_init_result = MagicMock()
+        mock_init_result.capabilities = MagicMock(tools=True, resources=True, prompts=True)
+        self.connector.client_session.initialize.return_value = mock_init_result
+
+        first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
+        second_tool = Tool(name="second", inputSchema={"type": "object", "properties": {}})
+        self.connector.client_session.list_tools.side_effect = [
+            ListToolsResult(tools=[first_tool], nextCursor="tools-page-2"),
+            ListToolsResult(tools=[second_tool]),
+        ]
+
+        first_resource = Resource(uri="file:///first.txt", name="first")
+        second_resource = Resource(uri="file:///second.txt", name="second")
+        self.connector.client_session.list_resources.side_effect = [
+            ListResourcesResult(resources=[first_resource], nextCursor="resources-page-2"),
+            ListResourcesResult(resources=[second_resource]),
+        ]
+
+        first_prompt = Prompt(name="first")
+        second_prompt = Prompt(name="second")
+        self.connector.client_session.list_prompts.side_effect = [
+            ListPromptsResult(prompts=[first_prompt], nextCursor="prompts-page-2"),
+            ListPromptsResult(prompts=[second_prompt]),
+        ]
+
+        await self.connector.initialize()
+
+        self.assertEqual(self.connector._tools, [first_tool, second_tool])
+        self.assertEqual(self.connector._resources, [first_resource, second_resource])
+        self.assertEqual(self.connector._prompts, [first_prompt, second_prompt])
+
     async def test_initialize_no_client(self, _):
         """Test initializing without a client."""
         self.connector.client_session = None
@@ -404,6 +452,51 @@ class TestHttpConnectorOperations(IsolatedAsyncioTestCase):
         self.connector.client_session.list_resources.assert_called_once_with()
         # The connector's list_resources method should return the list of resources directly.
         self.assertEqual(result, expected_resources_list)
+
+    async def test_list_tools_collects_all_pages(self, _):
+        """Tool discovery should follow nextCursor until every page is collected."""
+        first_tool = Tool(name="first", inputSchema={"type": "object", "properties": {}})
+        second_tool = Tool(name="second", inputSchema={"type": "object", "properties": {}})
+        self.connector.client_session.list_tools.side_effect = [
+            ListToolsResult(tools=[first_tool], nextCursor="tools-page-2"),
+            ListToolsResult(tools=[second_tool]),
+        ]
+
+        result = await self.connector.list_tools()
+
+        self.assertEqual(result, [first_tool, second_tool])
+        self.assertEqual(self.connector._tools, [first_tool, second_tool])
+        self.connector.client_session.list_tools.assert_has_awaits([call(), call("tools-page-2")])
+
+    async def test_list_resources_collects_all_pages(self, _):
+        """Resource discovery should follow nextCursor until every page is collected."""
+        first_resource = Resource(uri="file:///first.txt", name="first")
+        second_resource = Resource(uri="file:///second.txt", name="second")
+        self.connector.client_session.list_resources.side_effect = [
+            ListResourcesResult(resources=[first_resource], nextCursor="resources-page-2"),
+            ListResourcesResult(resources=[second_resource]),
+        ]
+
+        result = await self.connector.list_resources()
+
+        self.assertEqual(result, [first_resource, second_resource])
+        self.assertEqual(self.connector._resources, [first_resource, second_resource])
+        self.connector.client_session.list_resources.assert_has_awaits([call(), call("resources-page-2")])
+
+    async def test_list_prompts_collects_all_pages(self, _):
+        """Prompt discovery should follow nextCursor until every page is collected."""
+        first_prompt = Prompt(name="first")
+        second_prompt = Prompt(name="second")
+        self.connector.client_session.list_prompts.side_effect = [
+            ListPromptsResult(prompts=[first_prompt], nextCursor="prompts-page-2"),
+            ListPromptsResult(prompts=[second_prompt]),
+        ]
+
+        result = await self.connector.list_prompts()
+
+        self.assertEqual(result, [first_prompt, second_prompt])
+        self.assertEqual(self.connector._prompts, [first_prompt, second_prompt])
+        self.connector.client_session.list_prompts.assert_has_awaits([call(), call("prompts-page-2")])
 
     async def test_list_resources_no_client(self, _):
         """Test listing resources when not connected."""


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Python connectors previously consumed only the first page returned by MCP `tools/list`, `resources/list`, and `prompts/list`. Servers that paginate discovery results therefore exposed an incomplete capability set to `MCPClient` and higher-level consumers.

This PR follows each response's `nextCursor` until pagination is exhausted, both during eager connector initialization and when the public discovery methods are called directly. Cursors remain opaque (including an empty string). Malformed pages or cursor cycles emit a warning where appropriate and return the items collected so far instead of failing discovery or looping indefinitely.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Add a shared `BaseConnector._collect_paginated()` helper that invokes an MCP list method with successive cursors and combines its item collection.
2. Use the helper for tool, resource, and prompt discovery in base initialization and Streamable HTTP eager initialization.
3. Use the same pagination behavior in the public `list_tools()`, `list_resources()`, and `list_prompts()` methods.
4. Preserve accumulated results for `None`/missing/non-list page collections, accept empty-string cursors, and terminate non-string or repeated cursors safely with warnings.
5. Add unit coverage for multi-page aggregation and malformed pagination edge cases.

No dependencies were added or modified.

---

## Python Checklist

### Pre-commit Checklist

- [x] Code formatted with `ruff format`
- [x] Linting passes with `ruff check`
- [x] Added or updated tests if needed
- [x] Updated documentation if needed (not required; public API is unchanged)

## Example Usage (Before)

```python
tools = await connector.list_tools()
# Only the first server page was returned when nextCursor was present.
```

## Example Usage (After)

```python
tools = await connector.list_tools()
# Tools from every server page are returned.
```

## Documentation Updates

No documentation changes are required because the public API and return types are unchanged; this corrects protocol behavior.

## Testing

- `pytest -q tests/unit` on Python 3.12 with all extras — 316 passed
- `pytest -q tests/unit/test_http_connector.py` against the minimum supported `mcp==1.24.0` — 32 passed
- `ruff check .` with CI-pinned Ruff 0.15.22 — passed
- `ruff format --check .` with CI-pinned Ruff 0.15.22 — 224 files already formatted

Coverage includes eager HTTP initialization, base connector initialization, direct discovery methods, empty-string cursors, `None`/missing/non-list collections, non-string cursors, and repeated cursor cycles.

## Backwards Compatibility

This is backwards compatible. Single-page servers behave exactly as before; paginated servers now return the complete discovery result.

## Related Issues

No linked issue; found during a connector correctness audit.
