### PR TITLE
fix(python): remove invalid print()-style kwargs from sandbox connector logger.debug calls

### DIFF
--- a/libraries/python/mcp_use/client/connectors/sandbox.py
+++ b/libraries/python/mcp_use/client/connectors/sandbox.py
@@ -148,12 +148,12 @@ class SandboxConnector(BaseConnector):
     def _handle_stdout(self, data: str) -> None:
         """Handle stdout data from the sandbox process."""
         self.stdout_lines.append(data)
-        logger.debug(f"[SANDBOX STDOUT] {data}", end="", flush=True)
+        logger.debug(f"[SANDBOX STDOUT] {data}")
 
     def _handle_stderr(self, data: str) -> None:
         """Handle stderr data from the sandbox process."""
         self.stderr_lines.append(data)
-        logger.debug(f"[SANDBOX STDERR] {data}", file=self.errlog, end="", flush=True)
+        logger.debug(f"[SANDBOX STDERR] {data}")
 
     async def wait_for_server_response(self, base_url: str, timeout: int = 30) -> bool:
         """Wait for the server to respond to HTTP requests.

--- a/libraries/python/tests/unit/test_sandbox_connector.py
+++ b/libraries/python/tests/unit/test_sandbox_connector.py
@@ -222,6 +222,28 @@ class TestSandboxConnectorConnection:
         assert connector._connected is False
 
 
+class TestSandboxConnectorLogging:
+    """Tests for SandboxConnector stdout/stderr logging."""
+
+    def test_handle_stdout_and_stderr_do_not_raise_with_real_logger(self, mock_sandbox_modules, mock_os_environ):
+        """_handle_stdout/_handle_stderr must call logger.debug with args logging.Logger accepts."""
+        import logging
+
+        from mcp_use.client.connectors import sandbox as sandbox_module
+
+        real_logger = logging.getLogger("test-sandbox-real-logger")
+        real_logger.setLevel(logging.DEBUG)
+        with patch.object(sandbox_module, "logger", real_logger):
+            sandbox_options = SandboxOptions(api_key="test-api-key")
+            connector = SandboxConnector("npx", ["test-command"], e2b_options=sandbox_options)
+
+            connector._handle_stdout("some output")
+            connector._handle_stderr("some error")
+
+        assert connector.stdout_lines == ["some output"]
+        assert connector.stderr_lines == ["some error"]
+
+
 class TestSandboxConnectorCleanup:
     """Tests for SandboxConnector cleanup methods."""
 


### PR DESCRIPTION
SandboxConnector._handle_stdout/_handle_stderr passed end, flush, and
file kwargs to logger.debug(), which only accepts exc_info, stack_info,
stacklevel, and extra. This raised TypeError on every line of
stdout/stderr from a sandboxed process whenever DEBUG logging was
enabled.

Closes #2089

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CfDUwpphCqmCp5YjYPKXx6

# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Describe the changes introduced by this PR in a concise manner.

## Review Readiness

Help maintainers review this quickly:

- [ ] The PR is scoped to one issue or one clearly related change
- [ ] The PR description explains the user-visible problem and the fix
- [ ] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [ ] I verified the affected package/docs path with the commands listed below
- [ ] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. List the specific implementation details
2. Include code organization, architectural decisions
3. Note any dependencies that were added or modified

---

## TypeScript Checklist

> Complete this section if your PR includes TypeScript changes

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Ran `pnpm lint:fix` to auto-fix linting issues
- [ ] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Python Checklist

> Complete this section if your PR includes Python changes

### Pre-commit Checklist

Ensure all of the following have been completed:
- [ ] Code formatted with `ruff format`
- [ ] Linting passes with `ruff check`
- [ ] Added or updated tests if needed
- [ ] Updated documentation if needed

---

## Example Usage (Before)

```
# Include example code showing how things worked before (if applicable)
# Use the appropriate language syntax (python, typescript, bash, etc.)
```

## Example Usage (After)

```
# Include example code showing how things work after your changes
# Use the appropriate language syntax (python, typescript, bash, etc.)
```

## Documentation Updates

* List any documentation files that were updated
* Explain what was changed in each file

## Testing

Describe how you tested these changes:
- Unit tests added/modified
- Integration tests added/modified
- Manual testing performed
- Edge cases considered

## Backwards Compatibility

Explain whether these changes are backwards compatible. If not, describe what users will need to do to adapt to these changes.

## Related Issues

Closes #[issue_number]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox connector so DEBUG logging no longer crashes with a TypeError on every stdout/stderr line from a sandboxed process. The `logger.debug` calls passed print-style kwargs (`end`, `flush`, `file`) that `logging.Logger.debug` does not accept; they've been removed.

Adds a regression test that exercises both handlers with a real logger. Closes #2089.

<sup>Written for commit 02d6c9762a40d945facc1854bd84af3da3f151b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

