### PR TITLE
fix(release): preserve package artifacts during publish

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -138,6 +138,10 @@ jobs:
         id: publish-canary
         continue-on-error: true
         working-directory: libraries/typescript
+        env:
+          # Packages were built and packed above. Keep concurrent publishing from
+          # running lifecycle hooks that can mutate another package's artifacts.
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
         run: |
           # Using npm trusted publishing (OIDC) - no token needed
           pnpm changeset publish
@@ -400,6 +404,9 @@ jobs:
           steps.check-release.outputs.should_publish == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Packages were built and packed above. Keep concurrent publishing from
+          # running lifecycle hooks that can mutate another package's artifacts.
+          NPM_CONFIG_IGNORE_SCRIPTS: "true"
         id: publish-main
         continue-on-error: true
         run: |

--- a/libraries/typescript/.changeset/safe-client-publish-artifact.md
+++ b/libraries/typescript/.changeset/safe-client-publish-artifact.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/client": patch
+"@mcp-use/inspector": patch
+---
+
+Prevent concurrent package publishing from removing the Client build while its tarball is being created, and verify every published artifact contains its declared files and entry points.

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -56,7 +56,6 @@
     "build:client-exports": "tsup --config tsup.client.ts && node scripts/copy-client-styles.mjs",
     "build:server": "tsup --config tsup.server.ts",
     "verify:package": "node scripts/verify-package.mjs",
-    "prepublishOnly": "pnpm --filter @mcp-use/client build && pnpm build",
     "start": "node dist/cli.js --port 3000",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",

--- a/libraries/typescript/scripts/release-artifact.mjs
+++ b/libraries/typescript/scripts/release-artifact.mjs
@@ -1,0 +1,64 @@
+const wildcard = /[*?[\]{}]/u;
+
+function normalizedPath(value) {
+  return value.replace(/^\.\//u, "").replace(/\/$/u, "");
+}
+
+function entryPointPaths(value, paths = new Set()) {
+  if (typeof value === "string") {
+    if (value.startsWith("./") && !wildcard.test(value)) {
+      paths.add(normalizedPath(value));
+    }
+    return paths;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) entryPointPaths(item, paths);
+    return paths;
+  }
+  if (value && typeof value === "object") {
+    for (const item of Object.values(value)) entryPointPaths(item, paths);
+  }
+  return paths;
+}
+
+export function requiredPackedEntries(manifest) {
+  const exact = new Set();
+  const prefixes = new Set();
+
+  for (const field of ["main", "module", "types"]) {
+    const value = manifest[field];
+    if (typeof value === "string" && !wildcard.test(value)) {
+      exact.add(normalizedPath(value));
+    }
+  }
+  entryPointPaths(manifest.bin, exact);
+  entryPointPaths(manifest.exports, exact);
+
+  for (const value of manifest.files ?? []) {
+    if (typeof value !== "string" || wildcard.test(value)) continue;
+    const path = normalizedPath(value);
+    if (path) prefixes.add(path);
+  }
+
+  return { exact: [...exact].sort(), prefixes: [...prefixes].sort() };
+}
+
+export function packedArtifactErrors(manifest, files) {
+  const paths = new Set(files.map(({ path }) => normalizedPath(path)));
+  const { exact, prefixes } = requiredPackedEntries(manifest);
+  const errors = [];
+
+  for (const path of exact) {
+    if (!paths.has(path)) errors.push(`missing entry point ${path}`);
+  }
+  for (const prefix of prefixes) {
+    if (
+      ![...paths].some(
+        (path) => path === prefix || path.startsWith(`${prefix}/`)
+      )
+    ) {
+      errors.push(`files entry ${prefix} matched no packed files`);
+    }
+  }
+  return errors;
+}

--- a/libraries/typescript/scripts/release-channel.mjs
+++ b/libraries/typescript/scripts/release-channel.mjs
@@ -1,7 +1,10 @@
+import { spawnSync } from "node:child_process";
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import semver from "semver";
+
+import { packedArtifactErrors } from "./release-artifact.mjs";
 
 const workspaceRoot = process.cwd();
 const packageRoot = join(workspaceRoot, "packages");
@@ -32,6 +35,40 @@ function manifestEntries() {
 
 function manifests() {
   return manifestEntries().map(({ manifest }) => manifest);
+}
+
+function packedFiles(name, version) {
+  const result = spawnSync(
+    "npm",
+    ["pack", "--dry-run", "--ignore-scripts", "--json", `${name}@${version}`],
+    { cwd: workspaceRoot, encoding: "utf8" }
+  );
+  if (result.status !== 0) {
+    throw new Error(
+      `could not inspect ${name}@${version}: ${result.stderr || result.stdout}`
+    );
+  }
+  const [packed] = JSON.parse(result.stdout);
+  if (!packed?.files) {
+    throw new Error(`npm pack returned no file list for ${name}@${version}`);
+  }
+  return packed.files;
+}
+
+function verifyPackedArtifact(release) {
+  const manifest = manifests().find(({ name }) => name === release.name);
+  if (!manifest) throw new Error(`No local manifest for ${release.name}`);
+  const errors = packedArtifactErrors(
+    manifest,
+    packedFiles(release.name, release.version)
+  );
+  if (errors.length) {
+    throw new Error(
+      `${release.name}@${release.version} has an invalid npm artifact: ${errors.join(
+        ", "
+      )}`
+    );
+  }
 }
 
 function prereleaseState() {
@@ -367,6 +404,12 @@ async function verifyOnce(plan) {
     if (release.target) {
       if (!Object.hasOwn(versions, release.version)) {
         errors.push(`${release.name}@${release.version} is missing from npm`);
+      } else if (!option("--registry-file")) {
+        try {
+          verifyPackedArtifact(release);
+        } catch (error) {
+          errors.push(error instanceof Error ? error.message : String(error));
+        }
       }
       if (afterTags[release.channelTag] !== release.version) {
         errors.push(

--- a/libraries/typescript/scripts/release-channel.test.mjs
+++ b/libraries/typescript/scripts/release-channel.test.mjs
@@ -5,6 +5,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 
+import {
+  packedArtifactErrors,
+  requiredPackedEntries,
+} from "./release-artifact.mjs";
+
 const script = new URL("./release-channel.mjs", import.meta.url).pathname;
 
 function fixture({ localVersion, latest, canary, published = [] }) {
@@ -59,6 +64,62 @@ function writePreState(root, initialVersions, changesets = []) {
     })
   );
 }
+
+test("requires declared package files and entry points in packed artifacts", () => {
+  const manifest = {
+    name: "@mcp-use/client",
+    files: ["dist"],
+    module: "./dist/index.js",
+    types: "./dist/index.d.ts",
+    exports: {
+      ".": {
+        node: { import: "./dist/index.js", types: "./dist/index.d.ts" },
+        browser: {
+          import: "./dist/index-browser.js",
+          types: "./dist/index-browser.d.ts",
+        },
+      },
+      "./react": {
+        import: "./dist/react/index.js",
+        types: "./dist/react/index.d.ts",
+      },
+    },
+  };
+
+  assert.deepEqual(requiredPackedEntries(manifest), {
+    exact: [
+      "dist/index-browser.d.ts",
+      "dist/index-browser.js",
+      "dist/index.d.ts",
+      "dist/index.js",
+      "dist/react/index.d.ts",
+      "dist/react/index.js",
+    ],
+    prefixes: ["dist"],
+  });
+  assert.deepEqual(
+    packedArtifactErrors(manifest, [
+      { path: "README.md" },
+      { path: "package.json" },
+    ]),
+    [
+      "missing entry point dist/index-browser.d.ts",
+      "missing entry point dist/index-browser.js",
+      "missing entry point dist/index.d.ts",
+      "missing entry point dist/index.js",
+      "missing entry point dist/react/index.d.ts",
+      "missing entry point dist/react/index.js",
+      "files entry dist matched no packed files",
+    ]
+  );
+  assert.deepEqual(
+    packedArtifactErrors(
+      manifest,
+      requiredPackedEntries(manifest).exact.map((path) => ({ path }))
+    ),
+    []
+  );
+});
 
 test("rejects a stable source version below npm latest", () => {
   const { root, registryFile } = fixture({


### PR DESCRIPTION
## Summary

- prevent npm lifecycle hooks from mutating sibling build output during Changesets concurrent publishing
- remove Inspector’s cross-package `prepublishOnly` rebuild
- verify published npm tarballs contain every declared entry point and `files` directory
- release `@mcp-use/client` 2.2.5 and `@mcp-use/inspector` 20.3.6 (with normal dependent patch propagation)

## Root cause

Changesets publishes packages concurrently. Inspector’s `prepublishOnly` rebuilt `@mcp-use/client`, whose build starts with `rimraf dist`, while Client was being packed for publish. This race produced `@mcp-use/client@2.2.4` with only `README.md` and `package.json`.

The previous stable workflow failed before its final canary reset, so this branch intentionally starts from current `main` to restore canary to the stable release baseline.

## Verification

- `pnpm test:release-channel`
- `pnpm build`
- `pnpm verify:release-install`
- all seven local publishable tarballs validated against manifest entry points and `files`; Client contains 135 files
- validator rejects live `@mcp-use/client@2.2.4` (2 files; all `dist` entry points missing)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the concurrent publish race that shipped `@mcp-use/client@2.2.4` with only `README.md` and `package.json`. Publishing now skips lifecycle scripts since packages are pre-built, and the release channel verifies every tarball against declared entry points and `files` directories.

**Bug Fixes**
- Inspector's `prepublishOnly` no longer rebuilds `@mcp-use/client`; publish steps set `NPM_CONFIG_IGNORE_SCRIPTS=true`.
- Release verification rejects tarballs missing declared entry points or `files` directories.
- The release carries the OAuth loopback rebind fix, chat widget connection id fix, `--no-git` help removal, and CLI reference corrections.
- Reusable CI workflow calls now honor the passed ref and flags when approving fork PRs.

<sup>Written for commit a64ce4449e7e8e7d0c052e4cbef6c5c867637655. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

