### PR TITLE
fix(release): parse npm 12 keyed pack output

### DIFF
--- a/libraries/typescript/scripts/release-artifact.mjs
+++ b/libraries/typescript/scripts/release-artifact.mjs
@@ -65,7 +65,11 @@ export function packedArtifactErrors(manifest, files) {
 
 export function packedFilesFromNpmPackJson(output) {
   const parsed = JSON.parse(output);
-  const packed = Array.isArray(parsed) ? parsed[0] : parsed;
+  const packed = Array.isArray(parsed)
+    ? parsed[0]
+    : parsed?.files
+      ? parsed
+      : Object.values(parsed ?? {}).find((value) => value?.files);
   if (!packed?.files) {
     throw new Error("npm pack returned no file list");
   }

--- a/libraries/typescript/scripts/release-channel.test.mjs
+++ b/libraries/typescript/scripts/release-channel.test.mjs
@@ -122,7 +122,7 @@ test("requires declared package files and entry points in packed artifacts", () 
   );
 });
 
-test("accepts both npm pack JSON result shapes", () => {
+test("accepts npm pack array, direct object, and package-keyed JSON", () => {
   const packed = { files: [{ path: "package.json" }] };
   assert.deepEqual(
     packedFilesFromNpmPackJson(JSON.stringify([packed])),
@@ -130,6 +130,10 @@ test("accepts both npm pack JSON result shapes", () => {
   );
   assert.deepEqual(
     packedFilesFromNpmPackJson(JSON.stringify(packed)),
+    packed.files
+  );
+  assert.deepEqual(
+    packedFilesFromNpmPackJson(JSON.stringify({ "@mcp-use/client": packed })),
     packed.files
   );
 });


### PR DESCRIPTION
## Summary
- accept npm 12 package-keyed JSON from remote `npm pack --dry-run --json`
- retain compatibility with the prior array and direct-object forms
- add regression coverage for all three shapes

## Verification
- `node --test libraries/typescript/scripts/release-channel.test.mjs` (14/14)
- Prettier and `git diff --check`
- live `npm@12.0.2` validation of the four newly published stable packages; all required entry points and `files` entries present

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the release script to parse npm 12's keyed `npm pack --json` output, so release validation works with npm 12 while remaining compatible with the prior array and direct-object forms. Adds regression coverage for all three output shapes.

<sup>Written for commit f8315d42dbddb68c80b108e57e08b5081af0777d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

