### PR TITLE
fix(server): report a malformed verifier resource as configuration

### DIFF
--- a/libraries/typescript/.changeset/loud-pans-repeat.md
+++ b/libraries/typescript/.changeset/loud-pans-repeat.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix `createJwtVerifier` reporting a malformed `resource` option as an OAuth `invalid_token` error naming the token's resource claim. A configuration mistake at server startup now throws a `TypeError`, matching `oauthCustomProvider` and the other provider URL options.

--- a/libraries/typescript/packages/server/src/oauth/jwt.ts
+++ b/libraries/typescript/packages/server/src/oauth/jwt.ts
@@ -52,6 +52,8 @@ export interface JwtVerifierOptions {
  *
  * @param options - Issuer, keys, and claims to enforce.
  * @returns A verifier accepted anywhere an `OAuthTokenVerifier` is taken.
+ * @throws TypeError if `resource` is not an absolute HTTPS URL, or an HTTP URL
+ * for localhost, without credentials, query, or fragment.
  * @throws TypeError if `audience` is combined with `issuerBoundAccessTokens`.
  */
 export function createJwtVerifier(
@@ -59,7 +61,7 @@ export function createJwtVerifier(
 ): OAuthTokenVerifier {
   // jose overloads key material vs JWKS getters; runtime accepts either.
   const key = options.key ?? createRemoteJWKSet(options.jwksUrl);
-  const configuredResource = canonicalUrl(options.resource);
+  const configuredResource = configuredResourceUrl(options.resource);
   const configuredAudience = verifierAudience(options.audience);
   if (
     configuredAudience !== undefined &&
@@ -303,7 +305,33 @@ function validAudience(value: unknown): value is string | string[] {
   );
 }
 
-function canonicalUrl(value: URL | string): URL {
+/**
+ * Canonicalizes the `resource` option a verifier is constructed with.
+ *
+ * Deliberately not `normalizedProviderUrl`: that helper prefixes `https://`
+ * onto a scheme-less string, which is right for a provider domain but would
+ * quietly accept a malformed resource from a JavaScript caller that the types
+ * do not constrain.
+ */
+function configuredResourceUrl(value: URL | string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new TypeError(RESOURCE_URL_REQUIREMENT);
+  }
+  if (!isAllowedHttpUrl(url)) {
+    throw new TypeError(RESOURCE_URL_REQUIREMENT);
+  }
+  url.pathname = url.pathname === "/" ? "/" : url.pathname.replace(/\/+$/, "");
+  return url;
+}
+
+const RESOURCE_URL_REQUIREMENT =
+  "resource must use HTTPS, or HTTP for localhost, without credentials, query, or fragment";
+
+/** Canonicalizes the `resource` claim carried by a token. */
+function canonicalUrl(value: string): URL {
   try {
     const url = new URL(value);
     if (!isAllowedHttpUrl(url)) {

--- a/libraries/typescript/packages/server/tests/oauth-core.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-core.test.ts
@@ -498,6 +498,27 @@ describe("OAuth core", () => {
     ).toThrow("resource must use HTTPS, or HTTP for localhost");
   });
 
+  it("rejects a malformed verifier resource as configuration, not as a bad token", () => {
+    const requirement = new TypeError(
+      "resource must use HTTPS, or HTTP for localhost, without credentials, query, or fragment"
+    );
+    const verifier = (resource: URL | string) => () =>
+      createJwtVerifier({
+        issuer: "https://issuer.example.com",
+        jwksUrl: new URL("https://issuer.example.com/jwks"),
+        resource: resource as URL,
+      });
+
+    expect(verifier(new URL("https://api.example.com/mcp?v=1"))).toThrow(
+      requirement
+    );
+    // A JavaScript caller is not held to the URL type, and a scheme-less
+    // string must stay rejected rather than being read as https://.
+    expect(verifier("api.example.com/mcp")).toThrow(requirement);
+    expect(verifier("http://api.example.com/mcp")).toThrow(requirement);
+    expect(verifier("http://localhost:3000/mcp")).not.toThrow();
+  });
+
   it("resolves an explicit canonical resource and rejects a path mismatch", () => {
     const provider = oauthCustomProvider({
       createTokenVerifier: () => ({


### PR DESCRIPTION
## Why

`createJwtVerifier` canonicalizes its `resource` option with `canonicalUrl` (`jwt.ts:62`), the same helper that handles the `resource` claim carried by a token. That helper reports failures with `invalidToken`, so a configuration mistake at server startup throws an OAuth `invalid_token` error blaming a token that has not been presented yet:

```
https://api.example.com/mcp?v=1   -> OAuthError code=invalid_token
   "Token resource claim must be an absolute HTTPS URL, or HTTP URL for localhost"
https://api.example.com/mcp#frag  -> same
http://api.example.com/mcp        -> same
```

A trailing query string on the resource URL is an easy thing to get wrong, and the error sends you looking at your identity provider instead of at the line you just wrote.

The same option validated through the other public entry point behaves the way you would expect. `tests/oauth-core.test.ts:493` already pins it:

```ts
expect(() =>
  oauthCustomProvider({ ...validOptions, resource: "ftp://localhost/mcp" })
).toThrow("resource must use HTTPS, or HTTP for localhost");
```

So the two entry points that take a `resource` disagree on whether a bad one is a config error or an auth error.

## The change

Use `normalizedProviderUrl`, which already lives in this file and is what every provider URL option goes through (`workos.ts:144`, `auth0.ts:87`, `keycloak.ts:110`, `scalekit.ts:99`):

```diff
-  const configuredResource = canonicalUrl(options.resource);
+  const configuredResource = normalizedProviderUrl(options.resource, "resource");
```

```
https://api.example.com/mcp?v=1 -> TypeError:
   resource must use HTTPS, or HTTP for localhost, without credentials, query, or fragment
```

Which URLs are accepted does not change. Both helpers run the same `isAllowedHttpUrl` and both normalize the path the same way (`"/"` stays `"/"`, trailing slashes are stripped) so a resource that worked before still resolves to the identical canonical URL. Only the error type and wording move.

`canonicalUrl` now only ever sees a token claim, so its parameter narrows from `URL | string` to `string` and it gets a line of doc saying what it is for. Behaviour on the claim path is untouched: a malformed `resource` claim in a token still raises `invalidToken`, which is correct there.

## Test

One test in `tests/oauth-core.test.ts`, next to the existing config-validation expectations. On the unfixed source it fails with:

```
AssertionError: expected a thrown error to be TypeError: resource must use HTTPS, or HT…
```

## Validation

From `libraries/typescript/packages/server`: `vitest run` — 476 passed, 44 files. `tsc --noEmit` — clean.
Monorepo preflight (lint, typecheck, build, tests across packages) — 0 failing packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`createJwtVerifier` now reports a malformed `resource` option as a configuration `TypeError` instead of an OAuth `invalid_token` error. Accepted URL shapes and canonicalization remain unchanged, while malformed token `resource` claims still use `invalidToken`.

- Adds a regression test covering the configuration error.
- Narrows and documents `canonicalUrl` for token claims only.
- Adds a patch changeset for `mcp-use`.

<sup>Written for commit 87b308c6c9260bf1efc3039c2feb0f3941ef4555. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

