### PR TITLE
fix(cli): report a malformed JSON argument as a usage error

### DIFF
--- a/libraries/typescript/.changeset/cli-bad-json-usage-error.md
+++ b/libraries/typescript/.changeset/cli-bad-json-usage-error.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Report a malformed JSON argument to `client` and `screenshot` as a usage error instead of letting the engine's `SyntaxError` escape. A bad `{...}` or `key:=<json>` value exited 1 with a bare parser message and no indication of which argument was wrong, while every other grammar mistake in the same parser exits 2.

--- a/libraries/typescript/packages/cli/src/commands/client.ts
+++ b/libraries/typescript/packages/cli/src/commands/client.ts
@@ -607,7 +607,7 @@ export function parseMcpArguments(
 ): Record<string, unknown> {
   if (argv.length === 0) return {};
   if (argv.length === 1 && argv[0]?.trimStart().startsWith("{")) {
-    const value = JSON.parse(argv[0]) as unknown;
+    const value = parseJsonArgument(argv[0], "The JSON argument");
     if (value === null || Array.isArray(value) || typeof value !== "object") {
       throw new UsageError("The JSON argument must be an object.");
     }
@@ -626,9 +626,27 @@ export function parseMcpArguments(
     }
     const key = token.slice(0, separator).replace(/^--/, "");
     const raw = token.slice(separator + width);
-    result[key] = typed >= 0 ? (JSON.parse(raw) as unknown) : raw;
+    result[key] =
+      typed >= 0 ? parseJsonArgument(raw, `The value for "${key}"`) : raw;
   }
   return result;
+}
+
+/**
+ * Parse one JSON argument, reporting a bad one as a usage error.
+ *
+ * Without this the engine's own SyntaxError escapes, which exits 1 as an
+ * operational failure and says nothing about which argument was wrong, while
+ * every other grammar mistake in this function exits 2.
+ */
+function parseJsonArgument(raw: string, label: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (error) {
+    throw new UsageError(
+      `${label} is not valid JSON: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
 }
 
 function resolveBrowserMode(options: {

--- a/libraries/typescript/packages/cli/tests/cli/commands.test.ts
+++ b/libraries/typescript/packages/cli/tests/cli/commands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { parseMcpArguments } from "../../src/commands/client.js";
 import { resolveOrganization } from "../../src/commands/cloud-api.js";
+import { UsageError } from "../../src/commands/shared.js";
 
 describe("greenfield CLI command helpers", () => {
   it("parses string and typed MCP arguments", () => {
@@ -23,6 +24,16 @@ describe("greenfield CLI command helpers", () => {
       city: "Paris",
       days: 2,
     });
+  });
+
+  it("reports malformed JSON as a usage error naming the argument", () => {
+    expect(() => parseMcpArguments(["{bad json"])).toThrow(UsageError);
+    expect(() => parseMcpArguments(["{bad json"])).toThrow(
+      /^The JSON argument is not valid JSON: /
+    );
+    expect(() => parseMcpArguments(["count:={bad"])).toThrow(
+      /^The value for "count" is not valid JSON: /
+    );
   });
 
   it("resolves organizations only by id or slug", () => {


### PR DESCRIPTION
## Why

`parseMcpArguments` raises a clean `UsageError` for a `key=value` grammar mistake and for JSON that parses but is not an object, then lets the engine's own `SyntaxError` escape for JSON that does not parse at all.

```console
$ mcp-use client probe tools call foo '{bad json'
Expected property name or '}' in JSON at position 1 (line 1 column 2)     # exit 1

$ mcp-use client probe tools call foo 'count:={bad'
Expected property name or '}' in JSON at position 1 (line 1 column 2)     # exit 1
```

Two problems with that. Exit 1 is the operational-failure code, so a mistyped command line is reported as an API or runtime problem rather than the exit 2 the sibling errors use. And the message names nothing, which matters most for the `key:=<json>` form, where one token out of several is at fault and the output is identical either way.

For comparison, the same function's other failures:

```
Expected key=value or key:=<json>, received: X     # exit 2
The JSON argument must be an object.               # exit 2
```

## The change

Both parses go through one helper that names the argument and raises `UsageError`:

```console
$ mcp-use client probe tools call foo '{bad json'
The JSON argument is not valid JSON: Expected property name or '}' ...    # exit 2

$ mcp-use client probe tools call foo 'count:={bad'
The value for "count" is not valid JSON: Expected property name or '}' ...  # exit 2
```

The parser's message is kept because it carries the position, which is the useful part.

This runs during argument validation, before the client connects, so it is reachable without a reachable server. `screenshot` shares the same parser and gets the same behaviour, though it connects before parsing, so you need a live server to see it there.

## Test

Added to the existing `tests/cli/commands.test.ts`, which is where the two happy paths for this parser already live. On the unfixed source it fails with `expected error to be instance of UsageError`.

## Validation

From `libraries/typescript/packages/cli`: `vitest run` — 295 passed, 23 files.
From `libraries/typescript`: `eslint` and `prettier --check` on both changed files — clean.
Monorepo preflight — 0 failing packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reports malformed JSON in `client` and `screenshot` CLI arguments as a usage error instead of letting the engine's `SyntaxError` escape. A bad `{...}` or `key:=<json>` value previously exited 1 with a bare parser message that didn't name the faulty argument; it now exits 2 and names the argument, matching the other grammar mistakes in `parseMcpArguments`, while keeping the parser's position message. `client` parses before connecting, so this is reachable without a live server; `screenshot` parses after connecting, so it needs one.

<sup>Written for commit 9012ba6bae94f7721d463f73f02413cf62772d88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

