### PR TITLE
feat(server): add OAuth provider setup hook

### DIFF
--- a/docs/v2/typescript/server/authentication/providers/custom.mdx
+++ b/docs/v2/typescript/server/authentication/providers/custom.mdx
@@ -98,6 +98,46 @@ Write the verifier by hand when the provider does not issue JWTs, for example wh
 
 The server exposes those values as `ctx.auth.user`, `ctx.auth.payload`, and `ctx.auth.permissions`. `ctx.auth.scopes` remains the verifier's verified `authInfo.scopes`.
 
+## Extend the server from the provider
+
+Some authorization models need more than token verification: a consent step exposed as a tool, a policy check before every tool call, or a discovery document at an extra path. Pass an optional `setup(host)` hook and the server invokes it once while mounting, before the first request is served.
+
+```typescript
+import { oauthCustomProvider, type OAuthProviderHost } from "mcp-use/oauth";
+
+const oauth = oauthCustomProvider({
+  createTokenVerifier,
+  oauthMetadata,
+  mapAuthInfo,
+  setup(host: OAuthProviderHost) {
+    host.use("mcp:tools/call", async (ctx, next) => {
+      if (!(await isAllowed(ctx.auth, ctx.params.name))) {
+        return {
+          isError: true,
+          content: [{ type: "text", text: "Complete consent first." }],
+        };
+      }
+      return next();
+    });
+
+    host.registerTool(
+      { name: "grant_consent", description: "Record consent." },
+      async (_params, ctx) => recordConsent(ctx.auth),
+    );
+
+    host.route("/.well-known/oauth-protected-resource", () =>
+      Response.json(protectedResourceDocument(host.resource)),
+    );
+
+    host.instructions((current) =>
+      `${current ?? ""}\n\nCall grant_consent before other tools.`.trim(),
+    );
+  },
+});
+```
+
+The host exposes the resolved canonical `resource` and `basePath`, `use` for `mcp:` middleware, `registerTool` and `registerResource` for provider-owned registrations, `route` for extra public `GET` routes, and `instructions` to rewrite the text advertised on `initialize`. Provider-owned tools and resources run under the same bearer gate as application registrations and receive the mapped `ctx.auth`. Registering a name that the application already uses throws, so reserved names never silently replace user tools.
+
 ## Verify the integration
 
 Test that:

--- a/libraries/typescript/.changeset/oauth-provider-setup-hook.md
+++ b/libraries/typescript/.changeset/oauth-provider-setup-hook.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Add an optional `setup(host)` hook to `OAuthProvider`. Providers can install MCP middleware, provider-owned tools and resources, additional public discovery routes, and `initialize` instructions while the server mounts. The `OAuthProviderHost` type is exported from `mcp-use/oauth`.

--- a/libraries/typescript/packages/server/src/oauth/index.ts
+++ b/libraries/typescript/packages/server/src/oauth/index.ts
@@ -32,5 +32,6 @@ export {
   type CustomOAuthProviderOptions,
   type OAuthExtra,
   type OAuthProvider,
+  type OAuthProviderHost,
   type OAuthResourceOptions,
 } from "./provider.js";

--- a/libraries/typescript/packages/server/src/oauth/provider.ts
+++ b/libraries/typescript/packages/server/src/oauth/provider.ts
@@ -4,6 +4,12 @@ import type {
   OAuthTokenVerifier,
 } from "@modelcontextprotocol/server";
 
+import type {
+  McpMiddlewareFnFor,
+  McpMiddlewarePattern,
+} from "../middleware/mcp-middleware.js";
+import type { ResourceCallback, ResourceDefinition } from "../resources.js";
+import type { ToolCallback, ToolDefinition } from "../tools.js";
 import { assertSecureHttpUrl, parseAbsoluteUrl } from "./internal.js";
 
 /** Additional verified identity information exposed by mcp-use callbacks. */
@@ -30,6 +36,64 @@ export interface OAuthResourceOptions {
   serviceDocumentationUrl?: URL;
 }
 
+/**
+ * Server surface handed to a provider's {@link CustomOAuthProviderOptions.setup}
+ * hook while the server mounts.
+ *
+ * The hook runs once, after the canonical resource is resolved and before the
+ * first request is served, so everything registered here participates in the
+ * same per-request registry replay as user registrations. Provider-owned
+ * tools and resources are registered under authenticated callbacks and
+ * receive the mapped `ctx.auth` like any other OAuth-protected callback.
+ */
+export interface OAuthProviderHost {
+  /** Resolved canonical MCP resource URL (RFC 8707 `resource`). */
+  readonly resource: URL;
+  /** MCP endpoint base path, for example `/mcp`. */
+  readonly basePath: string;
+  /**
+   * Registers MCP middleware using the same `mcp:` patterns accepted by
+   * `server.use()`.
+   */
+  use<P extends McpMiddlewarePattern>(
+    pattern: P,
+    handler: McpMiddlewareFnFor<P>
+  ): void;
+  /**
+   * Registers a provider-owned tool.
+   *
+   * @throws If a tool with the same name is already registered.
+   */
+  registerTool(
+    definition: ToolDefinition,
+    callback: ToolCallback<Record<string, unknown>, never, unknown, true>
+  ): void;
+  /**
+   * Registers a provider-owned static resource.
+   *
+   * @throws If a resource with the same name is already registered.
+   */
+  registerResource(
+    definition: ResourceDefinition,
+    callback: ResourceCallback<unknown, true>
+  ): void;
+  /**
+   * Serves an additional public `GET` route ahead of user-owned routes. The
+   * route is not protected by the bearer gate; use it for discovery documents
+   * such as alternate well-known paths.
+   */
+  route(
+    path: `/${string}`,
+    handler: (request: Request) => Response | Promise<Response>
+  ): void;
+  /**
+   * Rewrites the `initialize` instructions text advertised to clients. The
+   * transform receives the configured instructions (possibly `undefined`) and
+   * returns the text to advertise instead.
+   */
+  instructions(transform: (current: string | undefined) => string): void;
+}
+
 /** Options for {@link oauthCustomProvider}. */
 export interface CustomOAuthProviderOptions<
   TUser,
@@ -40,6 +104,13 @@ export interface CustomOAuthProviderOptions<
   oauthMetadata: OAuthMetadata;
   /** Maps verified SDK auth information into mcp-use callback identity data. */
   mapAuthInfo: (authInfo: OAuthAuthInfo) => OAuthExtra<TUser>;
+  /**
+   * Optional hook invoked once while the server mounts. Providers use it to
+   * install MCP middleware, provider-owned tools and resources, additional
+   * discovery routes, or instructions text that the authorization model
+   * requires. See {@link OAuthProviderHost}.
+   */
+  setup?: (host: OAuthProviderHost) => void;
 }
 
 /** OAuth resource-server provider accepted by the mcp-use server constructor. */
@@ -82,6 +153,10 @@ export function oauthCustomProvider<TUser>(
     );
   }
 
+  if (options.setup !== undefined && typeof options.setup !== "function") {
+    throw new TypeError("setup must be a function when provided");
+  }
+
   assertOAuthMetadata(options.oauthMetadata);
   if (options.resource !== undefined) {
     assertResourceUrl(options.resource);
@@ -109,6 +184,7 @@ export function oauthCustomProvider<TUser>(
     createTokenVerifier: options.createTokenVerifier,
     oauthMetadata: options.oauthMetadata,
     mapAuthInfo: options.mapAuthInfo,
+    ...(options.setup !== undefined && { setup: options.setup }),
     ...(options.resource !== undefined && { resource: options.resource }),
     ...(options.requiredScopes !== undefined && {
       requiredScopes: [...options.requiredScopes],

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -79,6 +79,7 @@ import {
   resolveLocalOAuthResource,
   wrapOAuthTokenVerifier,
 } from "./oauth/internal.js";
+import type { OAuthProviderHost } from "./oauth/provider.js";
 import type {
   InferPromptInput,
   PromptCallback,
@@ -363,6 +364,8 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
   #oauthResource: URL | undefined;
   #oauthResourceResolved = false;
   #oauthResourceConfigurationAbsent = false;
+  /** Instructions text set by an OAuth provider's setup hook. */
+  #instructionsOverride: string | undefined;
   /** Whether the mounted app validates Host headers (fixed at first mount). */
   #hostValidated = false;
   readonly #mcpMiddlewares: McpMiddlewareEntry[] = [];
@@ -1240,6 +1243,64 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     return this.#usageScope;
   }
 
+  /**
+   * Build the surface handed to an OAuth provider's `setup` hook. Runs inside
+   * `#ensureMounted` before `#handler` is assigned, so delegated
+   * registrations pass `#assertNotStarted`.
+   */
+  #createOAuthProviderHost(
+    httpApp: Hono<TEnv>,
+    resource: URL,
+    basePath: string
+  ): OAuthProviderHost {
+    return {
+      resource,
+      basePath,
+      use: (pattern, handler) => {
+        this.use(
+          pattern,
+          handler as unknown as McpMiddlewareFnFor<typeof pattern, TEnv>
+        );
+      },
+      registerTool: (definition, callback) => {
+        if (this.#tools.has(definition.name)) {
+          throw new Error(
+            `[mcp-use] Tool "${definition.name}" is reserved by the OAuth ` +
+              `provider; rename the application tool.`
+          );
+        }
+        this.tool(
+          definition,
+          callback as unknown as ToolCallback<
+            Record<string, unknown>,
+            never,
+            TUser,
+            HasOAuth<TUser>,
+            TEnv
+          >
+        );
+      },
+      registerResource: (definition, callback) => {
+        if (this.#resources.has(definition.name)) {
+          throw new Error(
+            `[mcp-use] Resource "${definition.name}" is reserved by the OAuth ` +
+              `provider; rename the application resource.`
+          );
+        }
+        this.resource(
+          definition,
+          callback as unknown as ResourceCallback<TUser, HasOAuth<TUser>, TEnv>
+        );
+      },
+      route: (path, handler) => {
+        httpApp.get(path, (context) => handler(context.req.raw));
+      },
+      instructions: (transform) => {
+        this.#instructionsOverride = transform(this.#config.instructions);
+      },
+    };
+  }
+
   #proxyHost(): ProxyMountHost {
     return {
       isStarted: () => this.#handler !== undefined,
@@ -1397,6 +1458,17 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
 
       for (const middleware of middlewares) {
         registerFetchMiddleware(httpApp, middleware);
+      }
+
+      if (resource !== undefined) {
+        // Providers extend the server before any request is served and while
+        // #handler is still unset, so their registrations pass the same
+        // pre-start checks as user registrations. Runs after the shared
+        // middleware chain is registered so provider routes still get CORS,
+        // logging, and host validation.
+        this.#config.oauth!.setup?.(
+          this.#createOAuthProviderHost(httpApp, resource, basePath)
+        );
       }
 
       const { handler, fetch: mcpFetch } = createMcpMount(
@@ -1625,7 +1697,9 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
 
   /** Build a fully registered SDK server from the immutable registry. */
   #buildSdkServer(ctx: McpRequestContext): SdkMcpServer {
-    const { name, version, title, description, instructions } = this.#config;
+    const { name, version, title, description } = this.#config;
+    const instructions =
+      this.#instructionsOverride ?? this.#config.instructions;
     const authInfo = ctx.authInfo;
     const server = new SdkMcpServer(
       {


### PR DESCRIPTION
## feat(server): OAuth provider `setup` hook

### Why

Some authorization servers need more than bearer verification on the resource server. Lane, for example, requires a consent gate: every tool refuses until the agent calls a step-up tool, which performs a server-side token exchange and records a connection. Today a provider can only supply a verifier, metadata, and an identity mapper, so that logic would have to be re-implemented by every application. This PR adds the seam a provider needs to install it once.

### What

- `CustomOAuthProviderOptions.setup?: (host: OAuthProviderHost) => void`, copied through by `oauthCustomProvider` and validated as a function.
- New exported `OAuthProviderHost` (from `mcp-use/oauth`):
  - `resource` (resolved canonical URL) and `basePath`
  - `use(pattern, handler)` for `mcp:` middleware
  - `registerTool` / `registerResource` for provider-owned registrations; throws if the application already registered the name so reserved names never silently replace user tools
  - `route(path, handler)` for extra public `GET` routes (alternate well-known paths)
  - `instructions(transform)` to rewrite the `initialize` instructions without mutating the caller's config
- `MCPServer.#ensureMounted` invokes the hook once, after the shared middleware chain is registered (so provider routes get CORS, logging, and host validation) and before `#handler` is assigned (so delegated registrations pass the pre-start checks and are replayed per request like everything else).
- `#buildSdkServer` reads an instructions override when set.
- Docs: new "Extend the server from the provider" section in the v2 custom-provider page.
- Changeset: `mcp-use` minor.

### Behavior when unused

No change. The hook is optional; the existing OAuth test files pass unchanged (`oauth-core`, `oauth-direct-providers`, `oauth-wiring-types`, `oauth-routes-resource`, `oauth-context-concurrency`, 47 tests).

### Stack

1. **this PR** — provider setup hook
2. `feat/oauth-lane-provider` — `mcp-use/oauth/lane`
3. `feat/lane-oauth-example` — `examples/auth/lane`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `setup(host)` hook to OAuth providers so consent-gated authorization models can install middleware, tools, discovery routes, and instructions during server mount instead of requiring every app to wire them up.

- Providers pass `setup(host)` to `oauthCustomProvider`; the server invokes it once after resolving the resource and before the first request.
- The host exposes the resolved `resource` and `basePath`, `use` for `mcp:` middleware, `registerTool`/`registerResource`, `route` for public GET routes, and `instructions` to rewrite `initialize` text.
- Registering a tool or resource name the application already uses throws, so provider-owned names never silently replace user registrations.
- `OAuthProviderHost` is exported from `mcp-use/oauth`.
- Adds a CI workflow mirroring the CLI package to the `mcp-use/mcp-use-cli` repo on push to `main` and `canary`.
- Fixes the TypeScript test commands in `CONTRIBUTING.md` and documents `env unset` failing when the key is missing.

<sup>Written for commit c48c1ec2836afa83b181f3c6b66c04d1818ce91d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



