### PR TITLE
fix(release): accept npm pack object output

### DIFF
--- a/libraries/typescript/scripts/release-artifact.mjs
+++ b/libraries/typescript/scripts/release-artifact.mjs
@@ -62,3 +62,12 @@ export function packedArtifactErrors(manifest, files) {
   }
   return errors;
 }
+
+export function packedFilesFromNpmPackJson(output) {
+  const parsed = JSON.parse(output);
+  const packed = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!packed?.files) {
+    throw new Error("npm pack returned no file list");
+  }
+  return packed.files;
+}

--- a/libraries/typescript/scripts/release-channel.mjs
+++ b/libraries/typescript/scripts/release-channel.mjs
@@ -4,7 +4,10 @@ import { join } from "node:path";
 
 import semver from "semver";
 
-import { packedArtifactErrors } from "./release-artifact.mjs";
+import {
+  packedArtifactErrors,
+  packedFilesFromNpmPackJson,
+} from "./release-artifact.mjs";
 
 const workspaceRoot = process.cwd();
 const packageRoot = join(workspaceRoot, "packages");
@@ -48,11 +51,13 @@ function packedFiles(name, version) {
       `could not inspect ${name}@${version}: ${result.stderr || result.stdout}`
     );
   }
-  const [packed] = JSON.parse(result.stdout);
-  if (!packed?.files) {
-    throw new Error(`npm pack returned no file list for ${name}@${version}`);
+  try {
+    return packedFilesFromNpmPackJson(result.stdout);
+  } catch (error) {
+    throw new Error(
+      `could not parse npm pack file list for ${name}@${version}: ${error.message}`
+    );
   }
-  return packed.files;
 }
 
 function verifyPackedArtifact(release) {

--- a/libraries/typescript/scripts/release-channel.test.mjs
+++ b/libraries/typescript/scripts/release-channel.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 
 import {
   packedArtifactErrors,
+  packedFilesFromNpmPackJson,
   requiredPackedEntries,
 } from "./release-artifact.mjs";
 
@@ -118,6 +119,18 @@ test("requires declared package files and entry points in packed artifacts", () 
       requiredPackedEntries(manifest).exact.map((path) => ({ path }))
     ),
     []
+  );
+});
+
+test("accepts both npm pack JSON result shapes", () => {
+  const packed = { files: [{ path: "package.json" }] };
+  assert.deepEqual(
+    packedFilesFromNpmPackJson(JSON.stringify([packed])),
+    packed.files
+  );
+  assert.deepEqual(
+    packedFilesFromNpmPackJson(JSON.stringify(packed)),
+    packed.files
   );
 });
 


### PR DESCRIPTION
## Summary

- accept both object and one-element array JSON shapes from npm pack
- retain contextual errors when the registry response cannot be parsed
- cover both npm output shapes with a regression test

## Evidence

The Canary release published all four target packages, including a healthy 135-file @mcp-use/client@2.2.5-canary.0 tarball. Verification then failed with `object is not iterable` because npm 11 on the runner returned the single pack result as an object; local npm returned an array.

## Verification

- `pnpm test:release-channel` (14/14)
- targeted Prettier check
- `git diff --check`
- live `npm pack --dry-run --ignore-scripts --json @mcp-use/client@2.2.5-canary.0` confirms 135 files and complete dist output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes canary release verification failing when npm 11 returns a single pack result as an object instead of an array.

- Accepts both object and one-element array JSON shapes from `npm pack`.
- Preserves the original error message when parsing fails, adding package and version context.
- Adds a regression test covering both output shapes.

<sup>Written for commit dc78c800f09e89a80878b94ef5f6799b53d3793b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

