### PR TITLE
fix(client): clean up sandbox message listener and cancel readiness wait on unmount in ViewRenderer

### DIFF
--- a/libraries/typescript/.changeset/fix-viewrenderer-sandbox-cleanup.md
+++ b/libraries/typescript/.changeset/fix-viewrenderer-sandbox-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Clean up sandbox proxy message listener on unmount and add timeout in `ViewRenderer`.

--- a/libraries/typescript/.changeset/fix-viewrenderer-sandbox-cleanup.md
+++ b/libraries/typescript/.changeset/fix-viewrenderer-sandbox-cleanup.md
@@ -2,4 +2,4 @@
 "@mcp-use/client": patch
 ---
 
-Clean up sandbox proxy message listener on unmount and add timeout in `ViewRenderer`.
+Clean up sandbox proxy message listener and cancel pending readiness wait on `ViewRenderer` unmount.

--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -70,13 +70,17 @@ function CloseIcon() {
   );
 }
 
-function waitForSandboxProxyReady(
+/** @internal */
+export function waitForSandboxProxyReady(
   iframe: HTMLIFrameElement,
-  options?: { signal?: AbortSignal }
+  options?: { signal?: AbortSignal; timeoutMs?: number }
 ): Promise<void> {
   return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
     const cleanup = () => {
       window.removeEventListener("message", listener);
+      if (timer !== undefined) clearTimeout(timer);
       options?.signal?.removeEventListener("abort", onAbort);
     };
 
@@ -100,6 +104,17 @@ function waitForSandboxProxyReady(
       return;
     }
     options?.signal?.addEventListener("abort", onAbort, { once: true });
+
+    if (options?.timeoutMs !== undefined && options.timeoutMs > 0) {
+      timer = setTimeout(() => {
+        cleanup();
+        reject(
+          new Error(
+            `Sandbox proxy did not become ready within ${options.timeoutMs}ms`
+          )
+        );
+      }, options.timeoutMs);
+    }
 
     window.addEventListener("message", listener);
   });

--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -73,15 +73,11 @@ function CloseIcon() {
 /** @internal */
 export function waitForSandboxProxyReady(
   iframe: HTMLIFrameElement,
-  options?: { signal?: AbortSignal; timeoutMs?: number }
+  options?: { signal?: AbortSignal }
 ): Promise<void> {
-  const timeoutMs = options?.timeoutMs ?? 15_000;
   return new Promise((resolve, reject) => {
-    let timer: ReturnType<typeof setTimeout> | undefined;
-
     const cleanup = () => {
       window.removeEventListener("message", listener);
-      if (timer !== undefined) clearTimeout(timer);
       options?.signal?.removeEventListener("abort", onAbort);
     };
 
@@ -105,15 +101,6 @@ export function waitForSandboxProxyReady(
       return;
     }
     options?.signal?.addEventListener("abort", onAbort, { once: true });
-
-    if (timeoutMs > 0 && timeoutMs !== Infinity) {
-      timer = setTimeout(() => {
-        cleanup();
-        reject(
-          new Error(`Sandbox proxy did not become ready within ${timeoutMs}ms`)
-        );
-      }, timeoutMs);
-    }
 
     window.addEventListener("message", listener);
   });

--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -75,6 +75,7 @@ export function waitForSandboxProxyReady(
   iframe: HTMLIFrameElement,
   options?: { signal?: AbortSignal; timeoutMs?: number }
 ): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? 15_000;
   return new Promise((resolve, reject) => {
     let timer: ReturnType<typeof setTimeout> | undefined;
 
@@ -105,15 +106,13 @@ export function waitForSandboxProxyReady(
     }
     options?.signal?.addEventListener("abort", onAbort, { once: true });
 
-    if (options?.timeoutMs !== undefined && options.timeoutMs > 0) {
+    if (timeoutMs > 0 && timeoutMs !== Infinity) {
       timer = setTimeout(() => {
         cleanup();
         reject(
-          new Error(
-            `Sandbox proxy did not become ready within ${options.timeoutMs}ms`
-          )
+          new Error(`Sandbox proxy did not become ready within ${timeoutMs}ms`)
         );
-      }, options.timeoutMs);
+      }, timeoutMs);
     }
 
     window.addEventListener("message", listener);

--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -496,19 +496,23 @@ function ViewRendererBase({
           iframe.setAttribute("allow", allowAttribute);
         }
 
-        const readyPromise = waitForSandboxProxyReady(iframe, {
-          signal: abortController.signal,
-        });
         if (activeSandboxUrl.protocol === "blob:") {
           const response = await fetch(activeSandboxUrl.href);
           const sandboxHtml = await response.text();
-          if (disposed) return;
+          if (disposed || abortController.signal.aborted) return;
+          const readyPromise = waitForSandboxProxyReady(iframe, {
+            signal: abortController.signal,
+          });
           iframe.srcdoc = sandboxHtml;
+          await readyPromise;
         } else {
+          const readyPromise = waitForSandboxProxyReady(iframe, {
+            signal: abortController.signal,
+          });
           iframe.src = activeSandboxUrl.href;
+          await readyPromise;
         }
-        await readyPromise;
-        if (disposed) return;
+        if (disposed || abortController.signal.aborted) return;
 
         const capabilities: McpUiHostCapabilities = {
           ...effectiveHostCapabilities,

--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -70,17 +70,50 @@ function CloseIcon() {
   );
 }
 
-function waitForSandboxProxyReady(iframe: HTMLIFrameElement): Promise<void> {
-  return new Promise((resolve) => {
+function waitForSandboxProxyReady(
+  iframe: HTMLIFrameElement,
+  options?: { timeoutMs?: number; signal?: AbortSignal }
+): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? 15_000;
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      window.removeEventListener("message", listener);
+      if (timer !== undefined) clearTimeout(timer);
+      options?.signal?.removeEventListener("abort", onAbort);
+    };
+
     const listener = (event: MessageEvent) => {
       if (
         event.source === iframe.contentWindow &&
         event.data?.method === SANDBOX_PROXY_READY
       ) {
-        window.removeEventListener("message", listener);
+        cleanup();
         resolve();
       }
     };
+
+    const onAbort = () => {
+      cleanup();
+      reject(new Error("View sandbox initialization was aborted"));
+    };
+
+    if (options?.signal?.aborted) {
+      onAbort();
+      return;
+    }
+    options?.signal?.addEventListener("abort", onAbort, { once: true });
+
+    if (timeoutMs > 0 && timeoutMs !== Infinity) {
+      timer = setTimeout(() => {
+        cleanup();
+        reject(
+          new Error(`Sandbox proxy did not become ready within ${timeoutMs}ms`)
+        );
+      }, timeoutMs);
+    }
+
     window.addEventListener("message", listener);
   });
 }
@@ -449,6 +482,7 @@ function ViewRendererBase({
 
     let disposed = false;
     let bridge: AppBridge | null = null;
+    const abortController = new AbortController();
 
     const run = async () => {
       try {
@@ -462,7 +496,9 @@ function ViewRendererBase({
           iframe.setAttribute("allow", allowAttribute);
         }
 
-        const readyPromise = waitForSandboxProxyReady(iframe);
+        const readyPromise = waitForSandboxProxyReady(iframe, {
+          signal: abortController.signal,
+        });
         if (activeSandboxUrl.protocol === "blob:") {
           const response = await fetch(activeSandboxUrl.href);
           const sandboxHtml = await response.text();
@@ -716,7 +752,7 @@ function ViewRendererBase({
 
         onLifecycleChangeRef.current?.({ status: "ready" });
       } catch (err) {
-        if (!disposed) {
+        if (!disposed && !abortController.signal.aborted) {
           const message =
             err instanceof Error ? err.message : "Failed to connect view";
           setLoadError(message);
@@ -730,6 +766,7 @@ function ViewRendererBase({
 
     return () => {
       disposed = true;
+      abortController.abort();
       const toClose = bridge;
       bridgeRef.current = null;
       onAppToolsChangedRef.current?.(null);

--- a/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
+++ b/libraries/typescript/packages/client/src/react/view/ViewRenderer.tsx
@@ -72,15 +72,11 @@ function CloseIcon() {
 
 function waitForSandboxProxyReady(
   iframe: HTMLIFrameElement,
-  options?: { timeoutMs?: number; signal?: AbortSignal }
+  options?: { signal?: AbortSignal }
 ): Promise<void> {
-  const timeoutMs = options?.timeoutMs ?? 15_000;
   return new Promise((resolve, reject) => {
-    let timer: ReturnType<typeof setTimeout> | undefined;
-
     const cleanup = () => {
       window.removeEventListener("message", listener);
-      if (timer !== undefined) clearTimeout(timer);
       options?.signal?.removeEventListener("abort", onAbort);
     };
 
@@ -104,15 +100,6 @@ function waitForSandboxProxyReady(
       return;
     }
     options?.signal?.addEventListener("abort", onAbort, { once: true });
-
-    if (timeoutMs > 0 && timeoutMs !== Infinity) {
-      timer = setTimeout(() => {
-        cleanup();
-        reject(
-          new Error(`Sandbox proxy did not become ready within ${timeoutMs}ms`)
-        );
-      }, timeoutMs);
-    }
 
     window.addEventListener("message", listener);
   });

--- a/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
@@ -3,7 +3,10 @@
 import React from "react";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ViewRenderer } from "../../src/react/view/ViewRenderer.js";
+import {
+  ViewRenderer,
+  waitForSandboxProxyReady,
+} from "../../src/react/view/ViewRenderer.js";
 import type {
   ViewLifecycleEvent,
   ViewRendererSource,
@@ -127,5 +130,47 @@ describe("ViewRenderer sandbox lifecycle cleanup", () => {
     await act(async () => {
       renderer.unmount();
     });
+  });
+
+  it("handles timeout and cleans up window message listener", async () => {
+    vi.useFakeTimers();
+    const sandboxWindow = {} as Window;
+    const iframe = { contentWindow: sandboxWindow } as HTMLIFrameElement;
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+    const promise = waitForSandboxProxyReady(iframe, { timeoutMs: 5000 });
+    const expectation = expect(promise).rejects.toThrow(
+      "Sandbox proxy did not become ready within 5000ms"
+    );
+
+    await vi.advanceTimersByTimeAsync(5001);
+    await expectation;
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function)
+    );
+  });
+
+  it("handles abort signal and cleans up window message listener", async () => {
+    const sandboxWindow = {} as Window;
+    const iframe = { contentWindow: sandboxWindow } as HTMLIFrameElement;
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    const abortController = new AbortController();
+
+    const promise = waitForSandboxProxyReady(iframe, {
+      signal: abortController.signal,
+    });
+    const expectation = expect(promise).rejects.toThrow(
+      "View sandbox initialization was aborted"
+    );
+
+    abortController.abort();
+    await expectation;
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function)
+    );
   });
 });

--- a/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
@@ -70,7 +70,7 @@ describe("ViewRenderer sandbox cleanup & timeout", () => {
     );
   });
 
-  it("cleans up listener and transitions to ready when SANDBOX_PROXY_READY is received", async () => {
+  it("cleans up listener when SANDBOX_PROXY_READY is received", async () => {
     const sandboxWindow = {} as Window;
     const lifecycleEvents: ViewLifecycleEvent[] = [];
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
@@ -119,11 +119,12 @@ describe("ViewRenderer sandbox cleanup & timeout", () => {
     });
   });
 
-  it("handles sandbox handshake timeout and transitions to error status", async () => {
+  it("handles sandbox handshake timeout, transitions to error status, and cleans up listener", async () => {
     vi.useFakeTimers();
     const sandboxWindow = {} as Window;
     const lifecycleEvents: ViewLifecycleEvent[] = [];
     const onError = vi.fn();
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
     let renderer!: ReactTestRenderer;
 
     await act(async () => {
@@ -163,6 +164,10 @@ describe("ViewRenderer sandbox cleanup & timeout", () => {
         status: "error",
         error: expect.stringContaining("Sandbox proxy did not become ready"),
       })
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function)
     );
 
     await act(async () => {

--- a/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
@@ -173,4 +173,60 @@ describe("ViewRenderer sandbox lifecycle cleanup", () => {
       expect.any(Function)
     );
   });
+
+  it("handles default handshake timeout in ViewRenderer and transitions to error status", async () => {
+    vi.useFakeTimers();
+    const sandboxWindow = {} as Window;
+    const lifecycleEvents: ViewLifecycleEvent[] = [];
+    const onError = vi.fn();
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <ViewRenderer
+          viewId="default-timeout-test"
+          source={source}
+          sandboxUrl={sandboxUrl}
+          onError={onError}
+          onLifecycleChange={(event) => lifecycleEvents.push(event)}
+        />,
+        {
+          createNodeMock: (element) =>
+            element.type === "iframe"
+              ? {
+                  contentWindow: sandboxWindow,
+                  setAttribute: vi.fn(),
+                  src: "",
+                }
+              : {},
+        }
+      );
+    });
+
+    expect(lifecycleEvents).toContainEqual({ status: "connecting" });
+
+    // Advance timers past default 15s handshake timeout
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16000);
+    });
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringContaining("Sandbox proxy did not become ready")
+    );
+    expect(lifecycleEvents).toContainEqual(
+      expect.objectContaining({
+        status: "error",
+        error: expect.stringContaining("Sandbox proxy did not become ready"),
+      })
+    );
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function)
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
 });

--- a/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
@@ -27,8 +27,10 @@ describe("ViewRenderer sandbox lifecycle cleanup", () => {
     vi.restoreAllMocks();
   });
 
-  it("removes window message listener and cancels silently when unmounted before proxy ready", async () => {
-    const sandboxWindow = {} as Window;
+  it("removes exact window message listener and cancels silently when unmounted before proxy ready", async () => {
+    const sandboxWindow = {
+      postMessage: vi.fn(),
+    } as unknown as Window;
     const onError = vi.fn();
     const lifecycleEvents: ViewLifecycleEvent[] = [];
     let renderer!: ReactTestRenderer;
@@ -57,23 +59,23 @@ describe("ViewRenderer sandbox lifecycle cleanup", () => {
       );
     });
 
-    // Verify message listener was attached
-    const messageAddCalls = addEventListenerSpy.mock.calls.filter(
-      (call) => call[0] === "message"
+    // The readiness wait registers a message listener without capture phase (options !== true)
+    const readinessAddCalls = addEventListenerSpy.mock.calls.filter(
+      (call) => call[0] === "message" && call[2] !== true
     );
-    expect(messageAddCalls.length).toBeGreaterThan(0);
+    expect(readinessAddCalls.length).toBe(1);
+    const registeredWaitListener = readinessAddCalls[0]?.[1];
+    expect(registeredWaitListener).toBeTypeOf("function");
 
     // Unmount before SANDBOX_PROXY_READY is received
     await act(async () => {
       renderer.unmount();
     });
 
-    // Verify message listeners were removed on unmount
-    const messageRemoveCalls = removeEventListenerSpy.mock.calls.filter(
-      (call) => call[0] === "message"
-    );
-    expect(messageRemoveCalls.length).toBeGreaterThanOrEqual(
-      messageAddCalls.length
+    // Verify the exact readiness listener was removed on unmount
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "message",
+      registeredWaitListener
     );
 
     // Unmount should cancel silently without triggering onError or error lifecycle event
@@ -83,9 +85,12 @@ describe("ViewRenderer sandbox lifecycle cleanup", () => {
     );
   });
 
-  it("cleans up listener when SANDBOX_PROXY_READY is received", async () => {
-    const sandboxWindow = {} as Window;
+  it("cleans up exact listener when SANDBOX_PROXY_READY is received", async () => {
+    const sandboxWindow = {
+      postMessage: vi.fn(),
+    } as unknown as Window;
     const lifecycleEvents: ViewLifecycleEvent[] = [];
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
     let renderer!: ReactTestRenderer;
 
@@ -110,6 +115,12 @@ describe("ViewRenderer sandbox lifecycle cleanup", () => {
       );
     });
 
+    const readinessAddCalls = addEventListenerSpy.mock.calls.filter(
+      (call) => call[0] === "message" && call[2] !== true
+    );
+    const registeredWaitListener = readinessAddCalls[0]?.[1];
+    expect(registeredWaitListener).toBeTypeOf("function");
+
     // Send SANDBOX_PROXY_READY from the iframe
     const readyEvent = new MessageEvent("message", {
       data: { method: "ui/notifications/sandbox-proxy-ready" },
@@ -121,10 +132,10 @@ describe("ViewRenderer sandbox lifecycle cleanup", () => {
       window.dispatchEvent(readyEvent);
     });
 
-    // The ready listener should clean itself up upon resolution
+    // The ready listener should clean itself up upon resolution with the exact function
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       "message",
-      expect.any(Function)
+      registeredWaitListener
     );
 
     await act(async () => {
@@ -132,35 +143,23 @@ describe("ViewRenderer sandbox lifecycle cleanup", () => {
     });
   });
 
-  it("handles timeout and cleans up window message listener", async () => {
-    vi.useFakeTimers();
-    const sandboxWindow = {} as Window;
+  it("handles abort signal and cleans up exact window message listener in waitForSandboxProxyReady", async () => {
+    const sandboxWindow = {
+      postMessage: vi.fn(),
+    } as unknown as Window;
     const iframe = { contentWindow: sandboxWindow } as HTMLIFrameElement;
-    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
-
-    const promise = waitForSandboxProxyReady(iframe, { timeoutMs: 5000 });
-    const expectation = expect(promise).rejects.toThrow(
-      "Sandbox proxy did not become ready within 5000ms"
-    );
-
-    await vi.advanceTimersByTimeAsync(5001);
-    await expectation;
-
-    expect(removeEventListenerSpy).toHaveBeenCalledWith(
-      "message",
-      expect.any(Function)
-    );
-  });
-
-  it("handles abort signal and cleans up window message listener", async () => {
-    const sandboxWindow = {} as Window;
-    const iframe = { contentWindow: sandboxWindow } as HTMLIFrameElement;
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
     const abortController = new AbortController();
 
     const promise = waitForSandboxProxyReady(iframe, {
       signal: abortController.signal,
     });
+    const registeredListener = addEventListenerSpy.mock.calls.find(
+      (call) => call[0] === "message"
+    )?.[1];
+    expect(registeredListener).toBeTypeOf("function");
+
     const expectation = expect(promise).rejects.toThrow(
       "View sandbox initialization was aborted"
     );
@@ -170,22 +169,25 @@ describe("ViewRenderer sandbox lifecycle cleanup", () => {
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       "message",
-      expect.any(Function)
+      registeredListener
     );
   });
 
-  it("handles default handshake timeout in ViewRenderer and transitions to error status", async () => {
+  it("allows slow initialization beyond 15s without timeout and continues when ready", async () => {
     vi.useFakeTimers();
-    const sandboxWindow = {} as Window;
+    const sandboxWindow = {
+      postMessage: vi.fn(),
+    } as unknown as Window;
     const lifecycleEvents: ViewLifecycleEvent[] = [];
     const onError = vi.fn();
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
     let renderer!: ReactTestRenderer;
 
     await act(async () => {
       renderer = create(
         <ViewRenderer
-          viewId="default-timeout-test"
+          viewId="slow-init-test"
           source={source}
           sandboxUrl={sandboxUrl}
           onError={onError}
@@ -206,27 +208,218 @@ describe("ViewRenderer sandbox lifecycle cleanup", () => {
 
     expect(lifecycleEvents).toContainEqual({ status: "connecting" });
 
-    // Advance timers past default 15s handshake timeout
+    const registeredWaitListener = addEventListenerSpy.mock.calls.find(
+      (call) => call[0] === "message" && call[2] !== true
+    )?.[1];
+    expect(registeredWaitListener).toBeTypeOf("function");
+
+    // Advance fake timers well beyond 15 seconds (e.g. 30 seconds)
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(16000);
+      await vi.advanceTimersByTimeAsync(30_000);
     });
 
-    expect(onError).toHaveBeenCalledWith(
-      expect.stringContaining("Sandbox proxy did not become ready")
+    // Must NOT have timed out: no onError, no error status, listener remains attached
+    expect(onError).not.toHaveBeenCalled();
+    expect(lifecycleEvents).not.toContainEqual(
+      expect.objectContaining({ status: "error" })
     );
-    expect(lifecycleEvents).toContainEqual(
-      expect.objectContaining({
-        status: "error",
-        error: expect.stringContaining("Sandbox proxy did not become ready"),
-      })
+    expect(removeEventListenerSpy).not.toHaveBeenCalledWith(
+      "message",
+      registeredWaitListener
     );
+
+    // Deliver SANDBOX_PROXY_READY
+    const readyEvent = new MessageEvent("message", {
+      data: { method: "ui/notifications/sandbox-proxy-ready" },
+      origin: "https://sandbox.example",
+    });
+    Object.defineProperty(readyEvent, "source", { value: sandboxWindow });
+
+    await act(async () => {
+      window.dispatchEvent(readyEvent);
+    });
+
+    // The listener should now be removed with the exact function
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       "message",
-      expect.any(Function)
+      registeredWaitListener
+    );
+
+    // Initialization continues without error
+    expect(onError).not.toHaveBeenCalled();
+    expect(lifecycleEvents).not.toContainEqual(
+      expect.objectContaining({ status: "error" })
     );
 
     await act(async () => {
       renderer.unmount();
     });
+  });
+
+  it("cleans up previous exact listener silently and accepts readiness on replaced bridge effect", async () => {
+    const sandboxWindow = {
+      postMessage: vi.fn(),
+    } as unknown as Window;
+    const lifecycleEvents: ViewLifecycleEvent[] = [];
+    const onError = vi.fn();
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <ViewRenderer
+          viewId="initial-view-id"
+          source={source}
+          sandboxUrl={sandboxUrl}
+          onError={onError}
+          onLifecycleChange={(event) => lifecycleEvents.push(event)}
+        />,
+        {
+          createNodeMock: (element) =>
+            element.type === "iframe"
+              ? {
+                  contentWindow: sandboxWindow,
+                  setAttribute: vi.fn(),
+                  src: "",
+                }
+              : {},
+        }
+      );
+    });
+
+    const firstWaitListener = addEventListenerSpy.mock.calls.find(
+      (call) => call[0] === "message" && call[2] !== true
+    )?.[1];
+    expect(firstWaitListener).toBeTypeOf("function");
+
+    // Change viewId dependency to trigger effect teardown and re-run
+    await act(async () => {
+      renderer.update(
+        <ViewRenderer
+          viewId="replaced-view-id"
+          source={source}
+          sandboxUrl={sandboxUrl}
+          onError={onError}
+          onLifecycleChange={(event) => lifecycleEvents.push(event)}
+        />
+      );
+    });
+
+    // Previous wait's exact listener must be removed
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "message",
+      firstWaitListener
+    );
+
+    // Cancellation of previous wait must be silent
+    expect(onError).not.toHaveBeenCalled();
+    expect(lifecycleEvents).not.toContainEqual(
+      expect.objectContaining({ status: "error" })
+    );
+
+    // Find the replacement readiness listener
+    const secondWaitListener = addEventListenerSpy.mock.calls
+      .filter((call) => call[0] === "message" && call[2] !== true)
+      .map((call) => call[1])
+      .find((listener) => listener !== firstWaitListener);
+    expect(secondWaitListener).toBeTypeOf("function");
+
+    // Deliver SANDBOX_PROXY_READY to the replacement wait
+    const readyEvent = new MessageEvent("message", {
+      data: { method: "ui/notifications/sandbox-proxy-ready" },
+      origin: "https://sandbox.example",
+    });
+    Object.defineProperty(readyEvent, "source", { value: sandboxWindow });
+
+    await act(async () => {
+      window.dispatchEvent(readyEvent);
+    });
+
+    // Replacement wait cleans up its exact listener upon receiving readiness
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "message",
+      secondWaitListener
+    );
+
+    // Initialization continues cleanly
+    expect(onError).not.toHaveBeenCalled();
+    expect(lifecycleEvents).not.toContainEqual(
+      expect.objectContaining({ status: "error" })
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it("aborts cleanly when unmounted during blob loading without attaching listener or resuming initialization", async () => {
+    let resolveFetch!: (value: unknown) => void;
+    const fetchDeferred = new Promise((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => fetchDeferred as Promise<Response>);
+
+    const blobUrl = new URL("blob:https://sandbox.example/test-blob-uuid");
+    const onError = vi.fn();
+    const lifecycleEvents: ViewLifecycleEvent[] = [];
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+    const iframeMock = {
+      contentWindow: {} as Window,
+      setAttribute: vi.fn(),
+      src: "",
+      srcdoc: "",
+    };
+
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <ViewRenderer
+          viewId="blob-unmount-test"
+          source={source}
+          sandboxUrl={blobUrl}
+          onError={onError}
+          onLifecycleChange={(event) => lifecycleEvents.push(event)}
+        />,
+        {
+          createNodeMock: (element) =>
+            element.type === "iframe" ? iframeMock : {},
+        }
+      );
+    });
+
+    // fetch was initiated for the blob
+    expect(fetchSpy).toHaveBeenCalledWith(blobUrl.href);
+
+    // Unmount while fetch is still pending
+    await act(async () => {
+      renderer.unmount();
+    });
+
+    // Now resolve the deferred fetch and response text
+    await act(async () => {
+      resolveFetch({
+        text: async () => "<html><body>deferred content</body></html>",
+      });
+      await Promise.resolve();
+    });
+
+    // Verify no readiness listener was attached to window
+    const readinessAddCalls = addEventListenerSpy.mock.calls.filter(
+      (call) => call[0] === "message" && call[2] !== true
+    );
+    expect(readinessAddCalls.length).toBe(0);
+
+    // Verify iframe.srcdoc was never assigned and initialization did not resume
+    expect(iframeMock.srcdoc).toBe("");
+
+    // Verify no error was triggered
+    expect(onError).not.toHaveBeenCalled();
+    expect(lifecycleEvents).not.toContainEqual(
+      expect.objectContaining({ status: "error" })
+    );
   });
 });

--- a/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
@@ -9,7 +9,7 @@ import type {
   ViewRendererSource,
 } from "../../src/react/view/types.js";
 
-describe("ViewRenderer sandbox cleanup & timeout", () => {
+describe("ViewRenderer sandbox lifecycle cleanup", () => {
   const source: ViewRendererSource = {
     kind: "preloaded",
     html: "<html><body>widget</body></html>",
@@ -24,8 +24,10 @@ describe("ViewRenderer sandbox cleanup & timeout", () => {
     vi.restoreAllMocks();
   });
 
-  it("removes window message listener when unmounted before proxy ready", async () => {
+  it("removes window message listener and cancels silently when unmounted before proxy ready", async () => {
     const sandboxWindow = {} as Window;
+    const onError = vi.fn();
+    const lifecycleEvents: ViewLifecycleEvent[] = [];
     let renderer!: ReactTestRenderer;
     const addEventListenerSpy = vi.spyOn(window, "addEventListener");
     const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
@@ -36,6 +38,8 @@ describe("ViewRenderer sandbox cleanup & timeout", () => {
           viewId="cleanup-test"
           source={source}
           sandboxUrl={sandboxUrl}
+          onError={onError}
+          onLifecycleChange={(event) => lifecycleEvents.push(event)}
         />,
         {
           createNodeMock: (element) =>
@@ -67,6 +71,12 @@ describe("ViewRenderer sandbox cleanup & timeout", () => {
     );
     expect(messageRemoveCalls.length).toBeGreaterThanOrEqual(
       messageAddCalls.length
+    );
+
+    // Unmount should cancel silently without triggering onError or error lifecycle event
+    expect(onError).not.toHaveBeenCalled();
+    expect(lifecycleEvents).not.toContainEqual(
+      expect.objectContaining({ status: "error" })
     );
   });
 
@@ -109,62 +119,6 @@ describe("ViewRenderer sandbox cleanup & timeout", () => {
     });
 
     // The ready listener should clean itself up upon resolution
-    expect(removeEventListenerSpy).toHaveBeenCalledWith(
-      "message",
-      expect.any(Function)
-    );
-
-    await act(async () => {
-      renderer.unmount();
-    });
-  });
-
-  it("handles sandbox handshake timeout, transitions to error status, and cleans up listener", async () => {
-    vi.useFakeTimers();
-    const sandboxWindow = {} as Window;
-    const lifecycleEvents: ViewLifecycleEvent[] = [];
-    const onError = vi.fn();
-    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
-    let renderer!: ReactTestRenderer;
-
-    await act(async () => {
-      renderer = create(
-        <ViewRenderer
-          viewId="timeout-test"
-          source={source}
-          sandboxUrl={sandboxUrl}
-          onError={onError}
-          onLifecycleChange={(event) => lifecycleEvents.push(event)}
-        />,
-        {
-          createNodeMock: (element) =>
-            element.type === "iframe"
-              ? {
-                  contentWindow: sandboxWindow,
-                  setAttribute: vi.fn(),
-                  src: "",
-                }
-              : {},
-        }
-      );
-    });
-
-    expect(lifecycleEvents).toContainEqual({ status: "connecting" });
-
-    // Advance timers past default 15s handshake timeout
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(16000);
-    });
-
-    expect(onError).toHaveBeenCalledWith(
-      expect.stringContaining("Sandbox proxy did not become ready")
-    );
-    expect(lifecycleEvents).toContainEqual(
-      expect.objectContaining({
-        status: "error",
-        error: expect.stringContaining("Sandbox proxy did not become ready"),
-      })
-    );
     expect(removeEventListenerSpy).toHaveBeenCalledWith(
       "message",
       expect.any(Function)

--- a/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ViewRenderer } from "../../src/react/view/ViewRenderer.js";
+import type {
+  ViewLifecycleEvent,
+  ViewRendererSource,
+} from "../../src/react/view/types.js";
+
+describe("ViewRenderer sandbox cleanup & timeout", () => {
+  const source: ViewRendererSource = {
+    kind: "preloaded",
+    html: "<html><body>widget</body></html>",
+  };
+  const sandboxUrl = new URL("https://sandbox.example/widget");
+
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("removes window message listener when unmounted before proxy ready", async () => {
+    const sandboxWindow = {} as Window;
+    let renderer!: ReactTestRenderer;
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+    await act(async () => {
+      renderer = create(
+        <ViewRenderer
+          viewId="cleanup-test"
+          source={source}
+          sandboxUrl={sandboxUrl}
+        />,
+        {
+          createNodeMock: (element) =>
+            element.type === "iframe"
+              ? {
+                  contentWindow: sandboxWindow,
+                  setAttribute: vi.fn(),
+                  src: "",
+                }
+              : {},
+        }
+      );
+    });
+
+    // Verify message listener was attached
+    const messageAddCalls = addEventListenerSpy.mock.calls.filter(
+      (call) => call[0] === "message"
+    );
+    expect(messageAddCalls.length).toBeGreaterThan(0);
+
+    // Unmount before SANDBOX_PROXY_READY is received
+    await act(async () => {
+      renderer.unmount();
+    });
+
+    // Verify message listeners were removed on unmount
+    const messageRemoveCalls = removeEventListenerSpy.mock.calls.filter(
+      (call) => call[0] === "message"
+    );
+    expect(messageRemoveCalls.length).toBeGreaterThanOrEqual(
+      messageAddCalls.length
+    );
+  });
+
+  it("cleans up listener and transitions to ready when SANDBOX_PROXY_READY is received", async () => {
+    const sandboxWindow = {} as Window;
+    const lifecycleEvents: ViewLifecycleEvent[] = [];
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <ViewRenderer
+          viewId="handshake-test"
+          source={source}
+          sandboxUrl={sandboxUrl}
+          onLifecycleChange={(event) => lifecycleEvents.push(event)}
+        />,
+        {
+          createNodeMock: (element) =>
+            element.type === "iframe"
+              ? {
+                  contentWindow: sandboxWindow,
+                  setAttribute: vi.fn(),
+                  src: "",
+                }
+              : {},
+        }
+      );
+    });
+
+    // Send SANDBOX_PROXY_READY from the iframe
+    const readyEvent = new MessageEvent("message", {
+      data: { method: "ui/notifications/sandbox-proxy-ready" },
+      origin: "https://sandbox.example",
+    });
+    Object.defineProperty(readyEvent, "source", { value: sandboxWindow });
+
+    await act(async () => {
+      window.dispatchEvent(readyEvent);
+    });
+
+    // The ready listener should clean itself up upon resolution
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function)
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it("handles sandbox handshake timeout and transitions to error status", async () => {
+    vi.useFakeTimers();
+    const sandboxWindow = {} as Window;
+    const lifecycleEvents: ViewLifecycleEvent[] = [];
+    const onError = vi.fn();
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(
+        <ViewRenderer
+          viewId="timeout-test"
+          source={source}
+          sandboxUrl={sandboxUrl}
+          onError={onError}
+          onLifecycleChange={(event) => lifecycleEvents.push(event)}
+        />,
+        {
+          createNodeMock: (element) =>
+            element.type === "iframe"
+              ? {
+                  contentWindow: sandboxWindow,
+                  setAttribute: vi.fn(),
+                  src: "",
+                }
+              : {},
+        }
+      );
+    });
+
+    expect(lifecycleEvents).toContainEqual({ status: "connecting" });
+
+    // Advance timers past default 15s handshake timeout
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16000);
+    });
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.stringContaining("Sandbox proxy did not become ready")
+    );
+    expect(lifecycleEvents).toContainEqual(
+      expect.objectContaining({
+        status: "error",
+        error: expect.stringContaining("Sandbox proxy did not become ready"),
+      })
+    );
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Cleans up global window `message` event listeners and cancels pending sandbox proxy readiness waits upon `ViewRenderer` unmount or effect teardown.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Added `options?: { signal?: AbortSignal }` to `waitForSandboxProxyReady` in `ViewRenderer.tsx`.
2. Created a guaranteed `cleanup()` callback that detaches the `message` event listener on `window` and cleans up signal listeners whenever the promise resolves or aborts.
3. Connected an `AbortController` in `ViewRendererBase`'s lifecycle effect, invoking `abortController.abort()` on unmount or effect replacement.
4. Ensures unmount cancellations are handled silently without triggering false `onError` callbacks or erroneous error lifecycle states, while allowing mounted views to wait for initialization without an arbitrary timeout deadline.

---

## TypeScript Checklist

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [x] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```tsx
// If ViewRenderer unmounted before receiving SANDBOX_PROXY_READY, window message listener was permanently leaked.
<ViewRenderer viewId="test" source={source} sandboxUrl={sandboxUrl} />
```

## Example Usage (After)

```tsx
// Unmounting cleanly detaches window message listeners and cancels pending wait silently.
<ViewRenderer viewId="test" source={source} sandboxUrl={sandboxUrl} />
```

## Documentation Updates

* N/A (Internal lifecycle bugfix and listener cleanup)

## Testing

Describe how you tested these changes:
- Added `packages/client/tests/unit/view-renderer-sandbox-cleanup.test.tsx` testing:
  - Exact window `message` event listeners are removed and cancelled silently when unmounting prior to sandbox ready.
  - Event listener is detached upon receiving `SANDBOX_PROXY_READY`.
  - Slow initialization beyond 15s allows mounted views to wait without timeout and continues when ready.
  - Effect replacement before readiness removes previous wait's exact listener and cleanly accepts readiness on replacement effect.
  - Unmounting during blob loading aborts cleanly without attaching readiness listeners or resuming initialization.
  - All listener assertions match the exact function instance registered by the wait.
- Ran all related ViewRenderer tests: `pnpm --filter @mcp-use/client test tests/unit/view-renderer*` (3 files, 14 tests passed).
- Ran formatting and linting: `pnpm format && pnpm lint` (0 errors, 0 warnings).

## Backwards Compatibility

Fully backwards compatible.

## Related Issues

Closes #2414