### PR TITLE
fix(cli): warn on env set secret downgrade, document --secret required on every write

### DIFF
--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -503,7 +503,7 @@ mcp-use servers env unset srv_abc123 API_KEY --yes
 
 - `env list` returns metadata only. Values are never returned.
 - `env set` creates a production variable when `--branch` is omitted, or a preview variable when it is supplied.
-- `--secret` marks a value sensitive, but this must be passed on **every** write to the variable, including updates and rotations. Omitting `--secret` on an update stores the value as non-sensitive, even if the existing variable was previously marked sensitive. The CLI prints a warning (and sets `downgradedFromSecret: true` in `--json` output) when a write would downgrade an existing sensitive variable this way.
+- `--secret` stores a value as write-only, but this must be passed on **every** write to the variable, including updates and rotations. Omitting `--secret` on an update stores the value as non-sensitive, even if the existing variable was previously write-only. The CLI prints a short warning (`Warning: <key> is no longer write-only.`) when a write would downgrade an existing write-only variable this way; the resulting state is always reflected in the existing `secret` field of `--json` output.
 - `--branch <name>` scopes preview environment variables to a branch. Omit `--branch` for production resolution.
 - `env unset` prompts for confirmation unless `--yes` is set.
 

--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -503,7 +503,7 @@ mcp-use servers env unset srv_abc123 API_KEY --yes
 
 - `env list` returns metadata only. Values are never returned.
 - `env set` creates a production variable when `--branch` is omitted, or a preview variable when it is supplied.
-- `--secret` marks a value sensitive.
+- `--secret` marks a value sensitive, but this must be passed on **every** write to the variable, including updates and rotations. Omitting `--secret` on an update stores the value as non-sensitive, even if the existing variable was previously marked sensitive. The CLI prints a warning (and sets `downgradedFromSecret: true` in `--json` output) when a write would downgrade an existing sensitive variable this way.
 - `--branch <name>` scopes preview environment variables to a branch. Omit `--branch` for production resolution.
 - `env unset` prompts for confirmation unless `--yes` is set.
 

--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -503,7 +503,7 @@ mcp-use servers env unset srv_abc123 API_KEY --yes
 
 - `env list` returns metadata only. Values are never returned.
 - `env set` creates a production variable when `--branch` is omitted, or a preview variable when it is supplied.
-- `--secret` stores a value as write-only, but this must be passed on **every** write to the variable, including updates and rotations. Omitting `--secret` on an update stores the value as non-sensitive, even if the existing variable was previously write-only. The CLI prints a short warning (`Warning: <key> is no longer write-only.`) when a write would downgrade an existing write-only variable this way; the resulting state is always reflected in the existing `secret` field of `--json` output.
+- `--secret` stores a value as write-only. It must be passed on **every** write to the variable, including updates and rotations: omitting it stores the value as non-sensitive, even if the variable was previously write-only.
 - `--branch <name>` scopes preview environment variables to a branch. Omit `--branch` for production resolution.
 - `env unset` prompts for confirmation unless `--yes` is set.
 

--- a/libraries/typescript/.changeset/fancy-crabs-unite.md
+++ b/libraries/typescript/.changeset/fancy-crabs-unite.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Warn when env set would silently downgrade an existing sensitive variable, and document that --secret is required on every write

--- a/libraries/typescript/.changeset/fancy-crabs-unite.md
+++ b/libraries/typescript/.changeset/fancy-crabs-unite.md
@@ -2,4 +2,4 @@
 "@mcp-use/cli": patch
 ---
 
-Warn when env set would silently downgrade an existing sensitive variable, and document that --secret is required on every write
+Document that `--secret` must be passed on every `servers env set` write, including updates and rotations, and say so in the success message when a value is stored write-only

--- a/libraries/typescript/.changeset/itchy-worms-hear.md
+++ b/libraries/typescript/.changeset/itchy-worms-hear.md
@@ -1,5 +1,0 @@
----
-"@mcp-use/cli": patch
----
-
-Preserve the existing sensitive flag when rotating an environment variable without --secret

--- a/libraries/typescript/.changeset/itchy-worms-hear.md
+++ b/libraries/typescript/.changeset/itchy-worms-hear.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Preserve the existing sensitive flag when rotating an environment variable without --secret

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -290,12 +290,14 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
+  const sensitive =
+    values.secret === true ? true : (existing?.sensitive ?? false);
   const body = {
     key,
     value,
     branch: values.branch ?? null,
     environments: values.branch === undefined ? ["production"] : ["preview"],
-    sensitive: values.secret === true,
+    sensitive,
   };
   if (existing === undefined) {
     await api.request<unknown>(
@@ -313,7 +315,7 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     key,
     scope: values.branch === undefined ? "production" : "preview",
     branch: values.branch ?? null,
-    secret: values.secret === true,
+    secret: sensitive,
     updated: existing !== undefined,
   };
   printResult(result, json, `Set ${key}.`);

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -290,8 +290,7 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
-  const sensitive =
-    values.secret === true ? true : (existing?.sensitive ?? false);
+  const sensitive = values.secret === true || (existing?.sensitive ?? false);
   const body = {
     key,
     value,

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -29,7 +29,7 @@ Commands:
   update <id-or-slug>          Update server metadata or build configuration
   delete <id-or-slug>          Delete a server
   env list <server>            List environment variable metadata
-  env set <server> <KEY=VALUE> Create or update an environment variable (--secret required on every write to keep it sensitive)
+  env set <server> <KEY=VALUE> Create or update an environment variable
   env unset <server> <key>     Delete an environment variable
 
 Run mcp-use servers <command> --help for all options.
@@ -51,7 +51,7 @@ const COMMAND_HELP: Record<string, string> = {
   delete: `Usage: mcp-use servers delete <id-or-slug> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --yes               Confirm deletion without prompting\n  --json              Emit the deletion result; never prompt\n  -h, --help          Show this help`,
   env: `Usage: mcp-use servers env <list|set|unset> [options]\n\nCommands:\n  list <server>             List keys and metadata; values are never returned\n  set <server> <KEY=VALUE> Create or update a value\n  unset <server> <key>     Delete a value\n\nRun mcp-use servers env <command> --help for all options.`,
   "env list": `Usage: mcp-use servers env list <server> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Select preview variables for a branch\n  --json              Emit metadata only; never values\n  -h, --help          Show this help`,
-  "env set": `Usage: mcp-use servers env set <server> <KEY=VALUE> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Set a preview value for a branch (default: production)\n  --secret            Store the value as a sensitive, write-only secret. Required on every write, including updates and rotations. Without this flag, the value is stored as non-sensitive, even if the existing variable was sensitive.\n  --json              Emit mutation metadata only; never the value\n  -h, --help          Show this help`,
+  "env set": `Usage: mcp-use servers env set <server> <KEY=VALUE> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Set a preview value for a branch (default: production)\n  --secret            Store the value as a write-only secret. Required on every write to keep it write-only.\n  --json              Emit mutation metadata only; never the value\n  -h, --help          Show this help`,
   "env unset": `Usage: mcp-use servers env unset <server> <key> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Delete a preview value for a branch\n  --yes               Confirm deletion without prompting\n  --json              Emit the deletion result; never prompt\n  -h, --help          Show this help`,
 };
 
@@ -318,11 +318,12 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     branch: values.branch ?? null,
     secret: values.secret === true,
     updated: existing !== undefined,
-    ...(downgradesExistingSecret ? { downgradedFromSecret: true } : {}),
   };
   const message = downgradesExistingSecret
-    ? `Set ${key}. Warning: this variable was previously sensitive and is now stored as non-sensitive because --secret was not passed.`
-    : `Set ${key}.`;
+    ? `Warning: ${key} is no longer write-only.`
+    : values.secret === true
+      ? `Set ${key} (saved as write-only).`
+      : `Set ${key} (saved as non-sensitive).`;
   printResult(result, json, message);
   return 0;
 }

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -29,7 +29,7 @@ Commands:
   update <id-or-slug>          Update server metadata or build configuration
   delete <id-or-slug>          Delete a server
   env list <server>            List environment variable metadata
-  env set <server> <KEY=VALUE> Create or update an environment variable
+  env set <server> <KEY=VALUE> Create or update an environment variable (--secret required on every write to keep it sensitive)
   env unset <server> <key>     Delete an environment variable
 
 Run mcp-use servers <command> --help for all options.
@@ -51,7 +51,7 @@ const COMMAND_HELP: Record<string, string> = {
   delete: `Usage: mcp-use servers delete <id-or-slug> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --yes               Confirm deletion without prompting\n  --json              Emit the deletion result; never prompt\n  -h, --help          Show this help`,
   env: `Usage: mcp-use servers env <list|set|unset> [options]\n\nCommands:\n  list <server>             List keys and metadata; values are never returned\n  set <server> <KEY=VALUE> Create or update a value\n  unset <server> <key>     Delete a value\n\nRun mcp-use servers env <command> --help for all options.`,
   "env list": `Usage: mcp-use servers env list <server> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Select preview variables for a branch\n  --json              Emit metadata only; never values\n  -h, --help          Show this help`,
-  "env set": `Usage: mcp-use servers env set <server> <KEY=VALUE> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Set a preview value for a branch (default: production)\n  --secret            Mark the value sensitive\n  --json              Emit mutation metadata only; never the value\n  -h, --help          Show this help`,
+  "env set": `Usage: mcp-use servers env set <server> <KEY=VALUE> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Set a preview value for a branch (default: production)\n  --secret            Store the value as a sensitive, write-only secret. Required on every write, including updates and rotations. Without this flag, the value is stored as non-sensitive, even if the existing variable was sensitive.\n  --json              Emit mutation metadata only; never the value\n  -h, --help          Show this help`,
   "env unset": `Usage: mcp-use servers env unset <server> <key> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Delete a preview value for a branch\n  --yes               Confirm deletion without prompting\n  --json              Emit the deletion result; never prompt\n  -h, --help          Show this help`,
 };
 
@@ -290,7 +290,9 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
-  const sensitive = values.secret === true || (existing?.sensitive ?? false);
+  const sensitive = values.secret === true;
+  const downgradesExistingSecret =
+    existing?.sensitive === true && sensitive === false;
   const body = {
     key,
     value,
@@ -314,10 +316,14 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     key,
     scope: values.branch === undefined ? "production" : "preview",
     branch: values.branch ?? null,
-    secret: sensitive,
+    secret: values.secret === true,
     updated: existing !== undefined,
+    ...(downgradesExistingSecret ? { downgradedFromSecret: true } : {}),
   };
-  printResult(result, json, `Set ${key}.`);
+  const message = downgradesExistingSecret
+    ? `Set ${key}. Warning: this variable was previously sensitive and is now stored as non-sensitive because --secret was not passed.`
+    : `Set ${key}.`;
+  printResult(result, json, message);
   return 0;
 }
 

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -290,15 +290,12 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
-  const sensitive = values.secret === true;
-  const downgradesExistingSecret =
-    existing?.sensitive === true && sensitive === false;
   const body = {
     key,
     value,
     branch: values.branch ?? null,
     environments: values.branch === undefined ? ["production"] : ["preview"],
-    sensitive,
+    sensitive: values.secret === true,
   };
   if (existing === undefined) {
     await api.request<unknown>(
@@ -319,12 +316,11 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     secret: values.secret === true,
     updated: existing !== undefined,
   };
-  const message = downgradesExistingSecret
-    ? `Warning: ${key} is no longer write-only.`
-    : values.secret === true
-      ? `Set ${key} (saved as write-only).`
-      : `Set ${key} (saved as non-sensitive).`;
-  printResult(result, json, message);
+  printResult(
+    result,
+    json,
+    values.secret === true ? `Set ${key} (saved as write-only).` : `Set ${key}.`
+  );
   return 0;
 }
 

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -117,7 +117,7 @@ describe("server environment output safety", () => {
 
     const output = stdout.mock.calls.flat().join("");
     expect(JSON.parse(output)).toMatchObject({
-      downgradedFromSecret: true,
+      secret: false,
     });
   });
 
@@ -138,8 +138,7 @@ describe("server environment output safety", () => {
     ).resolves.toBe(0);
 
     const output = stdout.mock.calls.flat().join("");
-    expect(output).toContain("previously sensitive");
-    expect(output).toContain("non-sensitive");
+    expect(output).toContain("is no longer write-only");
   });
 
   it("does not mark a brand-new variable sensitive by default", async () => {

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -85,7 +85,7 @@ describe("server environment output safety", () => {
     });
   });
 
-  it("preserves an existing sensitive flag when --secret is not repeated on update", async () => {
+  it("clears an existing sensitive flag when --secret is not repeated on update, and warns", async () => {
     api.request
       .mockResolvedValueOnce([{ id: "env_1", key: "TOKEN", sensitive: true }])
       .mockResolvedValueOnce({
@@ -93,7 +93,9 @@ describe("server environment output safety", () => {
         key: "TOKEN",
         value: "rotated",
       });
-    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
 
     await expect(
       runServers(["env", "set", "server_1", "TOKEN=rotated", "--json"])
@@ -108,10 +110,36 @@ describe("server environment output safety", () => {
           value: "rotated",
           branch: null,
           environments: ["production"],
-          sensitive: true,
+          sensitive: false,
         }),
       }
     );
+
+    const output = stdout.mock.calls.flat().join("");
+    expect(JSON.parse(output)).toMatchObject({
+      downgradedFromSecret: true,
+    });
+  });
+
+  it("prints a human-readable warning when a write downgrades an existing secret", async () => {
+    api.request
+      .mockResolvedValueOnce([{ id: "env_1", key: "TOKEN", sensitive: true }])
+      .mockResolvedValueOnce({
+        id: "env_1",
+        key: "TOKEN",
+        value: "rotated",
+      });
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runServers(["env", "set", "server_1", "TOKEN=rotated"])
+    ).resolves.toBe(0);
+
+    const output = stdout.mock.calls.flat().join("");
+    expect(output).toContain("previously sensitive");
+    expect(output).toContain("non-sensitive");
   });
 
   it("does not mark a brand-new variable sensitive by default", async () => {

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -84,6 +84,62 @@ describe("server environment output safety", () => {
       updated: true,
     });
   });
+
+  it("preserves an existing sensitive flag when --secret is not repeated on update", async () => {
+    api.request
+      .mockResolvedValueOnce([{ id: "env_1", key: "TOKEN", sensitive: true }])
+      .mockResolvedValueOnce({
+        id: "env_1",
+        key: "TOKEN",
+        value: "rotated",
+      });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      runServers(["env", "set", "server_1", "TOKEN=rotated", "--json"])
+    ).resolves.toBe(0);
+
+    expect(api.request).toHaveBeenLastCalledWith(
+      "/servers/server_1/env-variables/env_1",
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          key: "TOKEN",
+          value: "rotated",
+          branch: null,
+          environments: ["production"],
+          sensitive: true,
+        }),
+      }
+    );
+  });
+
+  it("does not mark a brand-new variable sensitive by default", async () => {
+    api.request.mockResolvedValueOnce([]).mockResolvedValueOnce({
+      id: "env_2",
+      key: "NEW_VAR",
+      value: "value",
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      runServers(["env", "set", "server_1", "NEW_VAR=value", "--json"])
+    ).resolves.toBe(0);
+
+    expect(api.request).toHaveBeenLastCalledWith(
+      "/servers/server_1/env-variables",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          key: "NEW_VAR",
+          value: "value",
+          branch: null,
+          environments: ["production"],
+          sensitive: false,
+        }),
+      }
+    );
+  });
 });
 
 describe("server human output", () => {

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -85,7 +85,7 @@ describe("server environment output safety", () => {
     });
   });
 
-  it("clears an existing sensitive flag when --secret is not repeated on update, and warns", async () => {
+  it("clears an existing sensitive flag when --secret is not repeated on update", async () => {
     api.request
       .mockResolvedValueOnce([{ id: "env_1", key: "TOKEN", sensitive: true }])
       .mockResolvedValueOnce({
@@ -119,26 +119,6 @@ describe("server environment output safety", () => {
     expect(JSON.parse(output)).toMatchObject({
       secret: false,
     });
-  });
-
-  it("prints a human-readable warning when a write downgrades an existing secret", async () => {
-    api.request
-      .mockResolvedValueOnce([{ id: "env_1", key: "TOKEN", sensitive: true }])
-      .mockResolvedValueOnce({
-        id: "env_1",
-        key: "TOKEN",
-        value: "rotated",
-      });
-    const stdout = vi
-      .spyOn(process.stdout, "write")
-      .mockImplementation(() => true);
-
-    await expect(
-      runServers(["env", "set", "server_1", "TOKEN=rotated"])
-    ).resolves.toBe(0);
-
-    const output = stdout.mock.calls.flat().join("");
-    expect(output).toContain("is no longer write-only");
   });
 
   it("does not mark a brand-new variable sensitive by default", async () => {


### PR DESCRIPTION
## Pull Request Description

### Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

### Changes

Follow-up to #2389 (closed), addressing @khandrew1's feedback on #2388. Scoped to help text, docs, and the success message. `--secret` stays an explicit opt-in required on every write, and the write contract is unchanged.

- `env set --help` and the CLI reference now state that `--secret` must be passed on **every** write to a variable, including updates and rotations, and that omitting it stores the value as non-sensitive even if the variable was previously write-only.
- The success message reports the resulting state: `Set TOKEN (saved as write-only).` when `--secret` is passed, `Set TOKEN.` otherwise.

No downgrade detection, no warning branch, no new JSON fields, no new dependencies.

### Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

### Implementation Details

`envSet()` in `servers.ts` builds the request body with `sensitive: values.secret === true` as before. The only change is the message passed to `printResult()`, which depends solely on whether `--secret` was passed on this invocation. `--secret`'s help text in the detailed `env set --help` block was reworded; the top-level command summary is unchanged.

`docs/v2/typescript/api-reference/cli-reference.mdx` carries the same clarification.

### TypeScript Checklist

#### Packages Modified

- [x] docs
- [x] tests
- [x] cli
- [ ] create-mcp-use-app
- [ ] mcp-use (server)
- [ ] mcp-use (client)
- [ ] inspector

#### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues (via pre-commit hook)
- [x] Ran `pnpm format` to format code with Prettier (via pre-commit hook)
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset
- [x] Added or updated tests
- [x] Updated documentation in `docs/` folder

### Example Usage (Before)

```bash
mcp-use servers env set srv_abc123 TOKEN=old --secret   # Set TOKEN.
mcp-use servers env set srv_abc123 TOKEN=rotated        # Set TOKEN.  (stored non-sensitive, not obvious from the output)
```

### Example Usage (After)

```bash
mcp-use servers env set srv_abc123 TOKEN=old --secret   # Set TOKEN (saved as write-only).
mcp-use servers env set srv_abc123 TOKEN=rotated        # Set TOKEN.
```

### Documentation Updates

`docs/v2/typescript/api-reference/cli-reference.mdx`: the `--secret` note now explains that the flag must be repeated on every write, including updates and rotations.

### Testing

`tests/commands/servers.test.ts` gained two cases that pin the existing write semantics: an update without `--secret` sends `sensitive: false` and reports `secret: false` in `--json`, and a brand-new variable is not marked sensitive by default.

Ran `pnpm exec vitest run tests/commands/servers.test.ts` in `packages/cli`: 8 tests pass. `pnpm build` at the workspace root succeeds.

### Backwards Compatibility

No behavior change. `--secret` remains the sole determinant of `sensitive` on every write, and `--json` output is unchanged. This PR only clarifies the help text and docs and makes the human-readable success message report the resulting state. Patch bump via changeset.

## Related Issues

Closes #2388
