### PR TITLE
feat(inspector): configure embedded max steps

### DIFF
--- a/libraries/typescript/.changeset/fuzzy-spoons-chat.md
+++ b/libraries/typescript/.changeset/fuzzy-spoons-chat.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Allow embedded client-side chats to configure up to 100 agent steps.

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -138,6 +138,8 @@ export interface ChatTabProps {
   chatQuickQuestions?: string[];
   /** Initial followups shown above input in active chat mode. */
   chatFollowups?: string[];
+  /** Maximum agent steps for client-side chat. Defaults to 10 and is capped at 100. */
+  maxSteps?: number;
   /**
    * Wire protocol used by the streaming endpoint.
    * - `"sse"` (default): Inspector SSE protocol
@@ -209,6 +211,7 @@ export function ChatTab({
   hideToolSelector,
   chatQuickQuestions = [],
   chatFollowups = [],
+  maxSteps,
   streamProtocol,
   credentials,
   extraHeaders,
@@ -346,6 +349,7 @@ export function ChatTab({
     widgetModelContexts,
     disabledTools: effectiveDisabledTools,
     appToolConnections,
+    maxSteps,
   };
 
   const serverSideChat = useChatMessages({

--- a/libraries/typescript/packages/inspector/src/client/components/LayoutContent.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/LayoutContent.tsx
@@ -185,6 +185,7 @@ export function LayoutContent({
         clearButtonVariant={embeddedConfig.chatClearButtonVariant}
         chatQuickQuestions={embeddedConfig.chatQuickQuestions}
         chatFollowups={embeddedConfig.chatFollowups}
+        maxSteps={embeddedConfig.maxSteps}
         hideClearButton={embeddedConfig.chatHideClearButton}
         hideToolSelector={embeddedConfig.chatHideToolSelector}
         enableKeyboardShortcuts={false}
@@ -334,6 +335,7 @@ export function LayoutContent({
             clearButtonVariant={embeddedConfig.chatClearButtonVariant}
             chatQuickQuestions={embeddedConfig.chatQuickQuestions}
             chatFollowups={embeddedConfig.chatFollowups}
+            maxSteps={embeddedConfig.maxSteps}
             hideClearButton={embeddedConfig.chatHideClearButton}
             hideToolSelector={embeddedConfig.chatHideToolSelector}
             streamProtocol={embeddedConfig.chatStreamProtocol}

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -100,6 +100,7 @@ interface UseChatMessagesClientSideProps {
   initialMessages?: Message[];
   systemPrompt?: string;
   skills?: Skill[];
+  maxSteps?: number;
 }
 
 export function useChatMessagesClientSide({
@@ -116,6 +117,7 @@ export function useChatMessagesClientSide({
   initialMessages,
   systemPrompt = DEFAULT_CHAT_SYSTEM_PROMPT,
   skills = [],
+  maxSteps,
 }: UseChatMessagesClientSideProps) {
   const retryServerId = connection.id ?? connection.url;
   const privateStore = useChatSessionStore();
@@ -424,7 +426,10 @@ export function useChatMessagesClientSide({
             disabledTools && disabledTools.size > 0
               ? [...disabledTools].sort()
               : undefined,
-          maxSteps: 10,
+          maxSteps:
+            typeof maxSteps === "number" && Number.isFinite(maxSteps)
+              ? Math.min(100, Math.max(1, Math.trunc(maxSteps)))
+              : 10,
           autoInitialize: true,
         });
 

--- a/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
+++ b/libraries/typescript/packages/inspector/src/client/components/chat/useChatMessagesClientSide.ts
@@ -695,6 +695,7 @@ export function useChatMessagesClientSide({
       runtime,
       systemPrompt,
       skills,
+      maxSteps,
       setMessages,
       updateSession,
     ]

--- a/libraries/typescript/packages/inspector/src/client/context/InspectorContext.tsx
+++ b/libraries/typescript/packages/inspector/src/client/context/InspectorContext.tsx
@@ -91,6 +91,8 @@ export interface EmbeddedConfig {
   chatQuickQuestions?: string[];
   /** Initial followup suggestions shown above input in chat mode. */
   chatFollowups?: string[];
+  /** Maximum agent steps for client-side chat. Defaults to 10 and is capped at 100. */
+  maxSteps?: number;
   /** When true, hides the "New Chat" / clear button in the chat header. */
   chatHideClearButton?: boolean;
   /** When true, hides the tool selector (wrench icon) in the chat input. */


### PR DESCRIPTION
## Summary

- allow embedded Inspector clients to configure the client-side agent step limit
- preserve the existing 10-step default for normal Inspector sessions
- clamp embedded overrides to 100 steps
- add a patch changeset for @mcp-use/inspector

## Why

Manufact evals execute long, tool-heavy workflows through an embedded Inspector session. The existing hardcoded 10-step limit can stop these runs before cleanup and the final report.

## Validation

- Inspector typecheck
- Inspector lint on changed files
- Inspector package build
- Inspector unit tests: 262 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embedded Inspector chats can now set the client-side agent step limit instead of always using 10 steps, allowing long tool-heavy evals to complete. Standard sessions still default to 10 steps.

- Exposes `maxSteps` through `EmbeddedConfig` and `ChatTabProps`.
- Clamps finite overrides to whole numbers from 1 through 100 and applies changes when embedded configuration refreshes.
- Adds a patch changeset for `@mcp-use/inspector`.

<sup>Written for commit 28d425835a93614b0b85a7467738bd455ead6f37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Linear

- Related to [MCP-3144](https://linear.app/manufact/issue/MCP-3144/upgrade-and-pin-the-inspector-used-by-cloud-evals)
