### PR TITLE
fix(cli): validate servers list pagination before authenticating

### DIFF
--- a/libraries/typescript/.changeset/servers-list-validate-before-auth.md
+++ b/libraries/typescript/.changeset/servers-list-validate-before-auth.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Fix `servers list` reporting a bad `--limit` or `--skip` as `Not logged in.` when signed out. Pagination was validated after the cloud client was created, so an invalid page size surfaced as an operational failure with exit 1 instead of the usage error with exit 2 that `deployments list` already returns for the same input.

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -90,8 +90,8 @@ async function list(argv: readonly string[], json: boolean): Promise<number> {
     strict: true,
     options: commonListOptions(),
   });
-  const { api, organizationId } = await cloudApiForOrganization(values.org);
   const { limit, skip } = parsePagination(values.limit, values.skip);
+  const { api, organizationId } = await cloudApiForOrganization(values.org);
   const query = new URLSearchParams({
     organizationId,
     limit: String(limit),

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -121,6 +121,28 @@ describe("server environment deletion", () => {
   });
 });
 
+describe("server list argument validation", () => {
+  it("rejects a bad page size before authenticating", async () => {
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await expect(runServers(["list", "--limit", "0", "--json"])).resolves.toBe(
+      2
+    );
+
+    // Nothing should reach the cloud for a command line that cannot run.
+    expect(cloudApiForOrganization).not.toHaveBeenCalled();
+    expect(api.request).not.toHaveBeenCalled();
+    expect(JSON.parse(stderr.mock.calls.flat().join(""))).toEqual({
+      error: {
+        code: "usage_error",
+        message: "--limit must be an integer from 1 to 100.",
+      },
+    });
+  });
+});
+
 describe("server human output", () => {
   it("renders a compact list instead of raw API JSON", async () => {
     api.request.mockResolvedValue({

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -141,6 +141,25 @@ describe("server list argument validation", () => {
       },
     });
   });
+
+  it("rejects a bad skip before authenticating", async () => {
+    const stderr = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    await expect(runServers(["list", "--skip", "abc", "--json"])).resolves.toBe(
+      2
+    );
+
+    expect(cloudApiForOrganization).not.toHaveBeenCalled();
+    expect(api.request).not.toHaveBeenCalled();
+    expect(JSON.parse(stderr.mock.calls.flat().join(""))).toEqual({
+      error: {
+        code: "usage_error",
+        message: "--skip must be a non-negative integer.",
+      },
+    });
+  });
 });
 
 describe("server human output", () => {


### PR DESCRIPTION
## Why

`servers list` and `deployments list` take the same `--limit` and `--skip`, validate them against the same bounds, and disagree about what an invalid value is.

```console
$ mcp-use servers list --limit 0
Not logged in. Run `mcp-use login`.          # exit 1

$ mcp-use deployments list --limit 0
--limit must be an integer from 1 to 100.    # exit 2
```

`deployments list` validates first (`deployments.ts:93`), then creates the client. `servers list` had it the other way round (`servers.ts:92`), so signed out the check never runs and a mistyped page size is reported as an operational failure telling you to log in. Logging in and running it again then gives the real error.

Both `--limit abc` and `--skip abc` behave the same way.

## The change

One line moves:

```diff
-  const { api, organizationId } = await cloudApiForOrganization(values.org);
   const { limit, skip } = parsePagination(values.limit, values.skip);
+  const { api, organizationId } = await cloudApiForOrganization(values.org);
```

```console
$ mcp-use servers list --limit 0
--limit must be an integer from 1 to 100.    # exit 2
$ mcp-use servers list --skip abc
--skip must be a non-negative integer.       # exit 2
```

It also stops the command reaching for credentials in order to run something that cannot run either way.

I left `parsePagination` and `boundedInteger` as two helpers even though `parsePagination` now has a single caller. Folding it into `boundedInteger` would replace `--skip must be a non-negative integer.` with the generated `--skip must be an integer from 0 to 9007199254740991.`, which reads worse for a flag with no real upper bound. Happy to unify if you would rather have one helper and do not mind that message.

`org use` looks similar but is not: it has to fetch the organization list before it can tell whether the selector resolves, so authentication genuinely comes first there.

## Test

Added to `tests/commands/servers.test.ts`, asserting exit 2, the usage error, and that neither `cloudApiForOrganization` nor `api.request` was called. On the unfixed source it fails with `expected "vi.fn()" to not be called at all, but actually been called 1 times`.

## Validation

From `libraries/typescript/packages/cli`: `vitest run` — 297 passed, 23 files.
From `libraries/typescript`: `eslint` and `prettier --check` on both changed files — clean.
Monorepo preflight — 0 failing packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `servers list` validate `--limit` and `--skip` before creating the cloud client, so an invalid value now reports a usage error with exit 2 instead of `Not logged in.` with exit 1 when signed out. The command now matches `deployments list` behavior and no longer attempts authentication for a command line that cannot run.

<sup>Written for commit a770125ce8fc0d919be6c30ce6c27b464ce95b90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

