### PR TITLE
fix(inspector): resolve chat widgets by connection id

### DIFF
--- a/libraries/typescript/.changeset/fresh-apps-connect.md
+++ b/libraries/typescript/.changeset/fresh-apps-connect.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Render chat MCP Apps with the registered MCP connection id while preserving the logical server id for chat state and storage.

--- a/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
+++ b/libraries/typescript/packages/inspector/src/client/components/ChatTab.tsx
@@ -1658,7 +1658,7 @@ export function ChatTab({
             <MessageList
               messages={messages}
               isLoading={isLoading}
-              serverId={serverId}
+              serverId={connection.id}
               readResource={readResource}
               tools={connection.tools}
               sendMessage={sendWidgetMessage}


### PR DESCRIPTION
## Summary

- resolve chat MCP Apps with the registered MCP connection id
- preserve the logical server id for chat state, storage, model context, and host messages
- add an Inspector patch changeset

## Context

Hosted Cloud servers are registered in the MCP client with an environment-scoped id such as server-1::env::production, while ChatTab receives server-1 as its logical chat and agent id. ChatTab forwarded the logical id into the MCP Apps renderer, whose view host performs an exact lookup in useMcpClient().servers. The lookup missed and left the loading overlay visible indefinitely.

The widget path now uses connection.id. The public ChatTab serverId continues to identify chat state, so this does not split chat history or storage by environment.

## Validation

- pnpm test:unit: 55 files, 267 tests passed
- pnpm type-check
- focused ESLint and Prettier checks
- pnpm --filter @mcp-use/inspector... build, including client declarations, server bundle, production app bundle, and package verification
- git diff --check