### PR TITLE
fix(cli): prevent startup errors from being masked by ERR_SERVER_NOT_RUNNING in dev teardown

### DIFF
--- a/libraries/typescript/.changeset/fix-cli-dev-teardown-error-handling.md
+++ b/libraries/typescript/.changeset/fix-cli-dev-teardown-error-handling.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Prevent startup errors in `mcp-use dev` from being masked by `ERR_SERVER_NOT_RUNNING` during teardown.

--- a/libraries/typescript/packages/cli/src/cli/dev.ts
+++ b/libraries/typescript/packages/cli/src/cli/dev.ts
@@ -869,8 +869,14 @@ export async function runDev(options: DevOptions): Promise<void> {
     // vite.close() below owns upgraded HMR WebSockets.
     const httpClosed = new Promise<void>((resolve, reject) => {
       httpServer.close((error) => {
-        if (error !== undefined) reject(error);
-        else resolve();
+        if (
+          error !== undefined &&
+          (error as NodeJS.ErrnoException).code !== "ERR_SERVER_NOT_RUNNING"
+        ) {
+          reject(error);
+        } else {
+          resolve();
+        }
       });
     });
     httpServer.closeAllConnections();

--- a/libraries/typescript/packages/cli/tests/cli/dev.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/dev.test.ts
@@ -30,10 +30,16 @@ import {
 
 // Controllable tunnel state. Tests flip `url` to pin the tunnel-gated CORS
 // contract on Vite module URLs.
-const tunnelState = vi.hoisted(() => ({ url: null as string | null }));
+const tunnelState = vi.hoisted(() => ({
+  url: null as string | null,
+  failStart: false,
+}));
 vi.mock("@mcp-use/tunnel", () => ({
   createTunnelManager: () => ({
     start: async (port: number) => {
+      if (tunnelState.failStart) {
+        throw new Error("Tunnel connection failed on start");
+      }
       tunnelState.url = `https://fake.local.mcp-use.run`;
       void port;
       return { url: tunnelState.url, subdomain: "fake" };
@@ -1614,4 +1620,23 @@ describe("runDev (views)", () => {
       expect(docHtml).toContain("/@vite/client");
     }
   }, 90_000);
+
+  it("propagates startup errors cleanly without masking from teardown", async () => {
+    const cwd = copyFixture("dev-views-a", "views");
+    cleanups.push(() => removeDir(cwd));
+
+    tunnelState.failStart = true;
+    cleanups.push(() => {
+      tunnelState.failStart = false;
+    });
+
+    const port = await getFreePort();
+    await expect(
+      runDev({
+        cwd,
+        port,
+        tunnel: true,
+      })
+    ).rejects.toThrow("Tunnel connection failed on start");
+  });
 });


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Prevents early dev server startup errors (such as tunnel allocation or initialization failures) from being masked by `ERR_SERVER_NOT_RUNNING` when `teardown()` is invoked.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. In `packages/cli/src/cli/dev.ts`, updated `httpServer.close((error) => ...)` inside `teardown()` to treat `ERR_SERVER_NOT_RUNNING` as a clean resolution rather than a rejection.
2. Ensures `httpServer.closeAllConnections()` is always invoked during teardown to terminate active streams and long-lived client connections.
3. Added an automated regression test in `tests/cli/dev.test.ts` verifying that startup failures properly surface the root cause without being obscured by teardown errors.

---

## TypeScript Checklist

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```bash
# If tunnel startup failed during `mcp-use dev --tunnel`, the process crashed with:
Error: Server is not running. (ERR_SERVER_NOT_RUNNING)
```

## Example Usage (After)

```bash
# Now cleanly outputs the actual root cause of the startup failure:
Error: Tunnel connection failed on start
```

## Documentation Updates

* N/A (CLI developer experience bugfix)

## Testing

Describe how you tested these changes:
- Added a unit test in `packages/cli/tests/cli/dev.test.ts` verifying that startup errors propagate the original failure cause cleanly.
- Ran all CLI package tests: `pnpm --filter @mcp-use/cli test` (23 test files, 290 tests passed).
- Ran formatting and linting: `pnpm format && pnpm lint` (0 errors, 0 warnings).

## Backwards Compatibility

Fully backwards compatible.

## Related Issues

Closes #2440


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `@mcp-use/cli` dev server teardown so startup failures (like tunnel connection errors) surface their root cause instead of being masked by `ERR_SERVER_NOT_RUNNING`. Closes #2440.

- Treats `ERR_SERVER_NOT_RUNNING` from `httpServer.close()` as a clean shutdown.
- Keeps `closeAllConnections()` running during teardown to terminate active streams.
- Adds a regression test verifying startup errors propagate the original failure cause.

<sup>Written for commit fc5e2f04d240bca54c87c9e13314784900717b53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

