### PR TITLE
fix(server): support RFC 8707 multi-resource array in OAuth JWT resource claim verification

### DIFF
--- a/libraries/typescript/.changeset/support-rfc8707-multi-resource-claim.md
+++ b/libraries/typescript/.changeset/support-rfc8707-multi-resource-claim.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Support multi-resource array in OAuth JWT `resource` claims per RFC 8707 and RFC 9068.

--- a/libraries/typescript/packages/server/src/oauth/jwt.ts
+++ b/libraries/typescript/packages/server/src/oauth/jwt.ts
@@ -240,11 +240,16 @@ function verifiedResource(
 ): URL {
   const value = claims["resource"];
   if (value !== undefined) {
-    if (typeof value !== "string") {
-      throw invalidToken("Token resource claim must be an absolute URL");
+    if (!validResourceClaim(value)) {
+      throw invalidToken(
+        "Token resource claim must be an absolute URL or array of absolute URLs"
+      );
     }
-    const resource = canonicalUrl(value);
-    if (resource.href !== configuredResource.href) {
+    const rawResources = typeof value === "string" ? [value] : value;
+    const resources = rawResources.map(canonicalUrl);
+    if (
+      !resources.some((resource) => resource.href === configuredResource.href)
+    ) {
       throw invalidToken(
         "Token resource claim does not match protected resource"
       );
@@ -295,6 +300,15 @@ function verifierAudience(
 }
 
 function validAudience(value: unknown): value is string | string[] {
+  return (
+    typeof value === "string" ||
+    (Array.isArray(value) &&
+      value.length > 0 &&
+      value.every((item) => typeof item === "string"))
+  );
+}
+
+function validResourceClaim(value: unknown): value is string | string[] {
   return (
     typeof value === "string" ||
     (Array.isArray(value) &&

--- a/libraries/typescript/packages/server/src/oauth/jwt.ts
+++ b/libraries/typescript/packages/server/src/oauth/jwt.ts
@@ -299,7 +299,7 @@ function verifierAudience(
   );
 }
 
-function validAudience(value: unknown): value is string | string[] {
+function isStringOrStringArray(value: unknown): value is string | string[] {
   return (
     typeof value === "string" ||
     (Array.isArray(value) &&
@@ -308,13 +308,12 @@ function validAudience(value: unknown): value is string | string[] {
   );
 }
 
+function validAudience(value: unknown): value is string | string[] {
+  return isStringOrStringArray(value);
+}
+
 function validResourceClaim(value: unknown): value is string | string[] {
-  return (
-    typeof value === "string" ||
-    (Array.isArray(value) &&
-      value.length > 0 &&
-      value.every((item) => typeof item === "string"))
-  );
+  return isStringOrStringArray(value);
 }
 
 function canonicalUrl(value: URL | string): URL {

--- a/libraries/typescript/packages/server/tests/oauth-core.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-core.test.ts
@@ -269,6 +269,44 @@ describe("OAuth core", () => {
       code: OAuthErrorCode.InvalidToken,
       message: "Token resource claim does not match protected resource",
     });
+
+    // Multi-resource array per RFC 8707 / RFC 9068
+    await expect(
+      verifier.verifyAccessToken(
+        await sign({
+          aud: "provider-api",
+          resource: [canonicalResource.href, "https://other.example/mcp"],
+        })
+      )
+    ).resolves.toMatchObject({ resource: canonicalResource });
+
+    await expect(
+      verifier.verifyAccessToken(
+        await sign({
+          aud: "provider-api",
+          resource: [
+            "https://other1.example/mcp",
+            "https://other2.example/mcp",
+          ],
+        })
+      )
+    ).rejects.toMatchObject({
+      code: OAuthErrorCode.InvalidToken,
+      message: "Token resource claim does not match protected resource",
+    });
+
+    await expect(
+      verifier.verifyAccessToken(
+        await sign({
+          aud: "provider-api",
+          resource: 12345,
+        })
+      )
+    ).rejects.toMatchObject({
+      code: OAuthErrorCode.InvalidToken,
+      message:
+        "Token resource claim must be an absolute URL or array of absolute URLs",
+    });
   });
 
   it("rejects verifier output that does not prove resource binding", async () => {

--- a/libraries/typescript/packages/server/tests/oauth-core.test.ts
+++ b/libraries/typescript/packages/server/tests/oauth-core.test.ts
@@ -299,6 +299,19 @@ describe("OAuth core", () => {
       verifier.verifyAccessToken(
         await sign({
           aud: "provider-api",
+          resource: [],
+        })
+      )
+    ).rejects.toMatchObject({
+      code: OAuthErrorCode.InvalidToken,
+      message:
+        "Token resource claim must be an absolute URL or array of absolute URLs",
+    });
+
+    await expect(
+      verifier.verifyAccessToken(
+        await sign({
+          aud: "provider-api",
           resource: 12345,
         })
       )


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Adds support for multi-resource string arrays in OAuth JWT `resource` claims per RFC 8707 and RFC 9068 § 2.2, allowing access tokens issued for multiple target resources to validate cleanly on MCP servers.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Architectural Overview & Implementation Details

### Problem Background
Under **RFC 8707** (*Resource Indicators for OAuth 2.0*) and **RFC 9068 § 2.2** (*JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens*), the `resource` claim represents the target resource server(s) for which the token is valid. When multiple target resources are granted by an Authorization Server (e.g., Auth0, Okta, Keycloak, Entra ID, Ping), the `resource` claim is formatted as an array of string URIs:

```json
{
  "sub": "user_123",
  "iss": "https://auth.example.com",
  "resource": [
    "https://api.example.com/mcp",
    "https://api.example.com/data"
  ]
}
```

Previously, `packages/server/src/oauth/jwt.ts` strictly enforced `typeof value === "string"`. When presented with a multi-resource array token, the verifier threw an `invalid_token` error and rejected the token.

### Proposed Architecture & Solution
1. **Polymorphic Claim Validation (`validResourceClaim`)**:
   - Accepts both single `string` URIs and non-empty `string[]` arrays, bringing `resource` claim validation into architectural symmetry with `aud` and `iss`.
   - Strictly rejects empty arrays (`[]`), non-string elements, `null`, `boolean`, and arbitrary objects.
2. **Canonicalization & Membership Check**:
   - Maps each resource URI through `canonicalUrl`, ensuring consistent scheme enforcement (HTTPS strictly required; HTTP permitted exclusively on loopback/localhost) and trailing-slash normalization (`/mcp/` $\equiv$ `/mcp`).
   - Asserts that `configuredResource.href` is present in the resolved resource list.
3. **Precedence Hierarchy Preservation**:
   - If an explicit `resource` claim is present in the JWT, it continues to take absolute precedence over provider-specific audience fallbacks and must match the protected resource.

---

## TypeScript Checklist

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [x] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```json
// Token with multi-resource array was rejected with 401 invalid_token
{
  "sub": "user_123",
  "resource": ["https://api.example.com/mcp", "https://api.example.com/other"]
}
```

## Example Usage (After)

```json
// Token with multi-resource array verifies cleanly when the server's resource is listed
{
  "sub": "user_123",
  "resource": ["https://api.example.com/mcp", "https://api.example.com/other"]
}
```

## Documentation Updates

* N/A (Internal RFC standards compliance improvement with full backwards compatibility)

## Testing

Describe how you tested these changes:
- Added comprehensive test cases in `packages/server/tests/oauth-core.test.ts`:
  - Verified multi-resource array containing the matching canonical resource URL resolves and binds properly.
  - Verified multi-resource array targeting other resources is rejected with `Token resource claim does not match protected resource`.
  - Verified malformed claim types (e.g. numeric values, invalid types) are rejected with `Token resource claim must be an absolute URL or array of absolute URLs`.
- Ran full test suite across the `@mcp-use/server` package (`pnpm --filter mcp-use test`): 44 test files, 474 tests passed.
- Ran formatting and linting: `pnpm format && pnpm lint` (0 errors, 0 warnings).

## Backwards Compatibility

Fully backwards compatible. Single-string `resource` claims continue to follow the identical evaluation path.

## Related Issues

Closes #2438

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth JWT resource claim verification to accept multi-resource arrays per RFC 8707, so tokens issued for multiple target resources no longer get rejected.

- Allows non-empty `string[]` claims in addition to single strings.
- Verifies the configured resource is present in the array after canonicalization.
- Rejects empty arrays, non-string elements, and other types with a clearer error message.
- Single-string claims continue to work exactly as before.
- Adds tests for matching, non-matching, and malformed resource claims.

<sup>Written for commit fc05d27a231f3952860168fe0a5829e6654e27fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

