### PR TITLE
fix(ci): honor refs and flags in reusable workflow calls

### DIFF
--- a/.github/workflows/approve-fork-pr.yml
+++ b/.github/workflows/approve-fork-pr.yml
@@ -9,7 +9,7 @@ on:
         type: number
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: read
 
 concurrency:
@@ -19,6 +19,11 @@ concurrency:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ inputs.pull_number }}
     outputs:
       sha: ${{ steps.promote.outputs.sha }}
       branch: ${{ steps.promote.outputs.branch }}
@@ -31,7 +36,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = Number(core.getInput('pull_number'));
+            const prNumber = Number(process.env.PR_NUMBER);
             const { owner, repo } = context.repo;
             const pr = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
 
@@ -57,7 +62,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = Number(core.getInput('pull_number'));
+            const prNumber = Number(process.env.PR_NUMBER);
             const { owner, repo } = context.repo;
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner, repo, pull_number: prNumber, per_page: 100
@@ -65,8 +70,9 @@ jobs:
             const paths = files.map(f => f.filename);
 
             const python = paths.some(p => p.startsWith('libraries/python/'));
-            const typescript = paths.some(p => p.startsWith('libraries/typescript/'));
-            const create_mcp_use_app = paths.some(p => p.startsWith('libraries/typescript/packages/create-mcp-use-app/'));
+            const ciChanged = paths.includes('.github/workflows/ci.yml') || paths.includes('.github/workflows/approve-fork-pr.yml');
+            const typescript = ciChanged || paths.some(p => p.startsWith('libraries/typescript/'));
+            const create_mcp_use_app = ciChanged || paths.some(p => p.startsWith('libraries/typescript/packages/create-mcp-use-app/'));
 
             core.setOutput('python', String(python));
             core.setOutput('typescript', String(typescript));
@@ -76,7 +82,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const prNumber = Number(core.getInput('pull_number'));
+            const prNumber = Number(process.env.PR_NUMBER);
             const branch = "${{ steps.promote.outputs.branch }}";
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = `Approved CI for fork PR.\nPromoted head to \`${branch}\`.\nRunning CI now.\n\nWorkflow: ${runUrl}`;
@@ -89,6 +95,10 @@ jobs:
 
   run-ci:
     needs: promote
+    permissions:
+      contents: read
+      # Required by the reusable workflow's PR-reporting jobs.
+      pull-requests: write
     uses: ./.github/workflows/ci.yml
     with:
       ref: ${{ needs.promote.outputs.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,11 +92,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
-        if: github.event_name != 'workflow_call'
+        # Reusable workflows keep the caller's event name; ref is required for calls.
+        if: ${{ !inputs.ref }}
         with:
           filters: |
             python:
@@ -120,12 +121,13 @@ jobs:
         id: out
         uses: actions/github-script@v9
         env:
+          CI_INPUT_REF: ${{ inputs.ref }}
           CI_INPUT_PYTHON: ${{ inputs.python }}
           CI_INPUT_TYPESCRIPT: ${{ inputs.typescript }}
           CI_INPUT_CREATE: ${{ inputs.create_mcp_use_app }}
         with:
           script: |
-            const fromWfCall = context.eventName === 'workflow_call';
+            const fromWfCall = Boolean(process.env.CI_INPUT_REF);
             const py = fromWfCall ? (process.env.CI_INPUT_PYTHON === 'true') : ("${{ steps.filter.outputs.python }}" === 'true');
             const ts = fromWfCall ? (process.env.CI_INPUT_TYPESCRIPT === 'true') : ("${{ steps.filter.outputs.typescript }}" === 'true');
             const knip = fromWfCall ? (process.env.CI_INPUT_TYPESCRIPT === 'true') : ("${{ steps.filter.outputs.knip }}" === 'true');
@@ -151,7 +153,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - name: Set up Python 3.11
         uses: actions/setup-python@v7
         with:
@@ -182,7 +184,7 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v7
   #       with:
-  #         ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+  #         ref: ${{ inputs.ref || github.sha }}
   #     - name: Set up Python 3.11
   #       uses: actions/setup-python@v7
   #       with:
@@ -209,7 +211,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:
@@ -241,7 +243,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - name: Set up Python 3.11
         uses: actions/setup-python@v7
         with:
@@ -406,7 +408,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - name: Set up Python 3.11
         uses: actions/setup-python@v7
         with:
@@ -557,7 +559,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - name: Set up Python 3.11
         uses: actions/setup-python@v7
         with:
@@ -589,7 +591,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - name: Set up Python 3.11
         uses: actions/setup-python@v7
         with:
@@ -623,7 +625,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -666,7 +668,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -701,7 +703,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - uses: pnpm/action-setup@v4
         with:
           version: 11.13.1
@@ -744,7 +746,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - uses: pnpm/action-setup@v4
         with:
           version: 11.13.1
@@ -771,7 +773,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - uses: pnpm/action-setup@v4
         with:
           version: 11.13.1
@@ -806,7 +808,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - uses: pnpm/action-setup@v4
         with:
           version: 11.13.1
@@ -839,6 +841,8 @@ jobs:
         working-directory: libraries/typescript
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.sha }}
       - uses: pnpm/action-setup@v4
         with:
           version: 11.13.1
@@ -865,7 +869,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -887,7 +891,7 @@ jobs:
 
   typescript-changeset-check:
     needs: detect-changes
-    if: ${{ (github.event_name == 'workflow_call' && inputs.run_changeset_check) || (github.event_name == 'pull_request' && github.base_ref != 'canary' && needs.detect-changes.outputs.typescript == 'true') }}
+    if: ${{ (inputs.ref && inputs.run_changeset_check) || (!inputs.ref && github.event_name == 'pull_request' && github.base_ref != 'canary' && needs.detect-changes.outputs.typescript == 'true') }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -896,7 +900,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -951,7 +955,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - uses: pnpm/action-setup@v4
         with:
           version: 11.13.1
@@ -1016,7 +1020,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_call' && inputs.ref || github.sha }}
+          ref: ${{ inputs.ref || github.sha }}
       - uses: pnpm/action-setup@v4
         if: matrix.pm == 'pnpm'
         with:


### PR DESCRIPTION
## Changes

When `approve-fork-pr.yml` calls CI with a promoted PR commit, the reusable workflow retains the caller's `workflow_dispatch` event name. The existing `workflow_call` checks therefore ignore the supplied ref and job-selection inputs. This change makes CI use the requested commit and flags while preserving the existing behavior for ordinary push and pull-request runs.

Thanks to @MohammedAlkindi for identifying the missing tunnel checkout ref in #2391. Investigating that report uncovered the shared faulty condition in the other checkout steps and job-selection logic. This PR supersedes #2391 with the broader fix.

## Language / Project Scope

- [x] CI/CD or tooling

## Implementation Details

- Use `inputs.ref || github.sha` in all 18 checkout steps, including the tunnel job.
- Detect reusable calls from the required `inputs.ref`, so path filtering, job selection, and changeset gating honor caller inputs, including explicit `false` overrides.
- Pass the dispatched PR number to the approval scripts through an environment variable instead of reading an unset action input.
- Grant promotion the permissions needed to update refs and comment on the PR. Give the CI caller the permissions required by its reporting jobs while retaining read-only access to repository contents.
- Select TypeScript and create-app tests when either CI workflow file changes in an approved PR.

No package, dependency, or changeset changes.

## Review Readiness

- [x] Scoped to the reusable CI and fork-approval flow
- [x] Description explains the problem and fix
- [x] Diff avoids unrelated formatting and generated files
- [x] Affected workflow configuration verified locally
- [x] Checked existing open PRs; credits and supersedes #2391

## Testing

- Both workflows pass GitHub's workflow parser/schema validation.
- A temporary local harness using GitHub's expression evaluator and mocked approval API calls passes all 15 checks. It covers checkout refs, push/PR fallback behavior, every combination of job-selection flags, changeset overrides, PR-number propagation, new/existing promoted branches, changed-file selection, and caller/callee permissions. The same harness failed 12 checks against the original files. The harness is not included in this PR.
- Prettier checks pass for both workflow files.
- `git diff --cached --check` passes.

A live custom fork-approval run has not been performed; the validation above is local and uses mocked API calls.

## Backwards Compatibility

Ordinary push and pull-request runs continue to use `github.sha` and path-filter outputs. Reusable calls now honor their supplied ref and flags.

## Related Issues

Supersedes #2391. GitHub's [reusable-workflow context documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations#github-context) describes the inherited caller context.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes reusable workflow calls in CI so they now honor the supplied ref and job-selection flags. Previously, `approve-fork-pr.yml` calls to `ci.yml` ignored the promoted commit ref and inputs, running on the wrong commit and with default job selection. Now the reusable workflow uses `inputs.ref` to detect calls and uses that ref in all checkout steps, and job selection respects the caller's flags. Ordinary push and pull-request runs are unaffected.

**Bug Fixes**
- Detects reusable calls from the presence of `inputs.ref` instead of the `workflow_call` event name, which is lost when reusing workflows.
- Passes the PR number to approval scripts via an environment variable instead of an unset action input.
- Adjusts permissions so the approval workflow can promote refs and comment, while the CI caller only needs read access plus pull-request write for reporting.
- Runs TypeScript and create-app tests when either CI workflow file changes in an approved fork PR.

<sup>Written for commit a0ce61cec2e66f7321c7dc6136ab9adc7fa663b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

