### PR TITLE
fix(python): make streamable HTTP failure and SSE fallback visible in logs (#2369)

### DIFF
--- a/libraries/python/mcp_use/client/connectors/http.py
+++ b/libraries/python/mcp_use/client/connectors/http.py
@@ -254,14 +254,16 @@ class HttpConnector(BaseConnector):
         # Exception from the inner try is propagated here and in
         # the most cases is an McpError, so checking instances is useless
         except Exception as streamable_error:
-            logger.debug(f"Streamable HTTP failed: {streamable_error}")
+            logger.warning(f"Streamable HTTP failed: {streamable_error}")
 
             # Clean up the failed streamable HTTP connection manager
             if connection_manager:
                 try:
                     await connection_manager.close()
-                except Exception:
-                    pass
+                except Exception as cleanup_error:
+                    logger.warning(
+                        f"Error cleaning up failed streamable connection manager: {cleanup_error}"
+                    )
 
             # It doesn't make sense to check error types. Because client
             # always return a McpError, if he can't reach the server
@@ -271,7 +273,7 @@ class HttpConnector(BaseConnector):
             if should_fallback:
                 try:
                     # Fall back to the old SSE transport
-                    logger.debug(f"Attempting SSE fallback connection to: {self.base_url}")
+                    logger.info(f"Attempting SSE fallback connection to: {self.base_url}")
                     connection_manager = SseConnectionManager(
                         self.base_url,
                         self.headers,

--- a/libraries/python/tests/unit/test_http_connector.py
+++ b/libraries/python/tests/unit/test_http_connector.py
@@ -161,6 +161,102 @@ class TestHttpConnectorConnection(IsolatedAsyncioTestCase):
         self.assertTrue(self.connector._connected)
         self.assertIsNotNone(self.connector.client_session)
 
+    @patch("mcp_use.client.connectors.http.logger")
+    @patch("mcp_use.client.connectors.http.SseConnectionManager")
+    @patch("mcp_use.client.connectors.http.StreamableHttpConnectionManager")
+    @patch("mcp_use.client.connectors.http.ClientSession")
+    async def test_streamable_http_failure_and_sse_fallback_log_levels(
+        self, mock_client_session_class, mock_streamable_cm_class, mock_sse_cm_class, mock_logger, _
+    ):
+        """Test that streamable HTTP failure logs warning and SSE fallback logs info."""
+        mock_streamable_cm_instance = MagicMock()
+        mock_streamable_cm_instance.start = AsyncMock(return_value=("read_stream", "write_stream"))
+        mock_streamable_cm_instance.close = AsyncMock()
+        mock_streamable_cm_class.return_value = mock_streamable_cm_instance
+
+        mock_sse_cm_instance = MagicMock()
+        mock_sse_cm_instance.start = AsyncMock(return_value=("sse_read_stream", "sse_write_stream"))
+        mock_sse_cm_class.return_value = mock_sse_cm_instance
+
+        call_count = 0
+
+        def mock_client_session_factory(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock_instance = MagicMock()
+            mock_instance.__aenter__ = AsyncMock()
+            mock_instance.__aexit__ = AsyncMock()
+            mock_instance.initialize = AsyncMock()
+            if call_count == 1:
+                mock_instance.initialize.side_effect = McpError(ErrorData(code=1, message="Streamable dropped"))
+            else:
+                mock_instance.initialize.return_value = MagicMock(
+                    capabilities=MagicMock(tools=True, resources=True, prompts=True)
+                )
+            mock_instance.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
+            mock_instance.list_resources = AsyncMock(return_value=MagicMock(resources=[]))
+            mock_instance.list_prompts = AsyncMock(return_value=MagicMock(prompts=[]))
+            return mock_instance
+
+        mock_client_session_class.side_effect = mock_client_session_factory
+
+        await self.connector.connect()
+
+        # Streamable HTTP failure must be logged as warning
+        warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+        self.assertTrue(any("Streamable HTTP failed:" in msg for msg in warning_calls))
+
+        # SSE fallback attempt must be logged as info
+        info_calls = [call[0][0] for call in mock_logger.info.call_args_list]
+        self.assertTrue(any("Attempting SSE fallback connection to:" in msg for msg in info_calls))
+
+    @patch("mcp_use.client.connectors.http.logger")
+    @patch("mcp_use.client.connectors.http.SseConnectionManager")
+    @patch("mcp_use.client.connectors.http.StreamableHttpConnectionManager")
+    @patch("mcp_use.client.connectors.http.ClientSession")
+    async def test_streamable_cleanup_error_logged_at_warning(
+        self, mock_client_session_class, mock_streamable_cm_class, mock_sse_cm_class, mock_logger, _
+    ):
+        """Test that failure during cleanup of streamable connection manager is logged at warning."""
+        mock_streamable_cm_instance = MagicMock()
+        mock_streamable_cm_instance.start = AsyncMock(return_value=("read_stream", "write_stream"))
+        mock_streamable_cm_instance.close = AsyncMock(side_effect=RuntimeError("Close failed"))
+        mock_streamable_cm_class.return_value = mock_streamable_cm_instance
+
+        mock_sse_cm_instance = MagicMock()
+        mock_sse_cm_instance.start = AsyncMock(return_value=("sse_read_stream", "sse_write_stream"))
+        mock_sse_cm_class.return_value = mock_sse_cm_instance
+
+        call_count = 0
+
+        def mock_client_session_factory(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock_instance = MagicMock()
+            mock_instance.__aenter__ = AsyncMock()
+            mock_instance.__aexit__ = AsyncMock()
+            mock_instance.initialize = AsyncMock()
+            if call_count == 1:
+                mock_instance.initialize.side_effect = McpError(ErrorData(code=1, message="Streamable dropped"))
+            else:
+                mock_instance.initialize.return_value = MagicMock(
+                    capabilities=MagicMock(tools=True, resources=True, prompts=True)
+                )
+            mock_instance.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
+            mock_instance.list_resources = AsyncMock(return_value=MagicMock(resources=[]))
+            mock_instance.list_prompts = AsyncMock(return_value=MagicMock(prompts=[]))
+            return mock_instance
+
+        mock_client_session_class.side_effect = mock_client_session_factory
+
+        await self.connector.connect()
+
+        # Cleanup error must be logged as warning with exception detail
+        warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+        self.assertTrue(
+            any("Error cleaning up failed streamable connection manager: Close failed" in msg for msg in warning_calls)
+        )
+
     @patch("mcp_use.client.connectors.http.StreamableHttpConnectionManager")
     @patch("mcp_use.client.connectors.http.ClientSession")
     async def test_connect_with_streamable_http(self, mock_client_session_class, mock_cm_class, _):


### PR DESCRIPTION
### Summary

Resolves #2369.

When streamable HTTP transport fails and the connector falls back to legacy SSE transport, the transition was previously completely invisible at default log levels:
1. Streamable failure was logged at \debug\ only.
2. Swallowed cleanup errors for the failed streamable connection manager were completely unlogged.
3. SSE fallback connection attempt was logged at \debug\ only.

### Changes
- Raised streamable HTTP failure log level from \debug\ to \warning\.
- Logged connection manager cleanup exceptions at \warning\ with exception details instead of silently passing.
- Raised SSE fallback attempt log level to \info\.
- Added unit regression tests in \	ests/unit/test_http_connector.py\ verifying log calls during streamable failure, cleanup error, and SSE fallback.

### Verification
- Ran \python -m pytest libraries/python/tests/unit/test_http_connector.py\ (23/23 passing).
- Ran \uff check\ on modified files (0 errors).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves #2369 by making streamable HTTP transport failures and the fallback to SSE visible in logs at default levels. Transport behavior is unchanged; only log levels and previously swallowed cleanup errors are affected.

**Bug Fixes**
- Streamable HTTP failures now log at `warning` instead of `debug`.
- SSE fallback connection attempts now log at `info` instead of `debug`.
- Connection manager cleanup errors during fallback now log at `warning` with exception details instead of being silently ignored.
- Adds unit regression tests for these log calls.

<sup>Written for commit 0e9d4c7a0458754fbb6329e094d01192ad8807b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

