### PR TITLE
fix(ci): reject dev server smoke test startup failures

### DIFF
--- a/.github/scripts/dev-server-smoke-windows.ps1
+++ b/.github/scripts/dev-server-smoke-windows.ps1
@@ -1,0 +1,59 @@
+$ErrorActionPreference = 'Stop'
+
+# Own the job before launching any app process. The handle is non-inheritable;
+# killing this supervisor closes it and terminates all descendants, even if an
+# intermediate npm/cmd process has already exited. Never enumerate by port/name.
+Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+public static class SmokeJob {
+    [StructLayout(LayoutKind.Sequential)]
+    struct BasicLimits {
+        public long ProcessTime, JobTime;
+        public uint Flags;
+        public UIntPtr MinimumWorkingSet, MaximumWorkingSet;
+        public uint ActiveProcessLimit;
+        public UIntPtr Affinity;
+        public uint PriorityClass, SchedulingClass;
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    struct IoCounters {
+        public ulong ReadOps, WriteOps, OtherOps, ReadBytes, WriteBytes, OtherBytes;
+    }
+    [StructLayout(LayoutKind.Sequential)]
+    struct ExtendedLimits {
+        public BasicLimits Basic;
+        public IoCounters Io;
+        public UIntPtr ProcessMemory, JobMemory, PeakProcessMemory, PeakJobMemory;
+    }
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    static extern IntPtr CreateJobObject(IntPtr attributes, string name);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern bool SetInformationJobObject(IntPtr job, int infoClass,
+        ref ExtendedLimits limits, uint length);
+    [DllImport("kernel32.dll", SetLastError = true)]
+    static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+    [DllImport("kernel32.dll")]
+    static extern IntPtr GetCurrentProcess();
+
+    // Retain the handle for the lifetime of this process.
+    static IntPtr job;
+    public static void OwnProcessTree() {
+        job = CreateJobObject(IntPtr.Zero, null);
+        if (job == IntPtr.Zero) throw new Win32Exception();
+        var limits = new ExtendedLimits();
+        limits.Basic.Flags = 0x2000; // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        if (!SetInformationJobObject(job, 9, ref limits,
+                (uint)Marshal.SizeOf(typeof(ExtendedLimits))))
+            throw new Win32Exception();
+        if (!AssignProcessToJobObject(job, GetCurrentProcess()))
+            throw new Win32Exception();
+    }
+}
+'@
+
+[SmokeJob]::OwnProcessTree()
+& $env:MCP_SMOKE_NODE $env:MCP_SMOKE_SCRIPT --supervise
+exit $LASTEXITCODE

--- a/.github/scripts/dev-server-smoke.mjs
+++ b/.github/scripts/dev-server-smoke.mjs
@@ -1,0 +1,228 @@
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+const script = fileURLToPath(import.meta.url);
+const windows = process.platform === "win32";
+
+// Keep an ancestor alive until cleanup, even when the package manager exits.
+// This also keeps the process-group ID from being reused during the check.
+function supervise() {
+  const { pm, cwd } = JSON.parse(process.env.MCP_SMOKE_OPTIONS);
+  const report = (result) =>
+    writeFileSync(process.env.MCP_SMOKE_STATUS, JSON.stringify(result));
+  const child = spawn(pm, ["run", "dev"], {
+    cwd,
+    shell: windows, // Windows package-manager shims are .cmd files.
+    stdio: "inherit",
+  });
+  child.once("error", (error) => report({ error: error.message }));
+  child.once("exit", (code, signal) => report({ code, signal }));
+  setInterval(() => {}, 1000);
+  // Let the controller reap every member of the group before its leader exits.
+  if (!windows) process.on("SIGTERM", () => {});
+}
+
+export async function availablePort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address();
+  await new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
+export async function smokeTest({
+  pm,
+  cwd = process.cwd(),
+  timeoutMs = 90_000,
+  stableMs = 1000,
+  signal,
+}) {
+  if (!["npm", "yarn", "pnpm"].includes(pm)) {
+    throw new Error(`Unsupported package manager: ${pm}`);
+  }
+  const port = await availablePort();
+  const url = `http://127.0.0.1:${port}/mcp`;
+  const scratch = mkdtempSync(join(tmpdir(), "mcp-use-dev-smoke-"));
+  const statusFile = join(scratch, "exit.json");
+  const env = {
+    ...process.env,
+    PORT: String(port),
+    BROWSER: "none",
+    MCP_USE_ANONYMIZED_TELEMETRY: "false",
+    MCP_SMOKE_OPTIONS: JSON.stringify({ pm, cwd: resolve(cwd) }),
+    MCP_SMOKE_STATUS: statusFile,
+    MCP_SMOKE_NODE: process.execPath,
+    MCP_SMOKE_SCRIPT: script,
+  };
+  const child = windows
+    ? spawn(
+        "powershell.exe",
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          fileURLToPath(
+            new URL("./dev-server-smoke-windows.ps1", import.meta.url),
+          ),
+        ],
+        { env, stdio: ["ignore", "pipe", "pipe"] },
+      )
+    : spawn(process.execPath, [script, "--supervise"], {
+        env,
+        detached: true,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+  let output = "";
+  let exited;
+  let closed = false;
+  let failure;
+  let lastProbe = "no response";
+  for (const stream of [child.stdout, child.stderr]) {
+    stream.setEncoding("utf8");
+    stream.on("data", (chunk) => {
+      output = (output + chunk).slice(-256 * 1024);
+    });
+  }
+  child.once("error", (error) => {
+    exited = `launch error: ${error.message}`;
+  });
+  child.once("exit", (code, signal) => {
+    exited = `supervisor exited (code ${code}, signal ${signal})`;
+  });
+  child.once("close", () => {
+    closed = true;
+  });
+  const checkRunning = () => {
+    signal?.throwIfAborted();
+    if (exited) throw new Error(exited);
+    if (existsSync(statusFile)) {
+      // The supervisor is the only writer. An incomplete write is still an exit.
+      throw new Error(
+        `Dev command exited before the check completed: ${readFileSync(statusFile, "utf8")}`,
+      );
+    }
+  };
+
+  try {
+    const deadline = Date.now() + timeoutMs;
+    let readySince;
+    while (Date.now() < deadline) {
+      checkRunning();
+      let ready = false;
+      try {
+        const response = await fetch(url, {
+          redirect: "manual",
+          signal: AbortSignal.timeout(
+            Math.min(1000, Math.max(1, deadline - Date.now())),
+          ),
+        });
+        lastProbe = `HTTP ${response.status}`;
+        ready = response.status === 204;
+        await response.body?.cancel();
+      } catch (error) {
+        lastProbe = error.message;
+      }
+      checkRunning();
+      if (ready) {
+        readySince ??= Date.now();
+        if (Date.now() - readySince >= stableMs) break;
+      } else {
+        readySince = undefined;
+      }
+      await delay(100);
+    }
+    checkRunning();
+    if (readySince === undefined || Date.now() - readySince < stableMs) {
+      throw new Error(
+        `Readiness timeout after ${timeoutMs}ms (last probe: ${lastProbe})`,
+      );
+    }
+  } catch (error) {
+    failure = error;
+  } finally {
+    try {
+      if (child.pid) {
+        if (windows) {
+          // Terminating the native supervisor closes its non-inherited Job
+          // Object handle, which kills every descendant, including orphans.
+          if (!exited) child.kill("SIGKILL");
+        } else {
+          const killGroup = (signal) => {
+            try {
+              process.kill(-child.pid, signal);
+            } catch (error) {
+              if (error.code !== "ESRCH") throw error;
+            }
+          };
+          killGroup("SIGTERM");
+          await delay(500);
+          killGroup("SIGKILL");
+        }
+      }
+      const deadline = Date.now() + 5000;
+      while (!closed && Date.now() < deadline) await delay(50);
+      if (!closed) throw new Error("Process-tree cleanup timed out");
+      // A remaining listener is a failure, never something to kill by port.
+      const probe = createServer();
+      await new Promise((resolve, reject) => {
+        probe.once("error", reject);
+        probe.listen(port, "127.0.0.1", () => probe.close(resolve));
+      });
+    } catch (error) {
+      failure = new Error(
+        `${failure ? `${failure.message}; ` : ""}Cleanup failed: ${error.message}`,
+      );
+      child.stdout.destroy();
+      child.stderr.destroy();
+      child.unref();
+    }
+    rmSync(scratch, { recursive: true, force: true });
+  }
+  if (failure) {
+    throw new Error(
+      `${pm} run dev in ${resolve(cwd)}\nReadiness URL: ${url}\n${failure.message}\n--- dev server logs (last 256 KiB) ---\n${output || "(no output)"}`,
+    );
+  }
+  return { port, output };
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === script) {
+  if (process.argv[2] === "--supervise") {
+    supervise();
+  } else {
+    const controller = new AbortController();
+    for (const signal of ["SIGINT", "SIGTERM"]) {
+      process.on(signal, () =>
+        controller.abort(new Error(`Interrupted by ${signal}`)),
+      );
+    }
+    try {
+      await smokeTest({ pm: process.argv[2], signal: controller.signal });
+      console.log(
+        "Dev server became ready and its process tree was cleaned up successfully",
+      );
+    } catch (error) {
+      console.error(error.message);
+      process.exitCode = 1;
+    }
+  }
+}

--- a/.github/scripts/dev-server-smoke.test.mjs
+++ b/.github/scripts/dev-server-smoke.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const helper = new URL("./dev-server-smoke.mjs", import.meta.url);
+const fixture = `
+const { spawn } = require('node:child_process');
+const { appendFileSync } = require('node:fs');
+const { createServer } = require('node:http');
+appendFileSync('pids', process.pid + '\\n');
+process.on('SIGTERM', () => {}); // Verify forceful cleanup of stubborn children.
+const mode = process.env.FIXTURE_MODE;
+const role = process.argv[2];
+if (!role) {
+  if (mode === 'exit-zero') process.exit(0);
+  if (mode === 'crash') {
+    console.error('fixture startup failed');
+    process.exit(23);
+  }
+  if (mode === 'timeout') console.error('fixture never became ready');
+  const child = spawn(process.execPath, [__filename, 'worker'], { stdio: 'inherit' });
+  if (mode === 'orphan') {
+    child.unref();
+    setTimeout(() => process.exit(17), 300);
+  }
+} else if (role === 'worker') {
+  // This intermediate process exits in the orphan case. Its child must still
+  // be cleaned up after the package manager has exited.
+  const child = spawn(process.execPath, [__filename, 'leaf'], { stdio: 'inherit' });
+  if (mode === 'orphan') { child.unref(); setTimeout(() => process.exit(0), 100); }
+} else if (mode !== 'timeout' && mode !== 'orphan') {
+  createServer((req, res) => {
+    if (mode === 'hang') return;
+    res.writeHead(mode === 'wrong-status' ? 503 : 204);
+    res.end();
+    if (mode === 'ready-then-crash') setTimeout(() => process.exit(19), 50);
+  }).listen(Number(process.env.PORT), '127.0.0.1', () => console.log('fixture listening'));
+}
+setInterval(() => {}, 1000);
+`;
+
+async function runFixture(
+  t,
+  mode,
+  { direct = false, abort = false, command, pm = "npm" } = {},
+) {
+  // Spaces exercise Windows command/path handling too.
+  const cwd = mkdtempSync(join(tmpdir(), "mcp smoke fixture "));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  writeFileSync(
+    join(cwd, "package.json"),
+    JSON.stringify({
+      name: "dev-smoke-fixture",
+      private: true,
+      scripts: { dev: command ?? "node fixture.cjs" },
+    }),
+  );
+  writeFileSync(join(cwd, "fixture.cjs"), fixture);
+  const code = `
+    import { smokeTest } from ${JSON.stringify(helper.href)};
+    const controller = new AbortController();
+    ${abort ? "setTimeout(() => controller.abort(new Error('fixture interruption')), 3500);" : ""}
+    try {
+      await smokeTest({ pm: ${JSON.stringify(pm)}, timeoutMs: 5000, stableMs: 600, signal: controller.signal });
+      console.log('SMOKE PASSED');
+    } catch (error) {
+      console.error(error.message);
+      process.exitCode = 1;
+    }
+  `;
+  const child = spawn(
+    process.execPath,
+    direct
+      ? [fileURLToPath(helper), pm]
+      : ["--input-type=module", "--eval", code],
+    {
+      cwd,
+      env: { ...process.env, FIXTURE_MODE: mode },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let output = "";
+  child.stdout.on("data", (chunk) => {
+    output += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    output += chunk;
+  });
+  const result = await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error(`Smoke helper hung:\n${output}`));
+    }, 20_000);
+    child.once("error", (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("close", (code, signal) => {
+      clearTimeout(timeout);
+      resolve({ code, signal, output });
+    });
+  });
+  // Check descendants individually; closed output pipes alone do not prove
+  // that children which close/redirect their output have stopped.
+  if (existsSync(join(cwd, "pids"))) {
+    const pids = readFileSync(join(cwd, "pids"), "utf8")
+      .trim()
+      .split("\n")
+      .map(Number);
+    for (const pid of pids) {
+      const deadline = Date.now() + 5000;
+      while (alive(pid) && Date.now() < deadline) await delay(50);
+      assert.equal(
+        alive(pid),
+        false,
+        `Leaked fixture process ${pid}\n${output}`,
+      );
+    }
+  }
+  return result;
+}
+
+function alive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error.code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+for (const pm of (process.env.SMOKE_TEST_PACKAGE_MANAGERS ?? "npm").split(
+  ",",
+)) {
+  test(`${pm}: a real ready server passes and cleans up children/grandchildren`, async (t) => {
+    const unrelated = createServer((req, res) => {
+      res.writeHead(204);
+      res.end();
+    });
+    await new Promise((resolve) => unrelated.listen(0, "127.0.0.1", resolve));
+    t.after(() => unrelated.close());
+    const url = `http://127.0.0.1:${unrelated.address().port}`;
+    const result = await runFixture(t, "ready", { pm, direct: true });
+    assert.equal(result.code, 0, result.output);
+    assert.match(result.output, /became ready.*cleaned up successfully/);
+    assert.equal(
+      (await fetch(url)).status,
+      204,
+      "unrelated listener must survive",
+    );
+  });
+}
+
+test("a missing executable fails the actual CLI with useful logs", async (t) => {
+  const result = await runFixture(t, "unused", {
+    direct: true,
+    command: "mcp-use-intentionally-missing",
+  });
+  assert.equal(result.code, 1, result.output);
+  assert.match(result.output, /Dev command exited/);
+  assert.match(result.output, /mcp-use-intentionally-missing/);
+  assert.match(result.output, /dev server logs/);
+  assert.doesNotMatch(result.output, /cleaned up successfully/);
+});
+
+for (const mode of ["crash", "exit-zero", "orphan"]) {
+  test(`${mode}: early exit fails and orphaned descendants are cleaned up`, async (t) => {
+    const result = await runFixture(t, mode);
+    assert.equal(result.code, 1, result.output);
+    assert.match(result.output, /Dev command exited/);
+    if (mode === "crash") assert.match(result.output, /fixture startup failed/);
+  });
+}
+
+for (const mode of ["timeout", "wrong-status", "hang", "ready-then-crash"]) {
+  test(`${mode}: readiness must remain healthy within the deadline`, async (t) => {
+    const result = await runFixture(t, mode);
+    assert.equal(result.code, 1, result.output);
+    assert.match(result.output, /Readiness timeout/);
+    if (mode === "wrong-status") assert.match(result.output, /HTTP 503/);
+    if (mode === "timeout")
+      assert.match(result.output, /fixture never became ready/);
+  });
+}
+
+test("interruption fails and cleans up the process tree", async (t) => {
+  const result = await runFixture(t, "timeout", { abort: true });
+  assert.equal(result.code, 1, result.output);
+  assert.match(result.output, /fixture interruption/);
+});
+
+test("a missing package manager fails rather than timing out", async (t) => {
+  const previous = process.env.PATH;
+  process.env.PATH = "";
+  try {
+    const result = await runFixture(t, "unused");
+    assert.equal(result.code, 1, result.output);
+    // On Windows the native supervisor cannot be resolved with an empty PATH.
+    assert.match(result.output, /launch error|Dev command exited/);
+    assert.doesNotMatch(result.output, /Readiness timeout/);
+  } finally {
+    process.env.PATH = previous;
+  }
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,12 +104,14 @@ jobs:
             typescript:
               - 'libraries/typescript/**'
               - '.github/workflows/ci.yml'
+              - '.github/scripts/dev-server-smoke*'
             knip:
               - 'libraries/typescript/**'
               - '.github/workflows/ci.yml'
             create-mcp-use-app:
               - 'libraries/typescript/packages/create-mcp-use-app/**'
               - '.github/workflows/ci.yml'
+              - '.github/scripts/dev-server-smoke*'
             release-channel:
               - 'libraries/typescript/scripts/release-channel.mjs'
               - 'libraries/typescript/scripts/release-channel.test.mjs'
@@ -942,6 +944,26 @@ jobs:
             echo "If this PR doesn't require a changeset (docs, tests, internal changes), you can ignore this message."
           fi
 
+  dev-server-smoke-tests:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.create-mcp-use-app == 'true'
+    name: "dev-server-smoke/${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22.23.1
+      - name: Test readiness failures and process-tree cleanup
+        timeout-minutes: 5
+        run: node --test .github/scripts/dev-server-smoke.test.mjs
+
   # create-mcp-use-app Tests (only when CLI package changes)
   create-mcp-use-app-build:
     needs: [detect-changes, typescript-lint]
@@ -1061,44 +1083,16 @@ jobs:
           [ -f "test-app/index.ts" ] || exit 1
           echo "✅ Project created successfully"
 
-      - name: Test dev command (non --dev flag only)
+      # --template deliberately skips dependency installation in the scaffolder.
+      # Install with the matrix PM so its real local executable shim is tested.
+      - name: Install generated app dependencies
         if: matrix.flag == ''
         shell: bash
         working-directory: test-app
-        run: |
-          # Start dev server in background
-          case "${{ matrix.pm }}" in
-            npm)
-              npm run dev &
-              ;;
-            yarn)
-              yarn dev &
-              ;;
-            pnpm)
-              pnpm dev &
-              ;;
-          esac
+        run: ${{ matrix.pm }} install
 
-          DEV_PID=$!
-
-          # Wait for server to start (10 seconds should be enough)
-          sleep 10
-
-          # Kill the dev server
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            # On Windows, kill by port is more reliable than DEV_PID
-            # because bash's $! may not map to the actual Windows process ID
-            DEV_PORT=3000
-            for pid in $(netstat -ano 2>/dev/null | grep ":$DEV_PORT " | grep "LISTENING" | awk '{print $5}' | sort -u); do
-              taskkill //PID $pid //F 2>/dev/null || true
-            done
-            # Also try the process tree kill as fallback
-            taskkill //PID $DEV_PID //T //F 2>/dev/null || true
-          else
-            kill $DEV_PID 2>/dev/null || true
-          fi
-
-          # Wait for process to exit
-          wait $DEV_PID 2>/dev/null || true
-
-          echo "✅ Dev server started and stopped successfully"
+      - name: Test dev command (non --dev flag only)
+        if: matrix.flag == ''
+        working-directory: test-app
+        timeout-minutes: 3
+        run: node ../.github/scripts/dev-server-smoke.mjs ${{ matrix.pm }}


### PR DESCRIPTION
## Changes

The generated-app smoke test reported success even when `npm run dev` exited with “mcp-use is not recognized” ([Windows/npm/starter evidence](https://github.com/mcp-use/mcp-use/actions/runs/33679965378/job/100415306268?pr=2384)). It ignored the exit status and printed success after sleeping.

The missing executable has a confirmed installation cause: `create-mcp-use-app --template ...` defaults to skipping dependency installation, and the workflow never installed the generated app. Add an explicit install using the matrix package manager before running its normal `dev` script.

Replace the sleep/kill sequence with a dependency-free Node smoke check that requires repeated HTTP 204 responses from `/mcp` on an allocated loopback port. Startup errors, any early command exit (including code 0), readiness timeout, interruption, and cleanup failure return a nonzero exit status with the command, URL, and captured server logs.

## Language / Project Scope

- [x] CI/CD or tooling

## Implementation Details

- Preserve the existing OS/package-manager/template/flag matrix and generated package manifests.
- Keep a supervisor alive to observe package-manager exit and retain ownership of the process tree. Use a dedicated process group on Linux/macOS and a Windows Job Object with kill-on-close for descendants whose intermediate parent has exited. Cleanup never selects processes by port or name.
- Add a lightweight Linux/macOS/Windows regression job and path filters for helper changes.
- No package runtime changes, dependencies, or changeset are needed. The separate runner-finalization observation is outside this fix.

## Review Readiness

- [x] Scoped to the confirmed false-positive smoke test
- [x] Problem, root cause, and resulting behavior documented
- [x] No unrelated formatting or generated artifacts
- [x] Checked for existing open PRs solving this issue
- [x] Validated the affected paths

## Testing

- macOS: 13 subprocess regression tests passed, including ready servers via npm/yarn/pnpm, missing executable, exit 0/nonzero, orphaned grandchildren, never-ready/503/hung HTTP, crash after readiness, interruption, and missing package manager. Cleanup checks descendant PIDs and preserves an unrelated listener.
- Linux (`node:24-bookworm`, with an init process): all 11 default regression tests passed.
- Exact `create-mcp-use-app-2.0.5.tgz` artifact from the linked CI run: reproduced failure before installation, then successfully generated, installed, started, and cleaned up all nine npm/yarn/pnpm × starter/mcp-apps/blank combinations on macOS.
- Node syntax checks, targeted Prettier check, `git diff --check`, and pre-commit checks passed.
- Native GitHub Actions regression jobs passed on Linux, macOS, and Windows ([run](https://github.com/mcp-use/mcp-use/actions/runs/33685267186)). The fix was then rebased onto latest `main` without changing the patch (`git range-diff` is identical); CI for the rebased commit is running.

## Backwards Compatibility

Only CI behavior changes: unavailable or unhealthy dev servers now fail the check. Generated app behavior and published packages are unchanged.
