### PR TITLE
feat(oauth): add Lane provider under mcp-use/oauth/lane

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -335,6 +335,7 @@
                               "v2/typescript/server/authentication/providers/better-auth",
                               "v2/typescript/server/authentication/providers/clerk",
                               "v2/typescript/server/authentication/providers/convex",
+                              "v2/typescript/server/authentication/providers/lane",
                               "v2/typescript/server/authentication/providers/keycloak",
                               "v2/typescript/server/authentication/providers/supabase",
                               "v2/typescript/server/authentication/providers/workos",

--- a/docs/v2/typescript/server/authentication/index.mdx
+++ b/docs/v2/typescript/server/authentication/index.mdx
@@ -16,6 +16,7 @@ mcp-use supports resource-server providers whose authorization server supports D
 | Better Auth                              | [Better Auth](/v2/typescript/server/authentication/providers/better-auth) |
 | Clerk                                    | [Clerk](/v2/typescript/server/authentication/providers/clerk)             |
 | Convex                                   | [Convex](/v2/typescript/server/authentication/providers/convex)           |
+| Lane                                     | [Lane](/v2/typescript/server/authentication/providers/lane)               |
 | Keycloak                                 | [Keycloak](/v2/typescript/server/authentication/providers/keycloak)       |
 | Supabase                                 | [Supabase](/v2/typescript/server/authentication/providers/supabase)       |
 | WorkOS                                   | [WorkOS](/v2/typescript/server/authentication/providers/workos)           |

--- a/docs/v2/typescript/server/authentication/providers/lane.mdx
+++ b/docs/v2/typescript/server/authentication/providers/lane.mdx
@@ -1,0 +1,137 @@
+---
+title: "Lane Provider"
+description: "Configure Lane OAuth authentication and Lane's consent gate for a TypeScript MCP server."
+icon: "id-card"
+---
+
+Use the Lane provider when your MCP server sells to agents acting for KYC-verified people through [Lane](https://www.getonlane.com). Lane is a standard OAuth 2.1 authorization server: MCP clients register with it through Dynamic Client Registration and complete the authorization flow directly. On top of that, Lane adds a consent gate on the server: application tools refuse until the calling agent runs the reserved `lane_register_session` tool, which performs a server-side token exchange and records a connection for the calling credential.
+
+The provider verifies Lane access tokens and installs the gate, the two reserved tools, the `lane://auth-guide` resource, the root-path protected-resource document, and the instructions that steer agents to the step-up.
+
+## Before you start
+
+Lane must know about your server before tokens for it can be issued.
+
+1. Ask Lane to claim the exact public host of your MCP endpoint. Tokens are audienced to that host, and a token minted for one host is refused on every other. `localhost` cannot be claimed; use a tunnel hostname or a deployed URL.
+2. Ask Lane for a confidential client (id and secret) with the token-exchange grant enabled. It is used only for the step-up exchange. Clients registered through Lane's public registration endpoint cannot perform the exchange.
+3. Have a Lane account to log in with when you test.
+
+## Set environment variables
+
+```bash
+MCP_URL=https://shop.example.com
+MCP_USE_OAUTH_LANE_CLIENT_ID=your-confidential-client-id
+MCP_USE_OAUTH_LANE_CLIENT_SECRET=your-confidential-client-secret
+# MCP_USE_OAUTH_LANE_ISSUER=https://auth.getonlane.com/auth/mcp
+```
+
+`MCP_URL` is the server origin; the canonical resource is that origin plus the MCP base path, `/mcp` by default. The issuer defaults to Lane's production authorization server.
+
+## Configure the MCP server
+
+```typescript
+import { MCPServer } from "mcp-use";
+import {
+  memoryLaneConnectionStore,
+  oauthLaneProvider,
+} from "mcp-use/oauth/lane";
+
+const server = new MCPServer({
+  name: "storefront",
+  version: "1.0.0",
+  instructions: "Browse and buy digital goods.",
+  oauth: oauthLaneProvider({
+    connections: memoryLaneConnectionStore(),
+    scopes: {
+      checkout: "email",
+    },
+    onGateEvent: (event) => console.log("[lane]", event),
+  }),
+});
+
+server.tool({ name: "browse", description: "Browse the catalog." }, browse);
+server.tool({ name: "checkout", description: "Buy an item." }, checkout);
+
+export default server;
+```
+
+Client credentials and the issuer are read from the environment when the options are omitted. Pass `clientId`, `clientSecret`, `issuer`, and `resource` explicitly to override.
+
+### Options
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `connections` | required | Where completed step-ups are recorded. |
+| `clientId`, `clientSecret` | env | Confidential client used only for the token exchange. |
+| `issuer` | Lane production | Lane authorization server. |
+| `scopes` | `{}` | Connection scopes each tool requires, by tool name. Tools not listed are callable by any connected caller. |
+| `enforcement` | `"gate-all"` | `"log-only"` never refuses and emits `would-have-blocked` events instead. |
+| `onGateEvent` | none | Observer for `allowed`, `blocked`, and `would-have-blocked` decisions. |
+| `sessionInfoTool` | `true` | Register `lane_session_info`. |
+| `authGuide` | `true` | Register the `lane://auth-guide` resource. |
+| `exchanger`, `createTokenVerifier` | Lane defaults | Injection points for tests and development seams. |
+
+## How the gate works
+
+Every request to the MCP endpoint needs a valid Lane bearer, the same as any other mcp-use OAuth provider. After that:
+
+1. A verified caller with no recorded connection gets an error result from every application tool naming `lane_register_session`. The `initialize` instructions and the auth guide say the same thing.
+2. The agent calls `lane_register_session`. The server exchanges the caller's bearer for a token scoped to this server using the confidential client, records the granted scopes under the caller's subject and token `jti`, and returns `{ ok, personalized, scopes }`. The exchanged token never reaches the model.
+3. Application tools now run. A tool listed in `scopes` additionally requires every listed scope on the connection, or it returns an `insufficient_scope` error result.
+
+Connections are keyed by the token `jti`, so a refreshed access token is a new credential and the agent must run the step-up again. `lane_session_info` reports the current state at any point and accepts an optional `probe_scope`.
+
+Authority comes from the recorded connection, never from the bearer's own `scope` claim. `ctx.auth.permissions` is therefore always empty; `ctx.auth.user` carries the pairwise `id`, the calling `agentId`, and the `credentialId`.
+
+## Connection store
+
+`memoryLaneConnectionStore()` is correct for one process. When more than one instance answers for the same resource, implement `LaneConnectionStore` over a shared store such as a KV or database:
+
+```typescript
+import type { LaneConnectionStore } from "mcp-use/oauth/lane";
+
+const connections: LaneConnectionStore = {
+  async get(key) {
+    return (await kv.get(`lane:${key.sub}:${key.jti}`)) ?? null;
+  },
+  async put(key, value) {
+    const record = { ...value, createdAt: Date.now() };
+    await kv.set(`lane:${key.sub}:${key.jti}`, record);
+    return record;
+  },
+  async delete(key) {
+    await kv.delete(`lane:${key.sub}:${key.jti}`);
+  },
+};
+```
+
+## Verify the setup
+
+Run the server on the host Lane claimed and connect with an OAuth-capable MCP client.
+
+Confirm these cases:
+
+- `GET /.well-known/oauth-protected-resource` and the path-inserted form both name Lane's issuer.
+- The client completes the authorization flow with Lane.
+- `lane_session_info` reports `connected: false` before the step-up.
+- An application tool returns the "Login incomplete" error result before the step-up.
+- `lane_register_session` returns `ok: true`, and the same tool then succeeds.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Runnable Lane example"
+    icon="github"
+    href="https://github.com/mcp-use/mcp-use/tree/main/libraries/typescript/packages/server/examples/auth/lane"
+  >
+    A port of Lane's UCP index server on mcp-use.
+  </Card>
+  <Card
+    title="User Context"
+    icon="user"
+    href="/v2/typescript/server/authentication/user-context"
+  >
+    Use Lane identity data inside tools.
+  </Card>
+</CardGroup>

--- a/docs/v2/typescript/server/authentication/providers/lane.mdx
+++ b/docs/v2/typescript/server/authentication/providers/lane.mdx
@@ -4,7 +4,7 @@ description: "Configure Lane OAuth authentication and Lane's consent gate for a 
 icon: "id-card"
 ---
 
-Use the Lane provider when your MCP server sells to agents acting for KYC-verified people through [Lane](https://www.getonlane.com). Lane is a standard OAuth 2.1 authorization server: MCP clients register with it through Dynamic Client Registration and complete the authorization flow directly. On top of that, Lane adds a consent gate on the server: application tools refuse until the calling agent runs the reserved `lane_register_session` tool, which performs a server-side token exchange and records a connection for the calling credential.
+Use the Lane provider when your MCP server sells to agents acting for KYC-verified people through [Lane](https://www.getonlane.com). Lane is a standard OAuth 2.1 authorization server: MCP clients register with it through Dynamic Client Registration and complete the authorization flow directly. On top of that, Lane adds a consent gate on the server: application tools refuse until the calling agent runs the reserved `lane_register_session` tool, which performs a server-side token exchange and records a connection for the calling user and agent client.
 
 The provider verifies Lane access tokens and installs the gate, the two reserved tools, the `lane://auth-guide` resource, the root-path protected-resource document, and the instructions that steer agents to the step-up.
 
@@ -73,13 +73,15 @@ Client credentials and the issuer are read from the environment when the options
 
 ## How the gate works
 
-Every request to the MCP endpoint needs a valid Lane bearer, the same as any other mcp-use OAuth provider. After that:
+`initialize`, `tools/list`, and the `notifications/initialized` handshake work without authentication. Every tool call, including `lane_register_session` and `lane_session_info`, requires a valid Lane bearer or receives HTTP 401. Other MCP methods also require authentication. Supplied credentials are always verified, including during discovery.
+
+After authentication:
 
 1. A verified caller with no recorded connection gets an error result from every application tool naming `lane_register_session`. The `initialize` instructions and the auth guide say the same thing.
-2. The agent calls `lane_register_session`. The server exchanges the caller's bearer for a token scoped to this server using the confidential client, records the granted scopes under the caller's subject and token `jti`, and returns `{ ok, personalized, scopes }`. The exchanged token never reaches the model.
+2. The agent calls `lane_register_session`. The server exchanges the caller's bearer for a token scoped to this server using the confidential client, records the granted scopes under the caller's subject and OAuth `client_id`, and returns `{ ok, personalized, scopes }`. The exchanged token never reaches the model.
 3. Application tools now run. A tool listed in `scopes` additionally requires every listed scope on the connection, or it returns an `insufficient_scope` error result.
 
-Connections are keyed by the token `jti`, so a refreshed access token is a new credential and the agent must run the step-up again. `lane_session_info` reports the current state at any point and accepts an optional `probe_scope`.
+Connections are keyed by `(sub, client_id)`. A refreshed bearer for the same user and client reuses the connection until it expires or is removed. The connection stores the registration token’s `jti` for auditing; it is not part of the lookup key. `lane_session_info` reports the current state at any point and accepts an optional `probe_scope`.
 
 Authority comes from the recorded connection, never from the bearer's own `scope` claim. `ctx.auth.permissions` is therefore always empty; `ctx.auth.user` carries the pairwise `id`, the calling `agentId`, and the `credentialId`.
 
@@ -92,15 +94,15 @@ import type { LaneConnectionStore } from "mcp-use/oauth/lane";
 
 const connections: LaneConnectionStore = {
   async get(key) {
-    return (await kv.get(`lane:${key.sub}:${key.jti}`)) ?? null;
+    return (await kv.get(`lane:${JSON.stringify([key.sub, key.clientId])}`)) ?? null;
   },
   async put(key, value) {
     const record = { ...value, createdAt: Date.now() };
-    await kv.set(`lane:${key.sub}:${key.jti}`, record);
+    await kv.set(`lane:${JSON.stringify([key.sub, key.clientId])}`, record);
     return record;
   },
   async delete(key) {
-    await kv.delete(`lane:${key.sub}:${key.jti}`);
+    await kv.delete(`lane:${JSON.stringify([key.sub, key.clientId])}`);
   },
 };
 ```
@@ -112,10 +114,12 @@ Run the server on the host Lane claimed and connect with an OAuth-capable MCP cl
 Confirm these cases:
 
 - `GET /.well-known/oauth-protected-resource` and the path-inserted form both name Lane's issuer.
+- Anonymous initialization and tool listing succeed; an anonymous tool call returns HTTP 401.
 - The client completes the authorization flow with Lane.
 - `lane_session_info` reports `connected: false` before the step-up.
 - An application tool returns the "Login incomplete" error result before the step-up.
 - `lane_register_session` returns `ok: true`, and the same tool then succeeds.
+- A refreshed bearer for the same user and client can use the existing connection. A different client must register its own connection.
 
 ## Next steps
 

--- a/libraries/typescript/.changeset/add-lane-oauth-provider.md
+++ b/libraries/typescript/.changeset/add-lane-oauth-provider.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": minor
+---
+
+Add `oauthLaneProvider` for authenticating MCP servers with Lane (getonlane.com). Verifies Lane access tokens and installs Lane's consent gate: application tools refuse until the agent runs `lane_register_session`, which performs the server-side token exchange and records a connection. Also registers `lane_session_info`, the `lane://auth-guide` resource, and the root-path protected-resource document. Exports from `mcp-use/oauth/lane`.

--- a/libraries/typescript/.changeset/add-lane-oauth-provider.md
+++ b/libraries/typescript/.changeset/add-lane-oauth-provider.md
@@ -3,3 +3,5 @@
 ---
 
 Add `oauthLaneProvider` for authenticating MCP servers with Lane (getonlane.com). Verifies Lane access tokens and installs Lane's consent gate: application tools refuse until the agent runs `lane_register_session`, which performs the server-side token exchange and records a connection. Also registers `lane_session_info`, the `lane://auth-guide` resource, and the root-path protected-resource document. Exports from `mcp-use/oauth/lane`.
+
+Lane allows anonymous initialization and tool listing while requiring a bearer for every tool call. Connections are keyed by subject and OAuth client ID so token refresh preserves registration; the registration token ID is retained for auditing.

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -89,6 +89,10 @@
       "types": "./dist/oauth/convex.d.ts",
       "import": "./dist/oauth/convex.js"
     },
+    "./oauth/lane": {
+      "types": "./dist/oauth/lane.d.ts",
+      "import": "./dist/oauth/lane.js"
+    },
     "./node": {
       "types": "./dist/node-bridge.d.ts",
       "import": "./dist/node-bridge.js",

--- a/libraries/typescript/packages/server/src/oauth/lane.ts
+++ b/libraries/typescript/packages/server/src/oauth/lane.ts
@@ -1,0 +1,288 @@
+/**
+ * Lane OAuth provider for mcp-use servers.
+ *
+ * Lane (getonlane.com) is a standard OAuth 2.1 authorization server with an
+ * application-level consent gate: every application tool refuses until the
+ * calling agent runs the reserved `lane_register_session` tool, which performs
+ * a server-side RFC 8693 token exchange and records a connection for the
+ * calling credential. This module verifies Lane access tokens and installs
+ * that gate, the reserved tools, the auth-guide resource, the root-path
+ * protected-resource document, and the step-up instructions.
+ *
+ * @packageDocumentation
+ */
+import type {
+  AuthInfo,
+  OAuthMetadata,
+  OAuthTokenVerifier,
+} from "@modelcontextprotocol/server";
+import { decodeProtectedHeader } from "jose";
+
+import { oauthEnvironmentValue } from "./environment.js";
+import {
+  booleanValue,
+  createJwtVerifier,
+  invalidToken,
+  normalizedProviderUrl,
+  numberValue,
+  payloadFromAuthInfo,
+  providerEndpoint,
+  requiredString,
+  stringValue,
+} from "./jwt.js";
+import { createLaneTokenExchanger } from "./lane/exchanger.js";
+import { createLaneSetup } from "./lane/setup.js";
+import {
+  LANE_DEFAULT_ISSUER,
+  type LaneOAuthProviderOptions,
+  type LaneOAuthUser,
+} from "./lane/types.js";
+import { oauthCustomProvider, type OAuthProvider } from "./provider.js";
+
+export {
+  createLaneTokenExchanger,
+  type LaneTokenExchangerConfig,
+} from "./lane/exchanger.js";
+export {
+  memoryLaneConnectionStore,
+  type MemoryLaneConnectionStore,
+} from "./lane/connections.js";
+export {
+  LANE_AUTH_GUIDE_NAME,
+  LANE_AUTH_GUIDE_URI,
+  LANE_DEFAULT_ISSUER,
+  LANE_PERSONALIZATION_SCOPE,
+  LANE_SESSION_INFO_TOOL,
+  LANE_STEP_UP_TOOL,
+  LANE_TASK_MAX_CHARS,
+  type LaneConnectionInput,
+  type LaneConnectionKey,
+  type LaneConnectionRecord,
+  type LaneConnectionStore,
+  type LaneEnforcement,
+  type LaneGateDecision,
+  type LaneGateEvent,
+  type LaneOAuthProviderOptions,
+  type LaneOAuthUser,
+  type LaneTokenExchangeRequest,
+  type LaneTokenExchangeResult,
+  type LaneTokenExchanger,
+} from "./lane/types.js";
+
+/** RFC 9068: an access token says `at+jwt`; an ID token says `JWT`. */
+const ACCESS_TOKEN_TYP = "at+jwt";
+
+const DEFAULT_SCOPES_SUPPORTED = [
+  "mcp",
+  "offline_access",
+  "openid",
+  "profile",
+  "email",
+  "phone",
+];
+
+/**
+ * Creates a Lane OAuth provider.
+ *
+ * Tokens are verified against Lane's JWKS and must be audienced to this
+ * server's canonical resource. Authority for application tools comes from the
+ * connection recorded by `lane_register_session`, never from the bearer's own
+ * `scope` claim, so `ctx.auth.permissions` is always empty.
+ *
+ * @param options - Connection store, confidential client credentials, and gate
+ * configuration.
+ * @returns A provider for an OAuth-enabled MCP server.
+ * @throws A `TypeError` when the connection store or client credentials are
+ * missing.
+ *
+ * @example
+ * ```ts
+ * import { MCPServer } from "mcp-use";
+ * import {
+ *   memoryLaneConnectionStore,
+ *   oauthLaneProvider,
+ * } from "mcp-use/oauth/lane";
+ *
+ * const server = new MCPServer({
+ *   name: "storefront",
+ *   version: "1.0.0",
+ *   oauth: oauthLaneProvider({
+ *     resource: "https://shop.example.com/mcp",
+ *     connections: memoryLaneConnectionStore(),
+ *     scopes: { checkout: "email" },
+ *   }),
+ * });
+ * ```
+ */
+export function oauthLaneProvider(
+  options: LaneOAuthProviderOptions
+): OAuthProvider<LaneOAuthUser> {
+  const {
+    connections,
+    clientId: clientIdOption,
+    clientSecret: clientSecretOption,
+    issuer: issuerOption,
+    scopes,
+    enforcement,
+    onGateEvent,
+    sessionInfoTool,
+    authGuide,
+    exchanger: exchangerOption,
+    createTokenVerifier: verifierOption,
+    ...resourceOptions
+  } = options;
+
+  if (
+    connections === null ||
+    typeof connections !== "object" ||
+    typeof connections.get !== "function" ||
+    typeof connections.put !== "function"
+  ) {
+    throw new TypeError(
+      "oauthLaneProvider requires a connections store with get() and put()"
+    );
+  }
+
+  const issuer = normalizedProviderUrl(
+    issuerOption ??
+      oauthEnvironmentValue("MCP_USE_OAUTH_LANE_ISSUER") ??
+      LANE_DEFAULT_ISSUER,
+    "Lane issuer"
+  ).href.replace(/\/$/, "");
+
+  const exchanger =
+    exchangerOption ??
+    (() => {
+      const clientId =
+        clientIdOption ?? oauthEnvironmentValue("MCP_USE_OAUTH_LANE_CLIENT_ID");
+      const clientSecret =
+        clientSecretOption ??
+        oauthEnvironmentValue("MCP_USE_OAUTH_LANE_CLIENT_SECRET");
+      if (clientId === undefined || clientSecret === undefined) {
+        throw new TypeError(
+          "Lane clientId and clientSecret are required (or set " +
+            "MCP_USE_OAUTH_LANE_CLIENT_ID and MCP_USE_OAUTH_LANE_CLIENT_SECRET); " +
+            "the token-exchange grant refuses a public client"
+        );
+      }
+      return createLaneTokenExchanger({ clientId, clientSecret, issuer });
+    })();
+
+  const scopesSupported =
+    resourceOptions.scopesSupported === undefined
+      ? DEFAULT_SCOPES_SUPPORTED
+      : [...resourceOptions.scopesSupported];
+  const oauthMetadata = metadata(issuer, scopesSupported);
+
+  return oauthCustomProvider<LaneOAuthUser>({
+    ...resourceOptions,
+    scopesSupported,
+    createTokenVerifier: (resource) =>
+      verifierOption === undefined
+        ? laneVerifier(
+            createJwtVerifier({
+              issuer,
+              jwksUrl: new URL(providerEndpoint(issuer, "jwks")),
+              resource,
+            })
+          )
+        : verifierOption(resource),
+    oauthMetadata,
+    mapAuthInfo: mapUser,
+    setup: createLaneSetup({
+      issuer,
+      connections,
+      exchanger,
+      oauthMetadata,
+      scopesSupported,
+      ...(resourceOptions.resourceName !== undefined && {
+        resourceName: resourceOptions.resourceName,
+      }),
+      ...(resourceOptions.serviceDocumentationUrl !== undefined && {
+        serviceDocumentationUrl: resourceOptions.serviceDocumentationUrl,
+      }),
+      toolScopes: scopes ?? {},
+      enforcement: enforcement ?? "gate-all",
+      ...(onGateEvent !== undefined && { onGateEvent }),
+      sessionInfoTool: sessionInfoTool ?? true,
+      authGuide: authGuide ?? true,
+    }),
+  });
+}
+
+/**
+ * Adds the checks Lane requires on top of the shared JWT verifier: the token
+ * type must be `at+jwt` so an ID token cannot be replayed as an access token,
+ * and `jti` must be present because connections are keyed by it.
+ */
+function laneVerifier(inner: OAuthTokenVerifier): OAuthTokenVerifier {
+  return {
+    async verifyAccessToken(token: string): Promise<AuthInfo> {
+      let typ: string | undefined;
+      try {
+        typ = decodeProtectedHeader(token).typ;
+      } catch (error) {
+        throw invalidToken("Malformed Lane access token", error);
+      }
+      if (typ !== ACCESS_TOKEN_TYP) {
+        throw invalidToken(
+          `Lane access token must have typ ${ACCESS_TOKEN_TYP}`
+        );
+      }
+      const authInfo = await inner.verifyAccessToken(token);
+      if (requiredString(payloadFromAuthInfo(authInfo), "jti") === undefined) {
+        throw invalidToken("Lane access token is missing jti");
+      }
+      return authInfo;
+    },
+  };
+}
+
+function metadata(issuer: string, scopesSupported: string[]): OAuthMetadata {
+  return {
+    issuer,
+    authorization_endpoint: providerEndpoint(issuer, "authorize"),
+    token_endpoint: providerEndpoint(issuer, "token"),
+    registration_endpoint: providerEndpoint(issuer, "register"),
+    revocation_endpoint: providerEndpoint(issuer, "revoke"),
+    jwks_uri: providerEndpoint(issuer, "jwks"),
+    response_types_supported: ["code"],
+    grant_types_supported: [
+      "authorization_code",
+      "refresh_token",
+      "urn:ietf:params:oauth:grant-type:token-exchange",
+    ],
+    code_challenge_methods_supported: ["S256"],
+    scopes_supported: scopesSupported,
+  };
+}
+
+function mapUser(authInfo: AuthInfo) {
+  const payload = payloadFromAuthInfo(authInfo);
+  const id = requiredString(payload, "sub");
+  if (id === undefined) throw invalidToken("Missing Lane subject");
+  const agentId = requiredString(payload, "client_id");
+  if (agentId === undefined) throw invalidToken("Missing Lane client_id");
+  const credentialId = requiredString(payload, "jti");
+  if (credentialId === undefined) throw invalidToken("Missing Lane jti");
+
+  const host = stringValue(payload, "host");
+  const tier = stringValue(payload, "tier");
+  const clientVerified = booleanValue(payload, "client_verified");
+  const authTime = numberValue(payload, "auth_time");
+
+  return {
+    user: {
+      id,
+      agentId,
+      credentialId,
+      ...(host !== undefined && { host }),
+      ...(tier !== undefined && { tier }),
+      ...(clientVerified !== undefined && { clientVerified }),
+      ...(authTime !== undefined && { authTime }),
+    },
+    payload,
+    // Authority lives in the recorded connection, never in the bearer.
+    permissions: [],
+  };
+}

--- a/libraries/typescript/packages/server/src/oauth/lane.ts
+++ b/libraries/typescript/packages/server/src/oauth/lane.ts
@@ -5,7 +5,7 @@
  * application-level consent gate: every application tool refuses until the
  * calling agent runs the reserved `lane_register_session` tool, which performs
  * a server-side RFC 8693 token exchange and records a connection for the
- * calling credential. This module verifies Lane access tokens and installs
+ * calling user and agent client. This module verifies Lane access tokens and installs
  * that gate, the reserved tools, the auth-guide resource, the root-path
  * protected-resource document, and the step-up instructions.
  *
@@ -84,6 +84,8 @@ const DEFAULT_SCOPES_SUPPORTED = [
 /**
  * Creates a Lane OAuth provider.
  *
+ * Initialization and tool listing are public. Every tool call requires a valid
+ * bearer, including the provider-owned registration and session-info tools.
  * Tokens are verified against Lane's JWKS and must be audienced to this
  * server's canonical resource. Authority for application tools comes from the
  * connection recorded by `lane_register_session`, never from the bearer's own
@@ -177,6 +179,7 @@ export function oauthLaneProvider(
   return oauthCustomProvider<LaneOAuthUser>({
     ...resourceOptions,
     scopesSupported,
+    allowAnonymousDiscovery: true,
     createTokenVerifier: (resource) =>
       verifierOption === undefined
         ? laneVerifier(
@@ -213,7 +216,7 @@ export function oauthLaneProvider(
 /**
  * Adds the checks Lane requires on top of the shared JWT verifier: the token
  * type must be `at+jwt` so an ID token cannot be replayed as an access token,
- * and `jti` must be present because connections are keyed by it.
+ * and `jti` must be present to identify the credential used for registration.
  */
 function laneVerifier(inner: OAuthTokenVerifier): OAuthTokenVerifier {
   return {

--- a/libraries/typescript/packages/server/src/oauth/lane/connections.ts
+++ b/libraries/typescript/packages/server/src/oauth/lane/connections.ts
@@ -1,0 +1,61 @@
+import type {
+  LaneConnectionInput,
+  LaneConnectionKey,
+  LaneConnectionRecord,
+  LaneConnectionStore,
+} from "./types.js";
+
+/** In-memory store with a `size()` inspector for diagnostics. */
+export type MemoryLaneConnectionStore = LaneConnectionStore & {
+  /** Number of recorded connections. */
+  size(): number;
+};
+
+function keyOf(key: LaneConnectionKey): string {
+  return `${key.sub} ${key.jti}`;
+}
+
+/**
+ * Process-local connection store. Correct for a single server instance and
+ * for development; two replicas with separate memory stores disagree about
+ * whether a credential is connected. The exchanged access token is not
+ * retained because nothing reads it back.
+ */
+export function memoryLaneConnectionStore(): MemoryLaneConnectionStore {
+  const rows = new Map<string, LaneConnectionRecord>();
+  return {
+    async get(key) {
+      return rows.get(keyOf(key)) ?? null;
+    },
+    async put(key, value: LaneConnectionInput) {
+      const { accessToken: _dropped, ...rest } = value;
+      const record: LaneConnectionRecord = { ...rest, createdAt: Date.now() };
+      rows.set(keyOf(key), record);
+      return record;
+    },
+    async delete(key) {
+      rows.delete(keyOf(key));
+    },
+    size() {
+      return rows.size;
+    },
+  };
+}
+
+/**
+ * Reads a connection and treats an expired one as absent.
+ *
+ * @internal
+ */
+export async function liveLaneConnection(
+  store: LaneConnectionStore,
+  key: LaneConnectionKey,
+  nowMs: number = Date.now()
+): Promise<LaneConnectionRecord | null> {
+  const record = await store.get(key);
+  if (record === null) return null;
+  if (record.expiresAt !== undefined && record.expiresAt * 1000 <= nowMs) {
+    return null;
+  }
+  return record;
+}

--- a/libraries/typescript/packages/server/src/oauth/lane/connections.ts
+++ b/libraries/typescript/packages/server/src/oauth/lane/connections.ts
@@ -12,13 +12,13 @@ export type MemoryLaneConnectionStore = LaneConnectionStore & {
 };
 
 function keyOf(key: LaneConnectionKey): string {
-  return `${key.sub} ${key.jti}`;
+  return JSON.stringify([key.sub, key.clientId]);
 }
 
 /**
  * Process-local connection store. Correct for a single server instance and
  * for development; two replicas with separate memory stores disagree about
- * whether a credential is connected. The exchanged access token is not
+ * whether a user and client are connected. The exchanged access token is not
  * retained because nothing reads it back.
  */
 export function memoryLaneConnectionStore(): MemoryLaneConnectionStore {

--- a/libraries/typescript/packages/server/src/oauth/lane/exchanger.ts
+++ b/libraries/typescript/packages/server/src/oauth/lane/exchanger.ts
@@ -1,0 +1,119 @@
+import { normalizedStrings, providerEndpoint } from "../jwt.js";
+import {
+  LANE_DEFAULT_ISSUER,
+  type LaneTokenExchangeRequest,
+  type LaneTokenExchangeResult,
+  type LaneTokenExchanger,
+} from "./types.js";
+
+/** Options for {@link createLaneTokenExchanger}. */
+export interface LaneTokenExchangerConfig {
+  /** Confidential client id issued by Lane. */
+  clientId: string;
+  /** Confidential client secret issued by Lane. */
+  clientSecret: string;
+  /**
+   * Issuer whose `/token` endpoint receives the exchange.
+   *
+   * @defaultValue {@link LANE_DEFAULT_ISSUER}
+   */
+  issuer?: string;
+  /** Explicit token endpoint; overrides the issuer-derived one. */
+  tokenEndpoint?: string;
+  /**
+   * Request timeout in milliseconds.
+   *
+   * @defaultValue `10000`
+   */
+  timeoutMs?: number;
+  /** Fetch implementation, for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+const TOKEN_EXCHANGE_GRANT = "urn:ietf:params:oauth:grant-type:token-exchange";
+const ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+
+/**
+ * Creates the RFC 8693 exchanger the step-up tool uses. Authenticates with
+ * `client_secret_basic`; Lane refuses the exchange grant for public clients.
+ * No `scope` parameter is sent: Lane decides what the exchanged token carries.
+ *
+ * @throws A `TypeError` when either credential is missing.
+ */
+export function createLaneTokenExchanger(
+  config: LaneTokenExchangerConfig
+): LaneTokenExchanger {
+  if (!config.clientId || !config.clientSecret) {
+    throw new TypeError(
+      "createLaneTokenExchanger requires clientId and clientSecret; the " +
+        "exchange grant refuses a public client"
+    );
+  }
+  const issuer = (config.issuer ?? LANE_DEFAULT_ISSUER).replace(/\/+$/, "");
+  const endpoint = config.tokenEndpoint ?? providerEndpoint(issuer, "token");
+  const timeoutMs = config.timeoutMs ?? 10_000;
+  const fetchImpl = config.fetchImpl ?? fetch;
+  const credentials = btoa(
+    `${encodeURIComponent(config.clientId)}:${encodeURIComponent(config.clientSecret)}`
+  );
+
+  return {
+    async exchange(
+      request: LaneTokenExchangeRequest
+    ): Promise<LaneTokenExchangeResult> {
+      const body = new URLSearchParams({
+        grant_type: TOKEN_EXCHANGE_GRANT,
+        subject_token: request.subjectToken,
+        subject_token_type: ACCESS_TOKEN_TYPE,
+        resource: request.resource,
+      });
+
+      let response: Response;
+      try {
+        response = await fetchImpl(endpoint, {
+          method: "POST",
+          headers: {
+            authorization: `Basic ${credentials}`,
+            "content-type": "application/x-www-form-urlencoded",
+            accept: "application/json",
+          },
+          body,
+          signal: AbortSignal.timeout(timeoutMs),
+        });
+      } catch (error) {
+        const name = error instanceof Error ? error.name : "Error";
+        throw new Error(`token exchange could not reach ${endpoint}: ${name}`);
+      }
+
+      const payload = (await response.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+      >;
+      if (!response.ok) {
+        const code =
+          typeof payload["error"] === "string"
+            ? payload["error"]
+            : "unknown_error";
+        const description =
+          typeof payload["error_description"] === "string"
+            ? `: ${payload["error_description"]}`
+            : "";
+        throw new Error(
+          `token exchange refused: ${response.status} ${code}${description}`
+        );
+      }
+
+      const accessToken = payload["access_token"];
+      if (typeof accessToken !== "string" || accessToken.length === 0) {
+        throw new Error("token exchange returned no access_token");
+      }
+      const expiresIn = payload["expires_in"];
+      return {
+        accessToken,
+        scopes: normalizedStrings(payload["scope"]),
+        ...(typeof expiresIn === "number" &&
+          Number.isFinite(expiresIn) && { expiresIn }),
+      };
+    },
+  };
+}

--- a/libraries/typescript/packages/server/src/oauth/lane/setup.ts
+++ b/libraries/typescript/packages/server/src/oauth/lane/setup.ts
@@ -1,0 +1,391 @@
+import {
+  buildOAuthProtectedResourceMetadata,
+  type AuthInfo,
+  type CallToolResult,
+  type JsonSchemaType,
+  type OAuthMetadata,
+  type StandardSchemaWithJSON,
+} from "@modelcontextprotocol/server";
+
+import { normalizedStrings, numberValue, requiredString } from "../jwt.js";
+import type { OAuthProviderHost } from "../provider.js";
+import { liveLaneConnection } from "./connections.js";
+import {
+  decorateLaneInstructions,
+  laneAuthGuideText,
+  laneInsufficientScopeMessage,
+  laneSessionInfoDescription,
+  laneStepUpRequiredMessage,
+  laneStepUpToolDescription,
+  sanitizeLaneTask,
+} from "./text.js";
+import {
+  LANE_AUTH_GUIDE_NAME,
+  LANE_AUTH_GUIDE_URI,
+  LANE_PERSONALIZATION_SCOPE,
+  LANE_SESSION_INFO_TOOL,
+  LANE_STEP_UP_TOOL,
+  LANE_TASK_MAX_CHARS,
+  type LaneConnectionRecord,
+  type LaneConnectionStore,
+  type LaneEnforcement,
+  type LaneGateEvent,
+  type LaneTokenExchanger,
+} from "./types.js";
+
+/**
+ * Resolved configuration handed to the setup hook.
+ *
+ * @internal
+ */
+export interface LaneSetupConfig {
+  issuer: string;
+  connections: LaneConnectionStore;
+  exchanger: LaneTokenExchanger;
+  oauthMetadata: OAuthMetadata;
+  scopesSupported: string[];
+  resourceName?: string;
+  serviceDocumentationUrl?: URL;
+  toolScopes: Record<string, string | readonly string[]>;
+  enforcement: LaneEnforcement;
+  onGateEvent?: (event: LaneGateEvent) => void;
+  sessionInfoTool: boolean;
+  authGuide: boolean;
+}
+
+const RESERVED_TOOLS: ReadonlySet<string> = new Set([
+  LANE_STEP_UP_TOOL,
+  LANE_SESSION_INFO_TOOL,
+]);
+
+/** Verified caller facts the gate and reserved tools work from. */
+interface LaneClaims {
+  sub: string;
+  jti: string;
+  agentId: string;
+  issuer: string;
+  authTime: number | undefined;
+}
+
+/**
+ * Builds the provider `setup` hook that installs Lane's gate and surface.
+ *
+ * @internal
+ */
+export function createLaneSetup(
+  config: LaneSetupConfig
+): (host: OAuthProviderHost) => void {
+  return (host) => {
+    const resource = host.resource.href;
+    const rootMetadataPath = "/.well-known/oauth-protected-resource";
+    const metadataUrl = `${host.resource.origin}${rootMetadataPath}`;
+
+    host.use("mcp:tools/call", async (ctx, next) => {
+      const tool = ctx.params.name;
+      if (RESERVED_TOOLS.has(tool)) return next();
+
+      const claims = claimsFromAuthInfo(ctx.auth);
+      if (claims === undefined) {
+        return errorResult("unauthorized: no verified caller on this request");
+      }
+
+      const connection = await liveLaneConnection(config.connections, {
+        sub: claims.sub,
+        jti: claims.jti,
+      });
+      const scopes = connection?.scopes ?? [];
+
+      if (connection === null) {
+        if (config.enforcement === "gate-all") {
+          emit(config, { decision: "blocked", tool, claims, scopes });
+          return errorResult(laneStepUpRequiredMessage());
+        }
+        emit(config, { decision: "would-have-blocked", tool, claims, scopes });
+        return next();
+      }
+
+      for (const scope of normalizedStrings(config.toolScopes[tool])) {
+        if (!connection.scopes.includes(scope)) {
+          emit(config, { decision: "blocked", tool, claims, scopes });
+          return errorResult(laneInsufficientScopeMessage(scope));
+        }
+      }
+
+      emit(config, { decision: "allowed", tool, claims, scopes });
+      return next();
+    });
+
+    host.registerTool(
+      {
+        name: LANE_STEP_UP_TOOL,
+        description: laneStepUpToolDescription(),
+        inputSchema: jsonSchema({
+          type: "object",
+          properties: {
+            task: {
+              type: "string",
+              description:
+                "One line on what you are trying to accomplish, in the user's terms. Optional.",
+              maxLength: LANE_TASK_MAX_CHARS,
+            },
+          },
+          required: [],
+          additionalProperties: false,
+        }),
+      },
+      async (params, ctx) => {
+        const claims = claimsFromPayload(ctx.auth.payload);
+        if (claims === undefined) {
+          return errorResult(
+            "unauthorized: no verified caller on this request"
+          );
+        }
+
+        let granted;
+        try {
+          granted = await config.exchanger.exchange({
+            subjectToken: ctx.auth.accessToken,
+            resource,
+          });
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : "token exchange failed";
+          return errorResult(`step-up failed: ${message}`);
+        }
+
+        // Consent is mechanical and reads from what was just granted: without
+        // the personalization scope the connection is still recorded, but the
+        // model-authored task text is not.
+        const personalized = granted.scopes.includes(
+          LANE_PERSONALIZATION_SCOPE
+        );
+        const rawTask = params["task"];
+        const task =
+          personalized && typeof rawTask === "string"
+            ? sanitizeLaneTask(rawTask, LANE_TASK_MAX_CHARS)
+            : undefined;
+
+        await config.connections.put(
+          { sub: claims.sub, jti: claims.jti },
+          {
+            scopes: granted.scopes,
+            accessToken: granted.accessToken,
+            ...(granted.expiresIn !== undefined && {
+              expiresAt: Math.floor(Date.now() / 1000) + granted.expiresIn,
+            }),
+            ...(task !== undefined && task.length > 0 && { task }),
+          }
+        );
+
+        return textResult({ ok: true, personalized, scopes: granted.scopes });
+      }
+    );
+
+    if (config.sessionInfoTool) {
+      host.registerTool(
+        {
+          name: LANE_SESSION_INFO_TOOL,
+          description: laneSessionInfoDescription(),
+          inputSchema: jsonSchema({
+            type: "object",
+            properties: {
+              probe_scope: {
+                type: "string",
+                description:
+                  "Optional. Report whether this connection carries a named scope.",
+                maxLength: 64,
+              },
+            },
+            required: [],
+            additionalProperties: false,
+          }),
+        },
+        async (params, ctx) => {
+          const claims = claimsFromPayload(ctx.auth.payload);
+          if (claims === undefined) {
+            return errorResult(
+              "unauthorized: no verified caller on this request"
+            );
+          }
+          const connection = await liveLaneConnection(config.connections, {
+            sub: claims.sub,
+            jti: claims.jti,
+          });
+          const probe = params["probe_scope"];
+          return textResult(
+            sessionReport(
+              claims,
+              connection,
+              typeof probe === "string" && probe.length > 0 ? probe : undefined
+            )
+          );
+        }
+      );
+    }
+
+    if (config.authGuide) {
+      const text = laneAuthGuideText({
+        sessionInfo: config.sessionInfoTool,
+        metadataUrl,
+      });
+      host.registerResource(
+        {
+          name: LANE_AUTH_GUIDE_NAME,
+          uri: LANE_AUTH_GUIDE_URI,
+          title: "How to register a session",
+          description:
+            "What to call before using this server's tools, and what carries across Lane servers.",
+          mimeType: "text/markdown",
+        },
+        async (uri) => ({
+          contents: [{ uri: uri.href, mimeType: "text/markdown", text }],
+        })
+      );
+    }
+
+    // Lane's prober reads the root-form document; the SDK only serves the
+    // path-inserted form when the resource has a path.
+    if (host.resource.pathname !== "/" && host.resource.pathname !== "") {
+      const document = buildOAuthProtectedResourceMetadata({
+        oauthMetadata: config.oauthMetadata,
+        resourceServerUrl: host.resource,
+        scopesSupported: config.scopesSupported,
+        ...(config.resourceName !== undefined && {
+          resourceName: config.resourceName,
+        }),
+        ...(config.serviceDocumentationUrl !== undefined && {
+          serviceDocumentationUrl: config.serviceDocumentationUrl,
+        }),
+      });
+      const body = JSON.stringify(document);
+      host.route(
+        rootMetadataPath,
+        () =>
+          new Response(body, {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+              "access-control-allow-origin": "*",
+              "cache-control": "no-store",
+            },
+          })
+      );
+    }
+
+    host.instructions(decorateLaneInstructions);
+  };
+}
+
+function claimsFromAuthInfo(authInfo: AuthInfo | undefined) {
+  const payload = authInfo?.extra?.["payload"];
+  if (payload === null || typeof payload !== "object") return undefined;
+  return claimsFromPayload(payload as Record<string, unknown>);
+}
+
+function claimsFromPayload(
+  payload: Record<string, unknown>
+): LaneClaims | undefined {
+  const sub = requiredString(payload, "sub");
+  const jti = requiredString(payload, "jti");
+  if (sub === undefined || jti === undefined) return undefined;
+  return {
+    sub,
+    jti,
+    agentId: requiredString(payload, "client_id") ?? "",
+    issuer: requiredString(payload, "iss") ?? "",
+    authTime: numberValue(payload, "auth_time"),
+  };
+}
+
+function emit(
+  config: LaneSetupConfig,
+  input: {
+    decision: LaneGateEvent["decision"];
+    tool: string;
+    claims: LaneClaims;
+    scopes: string[];
+  }
+): void {
+  if (config.onGateEvent === undefined) return;
+  try {
+    config.onGateEvent({
+      decision: input.decision,
+      tool: input.tool,
+      agentId: input.claims.agentId,
+      sub: input.claims.sub,
+      scopes: [...input.scopes],
+    });
+  } catch {
+    // Observability must never break a tool call.
+  }
+}
+
+function sessionReport(
+  claims: LaneClaims,
+  connection: LaneConnectionRecord | null,
+  probeScope: string | undefined
+) {
+  const report: Record<string, unknown> = {
+    connected: connection !== null,
+    next_step:
+      connection === null
+        ? `No session yet. Call \`${LANE_STEP_UP_TOOL}\` first; every other tool on ` +
+          "this server is refused until you do."
+        : "Session established. Every tool on this server is callable.",
+    identity: {
+      customer_id: claims.sub,
+      agent_id: claims.agentId,
+      credential_id: claims.jti,
+      issuer: claims.issuer,
+      human_authenticated_at: isoFromSeconds(claims.authTime),
+    },
+    session:
+      connection === null
+        ? null
+        : {
+            scopes: connection.scopes,
+            task: connection.task ?? null,
+            task_recorded: connection.task !== undefined,
+            connected_at: new Date(connection.createdAt).toISOString(),
+            expires_at: isoFromSeconds(connection.expiresAt),
+          },
+  };
+  if (probeScope !== undefined) {
+    report["scope_probe"] = {
+      scope: probeScope,
+      granted: connection?.scopes.includes(probeScope) ?? false,
+    };
+  }
+  return report;
+}
+
+function isoFromSeconds(seconds: number | undefined): string | null {
+  return seconds === undefined ? null : new Date(seconds * 1000).toISOString();
+}
+
+function errorResult(text: string): CallToolResult {
+  return { isError: true, content: [{ type: "text", text }] };
+}
+
+function textResult(value: unknown): CallToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(value, null, 2) }] };
+}
+
+/** Wraps raw JSON Schema as a Standard Schema; the SDK validates input. */
+function jsonSchema(
+  schema: Record<string, unknown>
+): StandardSchemaWithJSON<Record<string, unknown>, Record<string, unknown>> {
+  return {
+    "~standard": {
+      version: 1,
+      vendor: "mcp-use-lane",
+      validate(value) {
+        return { value: value as Record<string, unknown> };
+      },
+      jsonSchema: {
+        input: () => schema as JsonSchemaType,
+        output: () => schema as JsonSchemaType,
+      },
+    },
+  };
+}

--- a/libraries/typescript/packages/server/src/oauth/lane/setup.ts
+++ b/libraries/typescript/packages/server/src/oauth/lane/setup.ts
@@ -91,7 +91,7 @@ export function createLaneSetup(
 
       const connection = await liveLaneConnection(config.connections, {
         sub: claims.sub,
-        jti: claims.jti,
+        clientId: claims.agentId,
       });
       const scopes = connection?.scopes ?? [];
 
@@ -166,8 +166,9 @@ export function createLaneSetup(
             : undefined;
 
         await config.connections.put(
-          { sub: claims.sub, jti: claims.jti },
+          { sub: claims.sub, clientId: claims.agentId },
           {
+            jti: claims.jti,
             scopes: granted.scopes,
             accessToken: granted.accessToken,
             ...(granted.expiresIn !== undefined && {
@@ -209,7 +210,7 @@ export function createLaneSetup(
           }
           const connection = await liveLaneConnection(config.connections, {
             sub: claims.sub,
-            jti: claims.jti,
+            clientId: claims.agentId,
           });
           const probe = params["probe_scope"];
           return textResult(
@@ -287,11 +288,14 @@ function claimsFromPayload(
 ): LaneClaims | undefined {
   const sub = requiredString(payload, "sub");
   const jti = requiredString(payload, "jti");
-  if (sub === undefined || jti === undefined) return undefined;
+  const agentId = requiredString(payload, "client_id");
+  if (sub === undefined || jti === undefined || agentId === undefined) {
+    return undefined;
+  }
   return {
     sub,
     jti,
-    agentId: requiredString(payload, "client_id") ?? "",
+    agentId,
     issuer: requiredString(payload, "iss") ?? "",
     authTime: numberValue(payload, "auth_time"),
   };

--- a/libraries/typescript/packages/server/src/oauth/lane/text.ts
+++ b/libraries/typescript/packages/server/src/oauth/lane/text.ts
@@ -1,0 +1,148 @@
+import { LANE_SESSION_INFO_TOOL, LANE_STEP_UP_TOOL } from "./types.js";
+
+/**
+ * Paragraphs appended to the server's `initialize` instructions. This text is
+ * Lane's steering mechanism: it is what makes an agent call the step-up tool.
+ *
+ * @internal
+ */
+export function laneStepUpInstruction(): string {
+  return (
+    `Authentication is not complete until you call \`${LANE_STEP_UP_TOOL}\` on this server. ` +
+    "Other tools are unavailable until you do. Call it once, with a one-line summary " +
+    "of what you are trying to accomplish, and then retry what you were doing.\n\n" +
+    "Working across more than one Lane server in the same task: reuse the SAME agent " +
+    `session and call \`${LANE_STEP_UP_TOOL}\` once on each server — once per server, not ` +
+    "once per tool call. Do not carry an access token from another server to this one: " +
+    "a Lane access token names exactly one audience, so a token minted for a different " +
+    "server is refused here. What carries across servers is the session, not the token."
+  );
+}
+
+/**
+ * Appends the step-up instruction to operator instructions. Idempotent.
+ *
+ * @internal
+ */
+export function decorateLaneInstructions(current: string | undefined): string {
+  const sentence = laneStepUpInstruction();
+  if (current === undefined || current.trim().length === 0) return sentence;
+  return current.includes(LANE_STEP_UP_TOOL)
+    ? current
+    : `${current.trim()}\n\n${sentence}`;
+}
+
+/**
+ * Error result text a gated tool answers with before the step-up.
+ *
+ * @internal
+ */
+export function laneStepUpRequiredMessage(): string {
+  return (
+    `Login incomplete — call \`${LANE_STEP_UP_TOOL}\` with a brief summary of your task, ` +
+    "then retry this call."
+  );
+}
+
+/**
+ * Error result text when the connection lacks a required scope.
+ *
+ * @internal
+ */
+export function laneInsufficientScopeMessage(scope: string): string {
+  return `insufficient_scope: this connection lacks \`${scope}\``;
+}
+
+/**
+ * `tools/list` description of the step-up tool.
+ *
+ * @internal
+ */
+export function laneStepUpToolDescription(): string {
+  return (
+    "Complete authentication for this server. Call this once before using other " +
+    "tools. Optionally include a one-line summary of your task so results can be " +
+    "tailored to it; the call works with no arguments at all."
+  );
+}
+
+/**
+ * `tools/list` description of the session-info tool.
+ *
+ * @internal
+ */
+export function laneSessionInfoDescription(): string {
+  return (
+    "What Lane knows about this session: who is calling, whether they have " +
+    "completed the step-up, and what that connection is allowed to do. Works " +
+    "before the step-up — call it to confirm an auth integration worked."
+  );
+}
+
+/**
+ * Markdown body of the auth-guide resource, generated from live configuration
+ * so it cannot drift from what the server serves.
+ *
+ * @internal
+ */
+export function laneAuthGuideText(options: {
+  sessionInfo: boolean;
+  metadataUrl: string;
+}): string {
+  const sections = [
+    "# Registering a session with this server",
+    "",
+    `Call \`${LANE_STEP_UP_TOOL}\` once on this server before calling anything`,
+    "else. Other tools refuse until you do, and the refusal names this tool.",
+    "",
+    "It takes one optional argument, `task`: a single line, in the user’s own",
+    "terms, describing what you are trying to accomplish. It is used to tailor",
+    "results. The call works with no arguments at all.",
+    "",
+    "## Working across more than one Lane server",
+    "",
+    `Reuse the SAME agent session, and call \`${LANE_STEP_UP_TOOL}\` once on each`,
+    "server — once per server, not once per tool call.",
+    "",
+    "Do NOT carry an access token from another server to this one. A Lane access",
+    "token names exactly one audience, so a token minted for a different server is",
+    "refused here. What carries across servers is the session, not the token.",
+  ];
+  if (options.sessionInfo) {
+    sections.push(
+      "",
+      "## Checking it worked",
+      "",
+      `\`${LANE_SESSION_INFO_TOOL}\` reports what Lane knows about this connection: whether a`,
+      "grant exists, its scopes, and when it expires. `connected: false` with an",
+      "identity still reported means the bearer verified but no session is recorded",
+      `— call \`${LANE_STEP_UP_TOOL}\`.`
+    );
+  }
+  sections.push(
+    "",
+    "## Where to authenticate",
+    "",
+    "This server publishes its authorization server at",
+    `\`${options.metadataUrl}\` (RFC 9728).`,
+    "Every unauthenticated request to the MCP endpoint is answered with `401` and a",
+    "`WWW-Authenticate` header naming that document."
+  );
+  return sections.join("\n");
+}
+
+/**
+ * Caps and de-fangs model-authored text before it is stored.
+ *
+ * @internal
+ */
+export function sanitizeLaneTask(value: string, maxChars: number): string {
+  return (
+    value
+      // Stripping control characters is the point of this line.
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x1f\x7f]/g, " ")
+      .trim()
+      .slice(0, maxChars)
+  );
+}

--- a/libraries/typescript/packages/server/src/oauth/lane/types.ts
+++ b/libraries/typescript/packages/server/src/oauth/lane/types.ts
@@ -1,0 +1,197 @@
+import type { OAuthTokenVerifier } from "@modelcontextprotocol/server";
+
+import type { OAuthResourceOptions } from "../provider.js";
+
+/** Reserved tool that completes Lane's step-up for the calling credential. */
+export const LANE_STEP_UP_TOOL = "lane_register_session";
+
+/** Reserved diagnostic tool reporting what Lane knows about the caller. */
+export const LANE_SESSION_INFO_TOOL = "lane_session_info";
+
+/** Registered name of the public auth-guide resource. */
+export const LANE_AUTH_GUIDE_NAME = "lane-auth-guide";
+
+/** URI of the public auth-guide resource. */
+export const LANE_AUTH_GUIDE_URI = "lane://auth-guide";
+
+/** Lane's production authorization server issuer. */
+export const LANE_DEFAULT_ISSUER = "https://auth.getonlane.com/auth/mcp";
+
+/** Scope that permits recording the agent's model-authored task summary. */
+export const LANE_PERSONALIZATION_SCOPE = "personalization:connection";
+
+/** Maximum stored length of the step-up `task` summary. */
+export const LANE_TASK_MAX_CHARS = 600;
+
+/** Normalized identity mapped from a verified Lane access token. */
+export interface LaneOAuthUser {
+  /** Pairwise subject: stable at this server, different at every other one. */
+  id: string;
+  /** OAuth `client_id` of the calling agent application. */
+  agentId: string;
+  /** Token `jti`; identifies the credential a connection is recorded for. */
+  credentialId: string;
+  /** Claimed merchant host the token was minted for, when present. */
+  host?: string;
+  /** Lane account tier, when present. */
+  tier?: string;
+  /** Whether Lane verified the calling client, when present. */
+  clientVerified?: boolean;
+  /** When the human last authenticated, in Unix seconds, when present. */
+  authTime?: number;
+}
+
+/** Identifies one connection: a subject on one credential. */
+export interface LaneConnectionKey {
+  /** Pairwise subject from the verified token. */
+  sub: string;
+  /** Token `jti`. A refreshed token is a new credential. */
+  jti: string;
+}
+
+/** Data recorded when a step-up completes. */
+export interface LaneConnectionInput {
+  /** Scopes granted by the token exchange. This is the caller's authority. */
+  scopes: string[];
+  /** Exchanged access token. Stores may discard it; nothing reads it back. */
+  accessToken?: string;
+  /** Expiry of the exchanged token, in Unix seconds. */
+  expiresAt?: number;
+  /** Sanitized task summary, recorded only when consent permits it. */
+  task?: string;
+}
+
+/** A stored connection. */
+export interface LaneConnectionRecord extends LaneConnectionInput {
+  /** When the connection was recorded, in Unix milliseconds. */
+  createdAt: number;
+}
+
+/**
+ * Persistence for Lane connections. Provide a shared store (KV, database)
+ * when more than one server instance answers for the same resource;
+ * {@link memoryLaneConnectionStore} is only correct for a single process.
+ */
+export interface LaneConnectionStore {
+  /** Returns the stored connection, or `null` when none is recorded. */
+  get(key: LaneConnectionKey): Promise<LaneConnectionRecord | null>;
+  /** Records a connection, replacing any previous record for the key. */
+  put(
+    key: LaneConnectionKey,
+    value: LaneConnectionInput
+  ): Promise<LaneConnectionRecord>;
+  /** Removes a connection. Optional; used for operator-driven revocation. */
+  delete?(key: LaneConnectionKey): Promise<void>;
+}
+
+/** Input to an RFC 8693 token exchange. */
+export interface LaneTokenExchangeRequest {
+  /** The caller's verified bearer token. */
+  subjectToken: string;
+  /** This server's canonical resource, sent as the RFC 8707 `resource`. */
+  resource: string;
+}
+
+/** Result of a successful token exchange. */
+export interface LaneTokenExchangeResult {
+  /** Access token minted for this server. Never returned to callers. */
+  accessToken: string;
+  /** Scopes granted by Lane at exchange time. */
+  scopes: string[];
+  /** Lifetime in seconds, when Lane reports one. */
+  expiresIn?: number;
+}
+
+/** Performs the server-side token exchange behind the step-up tool. */
+export interface LaneTokenExchanger {
+  /**
+   * Exchanges the caller's bearer for a token scoped to this server.
+   *
+   * @throws When Lane refuses the exchange or cannot be reached.
+   */
+  exchange(request: LaneTokenExchangeRequest): Promise<LaneTokenExchangeResult>;
+}
+
+/**
+ * What the gate does when a verified caller has no recorded connection.
+ *
+ * - `"gate-all"`: refuse every application tool with an error result until the
+ *   caller completes the step-up. Lane's production behavior.
+ * - `"log-only"`: never refuse; emit `would-have-blocked` gate events instead.
+ *   For rolling the gate out against live traffic before enforcing it.
+ */
+export type LaneEnforcement = "gate-all" | "log-only";
+
+/** Outcome of one gate decision. */
+export type LaneGateDecision = "allowed" | "blocked" | "would-have-blocked";
+
+/** Emitted once per application tool call after the gate decides. */
+export interface LaneGateEvent {
+  /** What the gate did. */
+  decision: LaneGateDecision;
+  /** Tool the caller invoked. */
+  tool: string;
+  /** OAuth `client_id` of the calling agent. */
+  agentId: string;
+  /** Pairwise subject of the calling user. */
+  sub: string;
+  /** Connection scopes at decision time; empty when no connection exists. */
+  scopes: string[];
+}
+
+/** Options for {@link oauthLaneProvider}. */
+export interface LaneOAuthProviderOptions extends OAuthResourceOptions {
+  /** Where completed step-ups are recorded. Required. */
+  connections: LaneConnectionStore;
+  /**
+   * Confidential Lane client id used only for the token exchange.
+   *
+   * @defaultValue `MCP_USE_OAUTH_LANE_CLIENT_ID`
+   */
+  clientId?: string;
+  /**
+   * Confidential Lane client secret used only for the token exchange.
+   *
+   * @defaultValue `MCP_USE_OAUTH_LANE_CLIENT_SECRET`
+   */
+  clientSecret?: string;
+  /**
+   * Lane authorization server issuer.
+   *
+   * @defaultValue `MCP_USE_OAUTH_LANE_ISSUER`, then {@link LANE_DEFAULT_ISSUER}
+   */
+  issuer?: URL | string;
+  /**
+   * Connection scopes each application tool requires, keyed by tool name.
+   * Tools absent from the map are callable by any connected caller.
+   */
+  scopes?: Record<string, string | readonly string[]>;
+  /**
+   * Gate behavior for callers without a connection.
+   *
+   * @defaultValue `"gate-all"`
+   */
+  enforcement?: LaneEnforcement;
+  /** Observer for gate decisions. Exceptions are swallowed. */
+  onGateEvent?: (event: LaneGateEvent) => void;
+  /**
+   * Register the `lane_session_info` diagnostic tool.
+   *
+   * @defaultValue `true`
+   */
+  sessionInfoTool?: boolean;
+  /**
+   * Register the `lane://auth-guide` resource.
+   *
+   * @defaultValue `true`
+   */
+  authGuide?: boolean;
+  /** Replaces the default exchanger built from the client credentials. */
+  exchanger?: LaneTokenExchanger;
+  /**
+   * Replaces the default Lane JWKS verifier. The default additionally
+   * requires the `at+jwt` token type and a `jti` claim; a replacement is
+   * used as-is.
+   */
+  createTokenVerifier?: (resource: URL) => OAuthTokenVerifier;
+}

--- a/libraries/typescript/packages/server/src/oauth/lane/types.ts
+++ b/libraries/typescript/packages/server/src/oauth/lane/types.ts
@@ -2,7 +2,7 @@ import type { OAuthTokenVerifier } from "@modelcontextprotocol/server";
 
 import type { OAuthResourceOptions } from "../provider.js";
 
-/** Reserved tool that completes Lane's step-up for the calling credential. */
+/** Reserved tool that completes Lane's step-up for the calling user and agent client. */
 export const LANE_STEP_UP_TOOL = "lane_register_session";
 
 /** Reserved diagnostic tool reporting what Lane knows about the caller. */
@@ -29,7 +29,7 @@ export interface LaneOAuthUser {
   id: string;
   /** OAuth `client_id` of the calling agent application. */
   agentId: string;
-  /** Token `jti`; identifies the credential a connection is recorded for. */
+  /** Token `jti`; identifies the credential used on this request. */
   credentialId: string;
   /** Claimed merchant host the token was minted for, when present. */
   host?: string;
@@ -41,16 +41,18 @@ export interface LaneOAuthUser {
   authTime?: number;
 }
 
-/** Identifies one connection: a subject on one credential. */
+/** Identifies one connection: a subject using one OAuth client. */
 export interface LaneConnectionKey {
   /** Pairwise subject from the verified token. */
   sub: string;
-  /** Token `jti`. A refreshed token is a new credential. */
-  jti: string;
+  /** OAuth `client_id`; stays stable when the client refreshes its bearer. */
+  clientId: string;
 }
 
 /** Data recorded when a step-up completes. */
 export interface LaneConnectionInput {
+  /** Token `jti` used to establish this connection, retained for auditing only. */
+  jti: string;
   /** Scopes granted by the token exchange. This is the caller's authority. */
   scopes: string[];
   /** Exchanged access token. Stores may discard it; nothing reads it back. */

--- a/libraries/typescript/packages/server/src/oauth/provider.ts
+++ b/libraries/typescript/packages/server/src/oauth/provider.ts
@@ -111,6 +111,13 @@ export interface CustomOAuthProviderOptions<
    * requires. See {@link OAuthProviderHost}.
    */
   setup?: (host: OAuthProviderHost) => void;
+  /**
+   * Allows unauthenticated POST requests for `initialize`, `tools/list`, and
+   * `notifications/initialized`. All other MCP methods still require a bearer.
+   * Supplied credentials are always verified, including discovery requests.
+   * Defaults to `false`; enabled automatically by the Lane provider.
+   */
+  allowAnonymousDiscovery?: boolean;
 }
 
 /** OAuth resource-server provider accepted by the mcp-use server constructor. */
@@ -157,6 +164,15 @@ export function oauthCustomProvider<TUser>(
     throw new TypeError("setup must be a function when provided");
   }
 
+  if (
+    options.allowAnonymousDiscovery !== undefined &&
+    typeof options.allowAnonymousDiscovery !== "boolean"
+  ) {
+    throw new TypeError(
+      "allowAnonymousDiscovery must be a boolean when provided"
+    );
+  }
+
   assertOAuthMetadata(options.oauthMetadata);
   if (options.resource !== undefined) {
     assertResourceUrl(options.resource);
@@ -185,6 +201,9 @@ export function oauthCustomProvider<TUser>(
     oauthMetadata: options.oauthMetadata,
     mapAuthInfo: options.mapAuthInfo,
     ...(options.setup !== undefined && { setup: options.setup }),
+    ...(options.allowAnonymousDiscovery !== undefined && {
+      allowAnonymousDiscovery: options.allowAnonymousDiscovery,
+    }),
     ...(options.resource !== undefined && { resource: options.resource }),
     ...(options.requiredScopes !== undefined && {
       requiredScopes: [...options.requiredScopes],

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -7,6 +7,7 @@ import {
   CLIENT_INFO_META_KEY,
   PROTOCOL_VERSION_META_KEY,
   isJSONRPCRequest,
+  isJSONRPCNotification,
   isInputRequiredResult,
   type ClientCapabilities,
   type McpHttpHandler,
@@ -1505,6 +1506,24 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
           }),
         });
         protectWithBearer = async (request, next) => {
+          if (
+            provider.allowAnonymousDiscovery === true &&
+            request.method === "POST" &&
+            !request.headers.has("authorization")
+          ) {
+            const body = getRequestBag(request).parsedBody;
+            // Inspect the same parsed body delivered to the MCP handler. Never
+            // exempt a batch or a tool call, including provider-owned tools.
+            if (
+              (isJSONRPCRequest(body) &&
+                (body.method === "initialize" ||
+                  body.method === "tools/list")) ||
+              (isJSONRPCNotification(body) &&
+                body.method === "notifications/initialized")
+            ) {
+              return next();
+            }
+          }
           const result = await gate(request);
           if (result instanceof Response) {
             return result;
@@ -1517,8 +1536,8 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
         // Authenticate the exact MCP route before the user-owned Hono app
         // runs. This makes verified identity available to route middleware
         // while leaving OAuth discovery, assets, and unrelated custom routes
-        // public. The explicitly public HTML landing-page carveout remains the
-        // only unauthenticated request allowed through this route.
+        // public. Providers can opt into anonymous MCP discovery; the public
+        // HTML landing page is controlled separately.
         httpApp.use("*", async (context, next) => {
           if (new URL(context.req.url).pathname !== basePath) {
             await next();

--- a/libraries/typescript/packages/server/tests/oauth-lane.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-lane.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { MCPServer } from "../src/index.js";
+import { OAuthError, OAuthErrorCode } from "../src/oauth/index.js";
+import {
+  memoryLaneConnectionStore,
+  oauthLaneProvider,
+  type LaneOAuthUser,
+} from "../src/oauth/lane.js";
+
+const resource = "https://lane.example.test/mcp";
+const issuer = "https://auth.getonlane.com/auth/mcp";
+const servers: MCPServer<LaneOAuthUser>[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+});
+
+function fixture() {
+  const connections = memoryLaneConnectionStore();
+  const exchange = vi.fn(async () => ({
+    accessToken: "exchanged-token",
+    scopes: ["email"],
+    expiresIn: 3600,
+  }));
+  const server = new MCPServer({
+    name: "lane-test",
+    version: "1.0.0",
+    oauth: oauthLaneProvider({
+      resource,
+      connections,
+      exchanger: { exchange },
+      createTokenVerifier: (audience) => ({
+        async verifyAccessToken(token) {
+          if (token === "invalid") {
+            throw new OAuthError(OAuthErrorCode.InvalidToken, "invalid token");
+          }
+          const [sub = "user", clientId = "client", jti = "first"] =
+            token.split(":");
+          return {
+            token,
+            clientId,
+            scopes: [],
+            expiresAt: Date.now() / 1000 + 3600,
+            resource: audience,
+            extra: { payload: { sub, client_id: clientId, jti, iss: issuer } },
+          };
+        },
+      }),
+    }),
+  });
+  const run = vi.fn(async () => ({
+    content: [{ type: "text" as const, text: "ok" }],
+  }));
+  server.tool({ name: "browse" }, run);
+  server.tool({ name: "checkout" }, run);
+  servers.push(server);
+  return { server, connections, exchange, run };
+}
+
+function rpc(
+  server: MCPServer<LaneOAuthUser>,
+  method: string,
+  params?: unknown,
+  token?: string
+) {
+  return post(
+    server,
+    {
+      jsonrpc: "2.0",
+      ...(method === "notifications/initialized" ? {} : { id: 1 }),
+      method,
+      ...(params === undefined ? {} : { params }),
+    },
+    token
+  );
+}
+
+function post(server: MCPServer<LaneOAuthUser>, body: unknown, token?: string) {
+  return server.fetch(
+    new Request(resource, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        "mcp-protocol-version": "2025-11-25",
+        ...(token === undefined ? {} : { authorization: `Bearer ${token}` }),
+      },
+      body: JSON.stringify(body),
+    })
+  );
+}
+
+async function result(response: Response) {
+  expect(response.status).toBe(200);
+  const body = await response.text();
+  return JSON.parse(
+    response.headers.get("content-type")?.includes("text/event-stream")
+      ? body
+          .split("\n")
+          .find((line) => line.startsWith("data: "))!
+          .slice(6)
+      : body
+  ).result;
+}
+
+async function call(
+  server: MCPServer<LaneOAuthUser>,
+  name: string,
+  token?: string
+) {
+  return rpc(server, "tools/call", { name, arguments: {} }, token);
+}
+
+describe("Lane anonymous discovery", () => {
+  it("allows initialize, the initialized notification, and the full tools list", async () => {
+    const { server, run, exchange } = fixture();
+    const initialized = await result(
+      await rpc(server, "initialize", {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "anonymous-prober", version: "1.0.0" },
+      })
+    );
+    expect(initialized.serverInfo.name).toBe("lane-test");
+    expect(initialized.instructions).toContain("lane_register_session");
+    expect((await rpc(server, "notifications/initialized")).status).toBe(202);
+    const listed = await result(await rpc(server, "tools/list"));
+    expect(
+      listed.tools.map((tool: { name: string }) => tool.name).sort()
+    ).toEqual([
+      "browse",
+      "checkout",
+      "lane_register_session",
+      "lane_session_info",
+    ]);
+    expect(run).not.toHaveBeenCalled();
+    expect(exchange).not.toHaveBeenCalled();
+  });
+
+  it("401s every anonymous tool call, including reserved tools, with OAuth metadata", async () => {
+    const { server, run, exchange } = fixture();
+    for (const tool of [
+      "browse",
+      "checkout",
+      "lane_register_session",
+      "lane_session_info",
+      "unknown",
+    ]) {
+      const response = await call(server, tool);
+      expect(response.status).toBe(401);
+      expect(response.headers.get("www-authenticate")).toContain(
+        'resource_metadata="https://lane.example.test/.well-known/oauth-protected-resource/mcp"'
+      );
+    }
+    expect(run).not.toHaveBeenCalled();
+    expect(exchange).not.toHaveBeenCalled();
+  });
+
+  it("does not exempt other methods, batches, or invalid supplied credentials", async () => {
+    const { server, run } = fixture();
+    for (const method of [
+      "resources/read",
+      "resources/list",
+      "prompts/list",
+      "ping",
+    ]) {
+      expect((await rpc(server, method)).status).toBe(401);
+    }
+    expect(
+      (
+        await post(server, [
+          { jsonrpc: "2.0", id: 1, method: "tools/list" },
+          {
+            jsonrpc: "2.0",
+            id: 2,
+            method: "tools/call",
+            params: { name: "browse" },
+          },
+        ])
+      ).status
+    ).toBe(401);
+    for (const method of [
+      "initialize",
+      "tools/list",
+      "notifications/initialized",
+    ]) {
+      expect((await rpc(server, method, undefined, "invalid")).status).toBe(
+        401
+      );
+    }
+    expect((await server.fetch(new Request(resource))).status).toBe(401);
+    expect(run).not.toHaveBeenCalled();
+  });
+});
+
+describe("Lane connection identity", () => {
+  it("reuses a connection after token refresh and retains registration jti", async () => {
+    const { server, connections, exchange, run } = fixture();
+    expect(
+      await result(await call(server, "browse", "user:client:first"))
+    ).toMatchObject({ isError: true });
+    expect(
+      await result(
+        await call(server, "lane_register_session", "user:client:first")
+      )
+    ).not.toHaveProperty("isError");
+    expect(
+      await connections.get({ sub: "user", clientId: "client" })
+    ).toMatchObject({ jti: "first", scopes: ["email"] });
+    expect(
+      await result(await call(server, "browse", "user:client:refreshed"))
+    ).not.toHaveProperty("isError");
+    const report = await result(
+      await call(server, "lane_session_info", "user:client:refreshed")
+    );
+    expect(JSON.parse(report.content[0].text)).toMatchObject({
+      connected: true,
+      identity: { credential_id: "refreshed" },
+    });
+    expect(
+      (await connections.get({ sub: "user", clientId: "client" }))?.jti
+    ).toBe("first");
+    expect(exchange).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(connections.size()).toBe(1);
+  });
+
+  it("isolates different subjects and clients even when they share a jti", async () => {
+    const { server, run } = fixture();
+    await result(
+      await call(server, "lane_register_session", "user:client:same")
+    );
+    for (const token of ["other:client:same", "user:other:same"]) {
+      expect(await result(await call(server, "browse", token))).toMatchObject({
+        isError: true,
+      });
+    }
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("requires registration again after connection expiry or deletion", async () => {
+    const { server, connections, run } = fixture();
+    const key = { sub: "user", clientId: "client" };
+    await connections.put(key, {
+      jti: "first",
+      scopes: [],
+      expiresAt: Date.now() / 1000 - 1,
+    });
+    expect(
+      await result(await call(server, "browse", "user:client:refreshed"))
+    ).toMatchObject({ isError: true });
+    await result(
+      await call(server, "lane_register_session", "user:client:refreshed")
+    );
+    await connections.delete!(key);
+    expect(
+      await result(await call(server, "browse", "user:client:next"))
+    ).toMatchObject({ isError: true });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("uses unambiguous compound keys", async () => {
+    const store = memoryLaneConnectionStore();
+    await store.put(
+      { sub: "a b", clientId: "c" },
+      { jti: "first", scopes: [] }
+    );
+    expect(await store.get({ sub: "a", clientId: "b c" })).toBeNull();
+  });
+});

--- a/libraries/typescript/packages/server/tsup.config.ts
+++ b/libraries/typescript/packages/server/tsup.config.ts
@@ -34,6 +34,7 @@ export default defineConfig([
       "oauth/better-auth": "src/oauth/better-auth.ts",
       "oauth/scalekit": "src/oauth/scalekit.ts",
       "oauth/convex": "src/oauth/convex.ts",
+      "oauth/lane": "src/oauth/lane.ts",
       // Keep the OpenAPI integration in a sibling chunk. `MCPServer` imports
       // it synchronously so `fromOpenAPI()` stays a synchronous constructor,
       // while the root entry retains its independently enforced size budget.

--- a/libraries/typescript/packages/server/typedoc.json
+++ b/libraries/typescript/packages/server/typedoc.json
@@ -13,6 +13,7 @@
     "src/oauth/better-auth.ts",
     "src/oauth/scalekit.ts",
     "src/oauth/convex.ts",
+    "src/oauth/lane.ts",
     "src/node-bridge.ts",
     "src/next/index.ts"
   ],


### PR DESCRIPTION
Adds `oauthLaneProvider` under `mcp-use/oauth/lane`, stacked on #2405. The provider verifies Lane access tokens and installs explicit session registration, connection-based tool gating, session diagnostics, an auth-guide resource, and protected-resource metadata.

Lane discovery works without a bearer: `initialize`, `notifications/initialized`, and the full `tools/list` response are public. Every tool call—including `lane_register_session` and `lane_session_info`—requires a valid bearer or returns HTTP 401 with the resource metadata challenge. Other MCP methods remain authenticated, and supplied credentials are always verified. The provider enables the new `allowAnonymousDiscovery` option; other OAuth providers retain their default authentication behavior.

Connections use `(sub, client_id)` instead of `(sub, jti)`. Refreshing a bearer for the same user and client reuses the connection until it expires or is removed. The registration token's `jti` is retained on the connection for auditing; different users and clients cannot share a connection. Applications using a shared `LaneConnectionStore` should use `key.sub` and `key.clientId`.

Registration stays explicit. `lane_register_session` performs the confidential server-side token exchange and records granted scopes. Tool authority comes from that connection, not the incoming bearer's scope claim. The provider retains strict resource audience, `at+jwt`, and required `jti` checks. Payment-tag integration and any new ownership-verification contract are outside this change.

Validation: 59 tests passed across eight OAuth suites, including anonymous discovery, 401s for reserved/application tools, invalid credentials, mixed batches, refresh reuse, user/client isolation, connection expiry/deletion, and existing provider behavior. Server typecheck and changed-file lint pass. Live Lane E2E remains unverified pending credentials.
