### PR TITLE
fix(cli): stop reporting deletes that never happened

### DIFF
--- a/libraries/typescript/.changeset/olive-pianos-repeat.md
+++ b/libraries/typescript/.changeset/olive-pianos-repeat.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Fix two delete commands reporting success for targets that do not exist. `servers env unset` printed `Deleted <key>.` and exited 0 when no variable matched the key and branch, and `client remove` printed `Removed <name>.` for a name that was never saved. Both now fail instead of hiding a typo or a mismatched `--branch` behind a successful-looking result.

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -184,6 +184,11 @@ async function remove(argv: readonly string[], json: boolean): Promise<number> {
   });
   const name = one(positionals, "mcp-use client remove <name>");
   const saved = await readServers();
+  if (saved.servers[name] === undefined) {
+    throw new UsageError(
+      `Unknown saved server: ${name}. Run \`mcp-use client list\` to see saved servers.`
+    );
+  }
   delete saved.servers[name];
   await writePrivateJson(SERVERS_PATH, saved);
   await rm(credentialsDirectory(name), { recursive: true, force: true });

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -184,7 +184,7 @@ async function remove(argv: readonly string[], json: boolean): Promise<number> {
   });
   const name = one(positionals, "mcp-use client remove <name>");
   const saved = await readServers();
-  if (saved.servers[name] === undefined) {
+  if (!Object.hasOwn(saved.servers, name)) {
     throw new UsageError(
       `Unknown saved server: ${name}. Run \`mcp-use client list\` to see saved servers.`
     );

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -2,6 +2,7 @@ import { parseArgs } from "node:util";
 
 import { cloudApiForOrganization, type CloudApi } from "./cloud-api.js";
 import {
+  CommandError,
   confirm,
   printResult,
   reportError,
@@ -352,12 +353,18 @@ async function envUnset(
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
-  if (existing !== undefined) {
-    await api.request(
-      `/servers/${encodeURIComponent(server)}/env-variables/${encodeURIComponent(existing.id)}`,
-      { method: "DELETE" }
+  if (existing === undefined) {
+    const scope =
+      values.branch === undefined ? "production" : `branch ${values.branch}`;
+    throw new CommandError(
+      "env_variable_not_found",
+      `Environment variable not found on ${server} (${scope}): ${key}`
     );
   }
+  await api.request(
+    `/servers/${encodeURIComponent(server)}/env-variables/${encodeURIComponent(existing.id)}`,
+    { method: "DELETE" }
+  );
   printResult({ deleted: key }, json, `Deleted ${key}.`);
   return 0;
 }

--- a/libraries/typescript/packages/cli/tests/commands/client.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/client.test.ts
@@ -495,6 +495,20 @@ describe("client human-readable output", () => {
     expect(stderr).toBe("");
   });
 
+  it("fails instead of reporting a remove that never happened", async () => {
+    await expect(runClient(["remove", "never-saved", "--json"])).resolves.toBe(
+      2
+    );
+    expect(stdout).toBe("");
+    expect(JSON.parse(stderr)).toEqual({
+      error: {
+        code: "usage_error",
+        message:
+          "Unknown saved server: never-saved. Run `mcp-use client list` to see saved servers.",
+      },
+    });
+  });
+
   it("removes without confirmation and supports JSON anywhere", async () => {
     await expect(
       runClient([

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -86,6 +86,41 @@ describe("server environment output safety", () => {
   });
 });
 
+describe("server environment deletion", () => {
+  it("fails instead of reporting a delete that never happened", async () => {
+    // The key exists in production, but the caller scoped the unset to a branch.
+    api.request.mockResolvedValueOnce([
+      { id: "env_1", key: "TOKEN", branch: null },
+    ]);
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runServers([
+        "env",
+        "unset",
+        "server_1",
+        "TOKEN",
+        "--branch",
+        "feature",
+        "--yes",
+        "--json",
+      ])
+    ).resolves.toBe(1);
+
+    // Only the lookup ran; nothing was deleted.
+    expect(api.request).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(stderr.mock.calls.flat().join(""))).toEqual({
+      error: {
+        code: "env_variable_not_found",
+        message:
+          "Environment variable not found on server_1 (branch feature): TOKEN",
+      },
+    });
+  });
+});
+
 describe("server human output", () => {
   it("renders a compact list instead of raw API JSON", async () => {
     api.request.mockResolvedValue({


### PR DESCRIPTION
## Why

Two delete commands print a success line and exit 0 when the thing they were asked to delete does not exist.

### `servers env unset`

It looks the key up, filters on both key and branch, then guards only the DELETE call on having found a match (`servers.ts:355`). The success line runs either way:

```ts
const existing = variables.find(
  (variable) =>
    variable.key === key && (variable.branch ?? undefined) === values.branch
);
if (existing !== undefined) {
  await api.request(`/servers/.../env-variables/${existing.id}`, { method: "DELETE" });
}
printResult({ deleted: key }, json, `Deleted ${key}.`);
```

Driving it against the mocked cloud API used by `tests/commands/servers.test.ts`, with the lookup returning a single production `TOKEN`:

```
$ ... env unset server_1 ABSENT --yes --json
{"deleted":"ABSENT"}                      exit 0, 1 API call, no DELETE

$ ... env unset server_1 TOKEN --branch feature --yes --json
{"deleted":"TOKEN"}                       exit 0, 1 API call, no DELETE
```

The second is the one that worries me. `TOKEN` exists, just in production rather than on the `feature` branch, so the filter misses and the caller is told the variable is gone. It is not. A cleanup script that walks a list of keys reports a clean run while leaving every one of them in place.

### `client remove`

It deletes a key from the saved-servers record without checking it was there (`client.ts:187`):

```console
$ mcp-use client remove not-a-real-server --json
{"removed":"not-a-real-server"}           exit 0

$ mcp-use client not-a-real-server auth status --json
{"error":{"code":"usage_error","message":"Unknown saved server: not-a-real-server. ..."}}   exit 2
```

Every other saved-server command rejects the name. `remove` is the one that accepts it.

## The change

Both now fail instead of reporting a no-op as success.

`env unset` raises `CommandError("env_variable_not_found", ...)`, matching how `cloud-api.ts:106` reports a missing organization, and names the scope it searched:

```
Environment variable not found on server_1 (branch feature): TOKEN
```

The scope is in the message because the branch mismatch is the case you cannot see from the command line you typed.

`client remove` reuses the existing unknown-saved-server wording and exit code, pointing at `client list` rather than `client connect`, since someone removing a server does not want to be told to connect it.

I did not touch `client <name> auth logout`, which also uses `force: true` and reports success unconditionally. Deleting credentials is idempotent by intent and `auth status` already reports whether a session exists, so there is nothing being hidden there.

## Tests

One test per command, both in the existing suite for the command they cover. Each fails on the unfixed source:

- `servers.test.ts` — `expected +0 to be 1`
- `client.test.ts` — `expected +0 to be 2`

## Validation

From `libraries/typescript/packages/cli`: `vitest run` — 296 passed, 23 files. `tsc --noEmit` — clean.
From `libraries/typescript`: `eslint` and `prettier --check` on all four changed files — clean.

One local note in case it saves someone time: `tests/cli/dev.test.ts` failed 32 of 34 for me with `server.__setRequestLogPrefix is not a function` until I rebuilt `packages/server`. My `dist` predated that method. It is not related to this diff, and the suite is green after `pnpm build`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two CLI delete commands that reported success when the target did not exist. `servers env unset` now errors when no variable matches the key and branch, and `client remove` rejects unknown saved servers instead of exiting 0.

**Bug Fixes**

- No-match errors return `env_variable_not_found` and name the searched production or branch scope.
- Unknown saved-server errors point to `mcp-use client list` and use exit code 2.
- Adds regression tests for branch mismatches and unknown server names.

<sup>Written for commit 47e89e1cda1c6b3436d26c4b62858899894fbb33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

