### PR TITLE
docs(server): clarify OAuth resource claim semantics

### DIFF
--- a/docs/v2/typescript/server/authentication/providers/custom.mdx
+++ b/docs/v2/typescript/server/authentication/providers/custom.mdx
@@ -82,7 +82,9 @@ export default server;
 
 `createTokenVerifier(resource)` receives the resolved canonical MCP resource. The verifier must validate token signature or introspection, issuer, expiry, and that resource, then return SDK auth information including `scopes`, `expiresAt`, and the validated `resource`.
 
-If your authorization server issues standard JWTs, `createJwtVerifier` does all of that for you, and is the same helper the built-in providers use. Given a `jwksUrl` it checks the signature, the issuer, the required `exp` and `sub` claims, and the resource binding, then returns the auth information in the shape the SDK expects. Pass `audience` when the provider's JWT audience differs from the MCP resource. With no `audience`, the token must carry a matching RFC 8707 `resource` claim or an `aud` claim containing the resource URL.
+If your authorization server issues standard JWTs, `createJwtVerifier` does all of that for you and is the same helper the built-in providers use. Given a `jwksUrl`, it checks the signature, issuer, required `exp` and `sub` claims, and resource binding. It then returns the auth information in the shape the SDK expects.
+
+For standards-conformant JWT access tokens, the verifier checks the [`aud` claim](https://www.rfc-editor.org/rfc/rfc7519.html#section-4.1.3) for the MCP resource URL. The `aud` claim can be a string or an array containing the resource URL. [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707.html#section-2) defines `resource` as an authorization and token request parameter, not as a JWT access-token claim. For compatibility with providers that include a non-standard `resource` claim, the verifier accepts a string-valued `resource` claim equal to the MCP resource URL and uses it instead of `aud`. Pass `audience` when the provider's JWT audience differs from the MCP resource.
 
 Write the verifier by hand when the provider does not issue JWTs, for example when you have to call a token introspection endpoint.
 


### PR DESCRIPTION
## Summary

- clarify that RFC 8707 defines resource as an OAuth request parameter, not a JWT access-token claim
- document aud as the standard JWT resource-binding claim, including its string and array forms
- identify the supported string-valued resource claim as a provider-compatibility behavior

Related to #2438.

## Testing

- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the custom provider docs so `resource` is described as an OAuth request parameter (per RFC 8707) rather than a JWT access-token claim, and documents `aud` as the standard JWT resource-binding claim in both string and array forms. Notes that a string-valued `resource` claim is accepted only for provider compatibility.

<sup>Written for commit 0373803a38907d25e0973b79880913d5fcda4ab3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

