### PR TITLE
docs(server): name the identity tools the auth examples actually expose

### DIFF
--- a/libraries/typescript/packages/server/examples/auth/README.md
+++ b/libraries/typescript/packages/server/examples/auth/README.md
@@ -11,9 +11,11 @@ These examples use direct external authorization servers:
 - [Convex](./convex/)
 - [Mixed OAuth with Better Auth](./mixed-oauth/)
 
-Each server exposes only the `get-user-info` tool. It never issues, proxies, or
-forwards access tokens. For public deployments, set `MCP_URL` to the server
-origin (for example, `https://mcp.example.com`), not the `/mcp` endpoint.
+Each server exposes a single read-only identity tool, named `get-user-info` or
+`whoami` depending on the example. The mixed OAuth example exposes `public_ping`
+and `protected_profile` instead. None of them issue, proxy, or forward access
+tokens. For public deployments, set `MCP_URL` to the server origin (for
+example, `https://mcp.example.com`), not the `/mcp` endpoint.
 
 OAuth protects the browser landing page at `/mcp` by default. These examples
 set `publicLandingPage: true` so people can open the HTML connection guide


### PR DESCRIPTION
`examples/auth/README.md` says every server exposes only `get-user-info`. Three of the examples it indexes do not: Better Auth and Convex name their tool `whoami`, and the mixed OAuth example exposes `public_ping` and `protected_profile`. A reader following the index opens one of those and looks for a tool that is not there.

Reworded to name both identity tool names and the mixed OAuth pair, without enumerating every example so it does not go stale as more are added. Kept the sentence that none of them issue, proxy, or forward access tokens, which is the substantive claim in that paragraph.

Verified by reading the `name:` field of every `server.tool()` call under `examples/auth/*/src/index.ts`: `get-user-info` in auth0, clerk, keycloak, supabase and workos; `whoami` in better-auth and convex; `public_ping` and `protected_profile` in mixed-oauth.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the auth examples README so the listed tools match what each example actually exposes.

- Better Auth and Convex name theirs `whoami`; the mixed OAuth example exposes `public_ping` and `protected_profile` instead of `get-user-info`.
- Keeps the note that none of them issue, proxy, or forward access tokens.

<sup>Written for commit 981784844cd6cd009132cb4afc264a6a72d02d63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

