### PR TITLE
fix(release): skip unchanged Canary plan entries

### DIFF
--- a/libraries/typescript/scripts/release-channel.mjs
+++ b/libraries/typescript/scripts/release-channel.mjs
@@ -242,6 +242,7 @@ function validateReleasePlan(channel, planFile) {
   const errors = [];
 
   for (const release of plan.releases ?? []) {
+    if (release.type === "none") continue;
     const plannedMajor =
       release.type === "major" ||
       semver.major(release.newVersion) > semver.major(release.oldVersion);

--- a/libraries/typescript/scripts/release-channel.test.mjs
+++ b/libraries/typescript/scripts/release-channel.test.mjs
@@ -414,6 +414,53 @@ test("accepts a Canary major with an explicit major changeset", () => {
   assert.equal(result.status, 0, result.stderr);
 });
 
+test("ignores unchanged packages in a Canary release plan", () => {
+  const { root, registryFile } = fixture({
+    localVersion: "2.0.4",
+    latest: "2.0.4",
+    canary: "2.0.4-canary.0",
+    published: ["2.0.4"],
+  });
+  const planFile = join(root, "changeset-status.json");
+  writeFileSync(
+    planFile,
+    JSON.stringify({
+      changesets: [
+        {
+          id: "client-fix",
+          releases: [{ name: "@mcp-use/client", type: "patch" }],
+        },
+      ],
+      releases: [
+        {
+          name: "@mcp-use/client",
+          type: "patch",
+          oldVersion: "2.2.4",
+          newVersion: "2.2.5-canary.0",
+        },
+        {
+          name: "@mcp-use/cli",
+          type: "none",
+          oldVersion: "4.1.10",
+          newVersion: "4.1.10",
+        },
+      ],
+      preState: { mode: "pre", tag: "canary" },
+    })
+  );
+
+  const result = run(
+    root,
+    registryFile,
+    "validate",
+    "--channel",
+    "canary",
+    "--plan",
+    planFile
+  );
+  assert.equal(result.status, 0, result.stderr);
+});
+
 test("registry verification accepts a completed target after a publish error", () => {
   const { root, registryFile } = fixture({
     localVersion: "2.0.5-canary.0",


### PR DESCRIPTION
## Summary

- ignore Changesets release-plan entries with `type: none` during Canary version validation
- cover the unchanged stable CLI entry produced by peer-range preparation

## Why

The `@mcp-use/client` artifact hotfix reached Canary but stopped before versioning or publishing because peer-range preparation included unchanged `@mcp-use/cli@4.1.10` as `type: none`. The validator incorrectly required that non-release to have a Canary version.

## Verification

- `pnpm test:release-channel` (13/13)
- Prettier check
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canary release validation now skips Changesets entries with `type: none`, so unchanged packages no longer block versioning or publishing.

- Adds a regression test for unchanged packages included by peer-range preparation.

<sup>Written for commit 1da01ea000d9f6bcb8cc6c646a42ff1ec3ede0c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

