### PR TITLE
fix(ci): keep fork test reports from failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,8 @@ jobs:
     if: always() && github.event_name == 'pull_request' && needs.python-transport-tests.result != 'skipped'
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      # Fork pull_request runs receive a read-only token from GitHub.
+      issues: write
     steps:
       - name: Download all test results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -292,7 +293,7 @@ jobs:
           pattern: transport-test-results-*
           path: test-results
           merge-multiple: false
-      - name: Generate PR comment
+      - name: Generate test report
         uses: actions/github-script@v9
         with:
           script: |
@@ -355,6 +356,17 @@ jobs:
             |-----------|--------|-------|--------|--------|--------|------|
             ${tableRows.join('\n')}
             `;
+
+            // Always keep the report visible, including for fork PRs where the
+            // token cannot (and must not) mutate repository issues.
+            await core.summary.addRaw(comment).write();
+
+            const headRepo = context.payload.pull_request.head.repo?.full_name;
+            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
+            if (headRepo !== baseRepo) {
+              core.info('Fork pull request detected; skipping issue comment mutation.');
+              return;
+            }
 
             // Find existing comment
             const { data: comments } = await github.rest.issues.listComments({
@@ -449,7 +461,8 @@ jobs:
     if: always() && github.event_name == 'pull_request' && needs.python-primitive-tests.result != 'skipped'
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      # Fork pull_request runs receive a read-only token from GitHub.
+      issues: write
     steps:
       - name: Download all test results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -457,7 +470,7 @@ jobs:
           pattern: primitive-test-results-*
           path: test-results
           merge-multiple: false
-      - name: Generate PR comment
+      - name: Generate test report
         uses: actions/github-script@v9
         with:
           script: |
@@ -520,6 +533,17 @@ jobs:
             |-----------|--------|-------|--------|--------|--------|------|
             ${tableRows.join('\n')}
             `;
+
+            // Always keep the report visible, including for fork PRs where the
+            // token cannot (and must not) mutate repository issues.
+            await core.summary.addRaw(comment).write();
+
+            const headRepo = context.payload.pull_request.head.repo?.full_name;
+            const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
+            if (headRepo !== baseRepo) {
+              core.info('Fork pull request detected; skipping issue comment mutation.');
+              return;
+            }
 
             // Find existing comment
             const { data: comments } = await github.rest.issues.listComments({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ permissions:
 #    - Outputs: python, typescript, knip, create-mcp-use-app
 #    - Subsequent jobs use these outputs to conditionally run
 #
-# 2. Python Tests (runs if libraries/python/** changed)
+# 2. Python Tests (runs if libraries/python/** or this workflow changed)
 #    ├─ python-lint: Ruff linting and formatting checks
 #    ├─ python-unit-tests: Matrix [Python 3.11, 3.12]
 #    ├─ python-transport-tests: Matrix [stdio, sse, streamable_http]
@@ -102,6 +102,7 @@ jobs:
           filters: |
             python:
               - 'libraries/python/**'
+              - '.github/workflows/ci.yml'
             typescript:
               - 'libraries/typescript/**'
               - '.github/workflows/ci.yml'


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [ ] TypeScript
- [ ] Python
- [ ] Documentation only
- [x] CI/CD or tooling

## Changes

The Python transport and primitive report jobs currently fail on pull requests from public forks even when every underlying test passes. GitHub downgrades the `pull_request` workflow token to read-only for forks, so the final `actions/github-script` step receives HTTP 403 while trying to create or update a PR comment. This produces two false-red CI jobs on otherwise healthy contributions.

This change always publishes both reports to the GitHub Actions job summary. For same-repository PRs it preserves the existing create/update PR-comment behavior; for fork PRs it detects the different head repository and skips repository mutation.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected workflow with the commands listed below
- [x] I checked for existing open PRs and issues that already solve the same problem

## Implementation Details

1. Rename both report steps from “Generate PR comment” to “Generate test report”.
2. Write the generated Markdown report through `core.summary` for every pull request.
3. Compare the pull request head repository with the base repository and return before comment mutation for fork PRs.
4. Preserve the existing issue-comment update/create flow for same-repository PRs.
5. Use the minimal job-level `issues: write` permission required by the issue-comment endpoint. GitHub automatically reduces it to read-only for fork `pull_request` runs.
6. Treat changes to `.github/workflows/ci.yml` as Python-relevant so edits to Python CI jobs are exercised by their own pull request.

No `pull_request_target`, secret, elevated fork token, dependency, or production-code change is introduced.

## Testing

- `git diff --check` — passed
- Ruby YAML parse of `.github/workflows/ci.yml` — passed
- Syntax checks for all three embedded JavaScript blocks — passed
- Luna/max security, correctness, and CI-coverage review — passed

This PR itself is submitted from a public fork, so its CI run also exercises the fork branch directly: both report jobs should publish job summaries and complete without attempting a PR comment.

## Backwards Compatibility

Same-repository pull requests retain their existing bot comments. Fork pull requests gain a green report job and can read the same report in the workflow summary instead of receiving an impossible comment attempt.

## Related Issues

No linked issue; reproduced in the report jobs of #2399 and #2365. No matching open issue or PR was found.
