### PR TITLE
fix(inspector): harden hosted OAuth state and relay boundaries

### DIFF
--- a/libraries/typescript/.changeset/hosted-oauth-state.md
+++ b/libraries/typescript/.changeset/hosted-oauth-state.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": minor
+---
+
+Harden the Inspector OAuth and MCP relay foundations for hosted deployments with explicit state-store modes, encrypted Redis state with readiness and safe compare-and-set semantics, issuer-aware confidential-client handling, exact-origin CORS, and an injectable relay authentication boundary.

--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -401,8 +401,23 @@ the hosted Inspector.
 Exact-origin CORS is not caller authentication. The reusable `mountInspector`
 and `mountOAuthProxy` APIs accept an `authenticate` callback so the embedding
 application can verify its own session or signed capability before any
-upstream request. The standalone CLI intentionally does not invent a browser
-credential. A publicly reachable product relay therefore remains a rollout
+upstream request. The callback is invoked as `(c, target)`; existing one-
+argument callbacks remain valid, while hosted verifiers should use the target
+context below to bind a capability without parsing or cloning the request body:
+
+```ts
+type InspectorRelayTarget = {
+  origin: string;
+  pathname: string;
+  method: string;
+};
+```
+
+The browser-facing capability belongs in the distinct
+`X-Inspector-Relay-Token` header. Both relay preflights allow it, and the
+relay strips it before every upstream request. Upstream `Authorization` is a
+separate application credential and must not be reused as the relay
+capability. A publicly reachable product relay therefore remains a rollout
 blocker until Cloud or an edge gateway supplies that user/session- and
 target-bound authentication boundary, plus a distributed rate limit. The
 Inspector's built-in rate limiter is a bounded per-process backstop, not a

--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -354,13 +354,40 @@ services:
 
 ### Environment Variables
 
-All configuration is optional. The inspector works out of the box with sensible defaults.
+Local development works with in-memory OAuth state. A production deployment
+must provide a shared Redis store and encryption key because OAuth registration
+and token requests may land on different replicas.
 
 | Variable   | Default    | Description                  |
 | ---------- | ---------- | ---------------------------- |
 | `NODE_ENV` | production | Node.js environment          |
 | `PORT`     | 8080       | Port to run the inspector on |
 | `HOST`     | 0.0.0.0    | Host to bind to              |
+| `INSPECTOR_OAUTH_REDIS_URL` (or `REDIS_URL`) | — | Shared Redis URL required in production |
+| `INSPECTOR_OAUTH_ENCRYPTION_KEY` | — | Base64-encoded 32-byte AES key required in production |
+| `INSPECTOR_OAUTH_ALLOWED_ORIGINS` | — | Comma-separated exact browser origins allowed for OAuth |
+| `INSPECTOR_MCP_ALLOWED_ORIGINS` | OAuth origins | Comma-separated exact browser origins allowed for MCP |
+| `INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON` | — | Server-only JSON array of configured confidential clients |
+| `INSPECTOR_ALLOW_LOOPBACK` | `true` locally, `false` in production | Permit loopback upstream targets |
+
+`INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON` is intentionally read only by the
+server. Its shape is:
+
+```json
+[
+  {
+    "serverUrls": ["https://mcp.example.com/mcp"],
+    "clientId": "server-issued-client-id",
+    "clientSecret": "server-issued-client-secret",
+    "authMethod": "client_secret_post"
+  }
+]
+```
+
+Secrets are never included in browser responses or logs. Do not use `*` for
+OAuth origins; list every product origin explicitly. For a multi-replica
+deployment, configure these values in the secret manager (Infisical/Railway)
+before routing application OAuth traffic to the hosted Inspector.
 
 ---
 

--- a/libraries/typescript/packages/inspector/README.md
+++ b/libraries/typescript/packages/inspector/README.md
@@ -354,19 +354,25 @@ services:
 
 ### Environment Variables
 
-Local development works with in-memory OAuth state. A production deployment
-must provide a shared Redis store and encryption key because OAuth registration
-and token requests may land on different replicas.
+The standalone CLI has three explicit OAuth state modes. Local/self-hosted
+development defaults to `memory`, while a production CLI defaults to
+`disabled` so an MCP-only deployment starts without OAuth infrastructure. Set
+`redis` for a multi-replica hosted Inspector; set `memory` only for a deliberate
+single-process deployment.
 
 | Variable   | Default    | Description                  |
 | ---------- | ---------- | ---------------------------- |
 | `NODE_ENV` | production | Node.js environment          |
 | `PORT`     | 8080       | Port to run the inspector on |
 | `HOST`     | 0.0.0.0    | Host to bind to              |
-| `INSPECTOR_OAUTH_REDIS_URL` (or `REDIS_URL`) | — | Shared Redis URL required in production |
-| `INSPECTOR_OAUTH_ENCRYPTION_KEY` | — | Base64-encoded 32-byte AES key required in production |
+| `INSPECTOR_OAUTH_STATE_STORE` | `memory` locally, `disabled` in production | `disabled`, `memory`, or `redis` |
+| `INSPECTOR_OAUTH_REDIS_URL` (or `REDIS_URL`) | — | Shared Redis URL required when state mode is `redis` |
+| `INSPECTOR_OAUTH_ENCRYPTION_KEY` | — | Base64-encoded 32-byte AES key required when state mode is `redis` |
+| `INSPECTOR_OAUTH_ENCRYPTION_KEY_ID` | `current` | Non-secret key ID written into new encryption envelopes |
+| `INSPECTOR_OAUTH_PREVIOUS_ENCRYPTION_KEYS_JSON` | — | Server-only JSON array of `{ "id", "key" }` old keys accepted during rotation |
+| `INSPECTOR_OAUTH_REDIS_KEY_PREFIX` | environment-scoped | Redis namespace; keep development and production prefixes separate |
 | `INSPECTOR_OAUTH_ALLOWED_ORIGINS` | — | Comma-separated exact browser origins allowed for OAuth |
-| `INSPECTOR_MCP_ALLOWED_ORIGINS` | OAuth origins | Comma-separated exact browser origins allowed for MCP |
+| `INSPECTOR_MCP_ALLOWED_ORIGINS` | OAuth origins (or no cross-origin access in production) | Comma-separated exact browser origins allowed for MCP; omission is legacy wildcard only in local mode |
 | `INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON` | — | Server-only JSON array of configured confidential clients |
 | `INSPECTOR_ALLOW_LOOPBACK` | `true` locally, `false` in production | Permit loopback upstream targets |
 
@@ -377,6 +383,7 @@ server. Its shape is:
 [
   {
     "serverUrls": ["https://mcp.example.com/mcp"],
+    "authorizationServers": ["https://login.example.com"],
     "clientId": "server-issued-client-id",
     "clientSecret": "server-issued-client-secret",
     "authMethod": "client_secret_post"
@@ -385,9 +392,22 @@ server. Its shape is:
 ```
 
 Secrets are never included in browser responses or logs. Do not use `*` for
-OAuth origins; list every product origin explicitly. For a multi-replica
-deployment, configure these values in the secret manager (Infisical/Railway)
-before routing application OAuth traffic to the hosted Inspector.
+OAuth or hosted MCP origins; list every product origin explicitly. DCR state is
+encrypted at rest, uses revision-aware writes, and accepts old key IDs only
+when those old keys are explicitly configured. Configure these values in the
+secret manager (Infisical/Railway) before routing application OAuth traffic to
+the hosted Inspector.
+
+Exact-origin CORS is not caller authentication. The reusable `mountInspector`
+and `mountOAuthProxy` APIs accept an `authenticate` callback so the embedding
+application can verify its own session or signed capability before any
+upstream request. The standalone CLI intentionally does not invent a browser
+credential. A publicly reachable product relay therefore remains a rollout
+blocker until Cloud or an edge gateway supplies that user/session- and
+target-bound authentication boundary, plus a distributed rate limit. The
+Inspector's built-in rate limiter is a bounded per-process backstop, not a
+multi-replica product authorization mechanism; PR #2260's relay rate-limit
+changes are not implicitly included here.
 
 ---
 

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -147,9 +147,7 @@
       "optional": true
     }
   },
-  "dependencies": {
-    "redis": "^5.8.2"
-  },
+  "dependencies": {},
   "publishConfig": {
     "access": "public"
   },
@@ -179,6 +177,7 @@
     "react-router": "^8.3.0",
     "react-resizable-panels": "^4.6.4",
     "rate-limiter-flexible": "^11.2.0",
+    "redis": "^5.8.2",
     "rollup-plugin-visualizer": "^6.0.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",

--- a/libraries/typescript/packages/inspector/package.json
+++ b/libraries/typescript/packages/inspector/package.json
@@ -147,7 +147,9 @@
       "optional": true
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "redis": "^5.8.2"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/libraries/typescript/packages/inspector/src/server/cli-config.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli-config.ts
@@ -1,0 +1,91 @@
+import type { OAuthProxyConfidentialClientResolver } from "./proxy/oauth-proxy.js";
+
+/** Parse server-only confidential-client configuration for the standalone CLI. */
+export function createConfidentialClientResolver(
+  value: string | undefined
+): OAuthProxyConfidentialClientResolver | undefined {
+  if (!value) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(
+      "INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be valid JSON"
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be an array"
+    );
+  }
+  const clients = parsed.map((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error("Invalid Inspector confidential client entry");
+    }
+    const record = entry as Record<string, unknown>;
+    const serverUrls = record.serverUrls;
+    const authorizationServers = record.authorizationServers;
+    if (
+      !Array.isArray(serverUrls) ||
+      serverUrls.length === 0 ||
+      !serverUrls.every((url): url is string => typeof url === "string") ||
+      (authorizationServers !== undefined &&
+        (!Array.isArray(authorizationServers) ||
+          !authorizationServers.every(
+            (url): url is string => typeof url === "string"
+          )))
+    ) {
+      throw new Error("Invalid Inspector confidential client entry");
+    }
+    const clientId = record.clientId;
+    const clientSecret = record.clientSecret;
+    const authMethod = record.authMethod;
+    if (
+      typeof clientId !== "string" ||
+      typeof clientSecret !== "string" ||
+      (authMethod !== "client_secret_basic" &&
+        authMethod !== "client_secret_post")
+    ) {
+      throw new Error("Invalid Inspector confidential client entry");
+    }
+    return {
+      serverUrls: serverUrls.map((url) => canonicalUrl(url)),
+      authorizationServers: (authorizationServers ?? []).map((url) =>
+        canonicalUrl(url)
+      ),
+      clientId,
+      clientSecret,
+      authMethod: authMethod as "client_secret_basic" | "client_secret_post",
+    };
+  });
+  return ({ serverUrl, clientId, authorizationServer }) => {
+    const match = clients.find(
+      (client) =>
+        client.clientId === clientId &&
+        client.serverUrls.some((url) => url === canonicalUrl(serverUrl)) &&
+        (client.authorizationServers.length === 0 ||
+          (authorizationServer !== undefined &&
+            client.authorizationServers.includes(
+              canonicalUrl(authorizationServer)
+            )))
+    );
+    return match
+      ? {
+          clientSecret: match.clientSecret,
+          authMethod: match.authMethod,
+        }
+      : undefined;
+  };
+}
+
+function canonicalUrl(value: string): string {
+  const url = new URL(value);
+  url.hash = "";
+  if (
+    (url.protocol === "https:" && url.port === "443") ||
+    (url.protocol === "http:" && url.port === "80")
+  ) {
+    url.port = "";
+  }
+  return url.toString().replace(/\/$/, "");
+}

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -10,7 +10,10 @@ import {
   createRedisOAuthProxyStateStore,
   decodeOAuthProxyEncryptionKey,
 } from "./proxy/index.js";
-import type { OAuthProxyConfidentialClientResolver } from "./proxy/oauth-proxy.js";
+import type {
+  OAuthProxyConfidentialClientResolver,
+  OAuthProxyEncryptionKey,
+} from "./proxy/index.js";
 import {
   findAvailablePort,
   formatErrorDiagnostic,
@@ -94,29 +97,40 @@ const allowLoopback = process.env.INSPECTOR_ALLOW_LOOPBACK
 const oauthAllowedOrigins = parseOrigins(
   process.env.INSPECTOR_OAUTH_ALLOWED_ORIGINS
 );
-const mcpAllowedOrigins = parseOrigins(
-  process.env.INSPECTOR_MCP_ALLOWED_ORIGINS ??
-    process.env.INSPECTOR_OAUTH_ALLOWED_ORIGINS
-);
 const production = process.env.NODE_ENV === "production";
+const mcpOriginValue = process.env.INSPECTOR_MCP_ALLOWED_ORIGINS;
+const mcpAllowedOrigins =
+  mcpOriginValue !== undefined
+    ? parseOrigins(mcpOriginValue)
+    : process.env.INSPECTOR_OAUTH_ALLOWED_ORIGINS !== undefined
+      ? oauthAllowedOrigins
+      : production
+        ? []
+        : undefined;
 const redisUrl = process.env.INSPECTOR_OAUTH_REDIS_URL ?? process.env.REDIS_URL;
 const encryptionKeyValue = process.env.INSPECTOR_OAUTH_ENCRYPTION_KEY;
-if (production && (!redisUrl || !encryptionKeyValue)) {
-  throw new Error(
-    "Production Inspector OAuth requires INSPECTOR_OAUTH_REDIS_URL (or REDIS_URL) and INSPECTOR_OAUTH_ENCRYPTION_KEY"
-  );
-}
-if (production && oauthAllowedOrigins.length === 0) {
-  throw new Error(
-    "Production Inspector OAuth requires INSPECTOR_OAUTH_ALLOWED_ORIGINS"
-  );
-}
-const oauthProxyStateStore = redisUrl
-  ? createRedisOAuthProxyStateStore({
-      url: redisUrl,
-      encryptionKey: decodeOAuthProxyEncryptionKey(encryptionKeyValue ?? ""),
-    })
-  : createMemoryOAuthProxyStateStore();
+const oauthStateStoreMode = parseOAuthStateStoreMode(
+  process.env.INSPECTOR_OAUTH_STATE_STORE,
+  redisUrl,
+  encryptionKeyValue,
+  production
+);
+const oauthProxyStateStore =
+  oauthStateStoreMode === "redis"
+    ? createRedisOAuthProxyStateStore({
+        url: redisUrl!,
+        encryptionKey: decodeOAuthProxyEncryptionKey(encryptionKeyValue!),
+        encryptionKeyId: process.env.INSPECTOR_OAUTH_ENCRYPTION_KEY_ID,
+        decryptionKeys: parsePreviousEncryptionKeys(
+          process.env.INSPECTOR_OAUTH_PREVIOUS_ENCRYPTION_KEYS_JSON
+        ),
+        keyPrefix:
+          process.env.INSPECTOR_OAUTH_REDIS_KEY_PREFIX ??
+          `mcp-use:inspector:oauth:${process.env.NODE_ENV ?? "development"}:`,
+      })
+    : oauthStateStoreMode === "memory"
+      ? createMemoryOAuthProxyStateStore()
+      : undefined;
 const oauthProxyConfidentialClientResolver = createConfidentialClientResolver(
   process.env.INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON
 );
@@ -126,6 +140,7 @@ registerInspectorProxyRoutes(app, {
   oauthProxyAllowedOrigins: oauthAllowedOrigins,
   mcpProxyAllowedOrigins: mcpAllowedOrigins,
   oauthProxyAllowLoopback: allowLoopback,
+  oauth: oauthStateStoreMode !== "disabled",
   oauthProxyStateStore,
   oauthProxyConfidentialClientResolver,
 });
@@ -135,17 +150,16 @@ registerInspectorShell(app, {
   manufactChatUrl: process.env.MANUFACT_CHAT_URL,
 });
 
-process.once("SIGTERM", () => {
-  void oauthProxyStateStore.close?.();
-});
-process.once("SIGINT", () => {
-  void oauthProxyStateStore.close?.();
-});
+let shutdownStarted = false;
+process.once("SIGTERM", () => void shutdown("SIGTERM"));
+process.once("SIGINT", () => void shutdown("SIGINT"));
+let activeServer: ReturnType<typeof serve> | undefined;
 
 async function startServer() {
   try {
+    await oauthProxyStateStore?.ready?.();
     const port = await findAvailablePort(startPort);
-    serve({
+    const server = serve({
       fetch: app.fetch,
       port,
     });
@@ -168,6 +182,7 @@ async function startServer() {
         console.error(`Browser open error: ${formatErrorDiagnostic(error)}`);
       }
     }
+    activeServer = server;
     return { port, fetch: app.fetch };
   } catch (error) {
     console.error(
@@ -178,6 +193,85 @@ async function startServer() {
 }
 
 startServer();
+
+async function shutdown(signal: string): Promise<void> {
+  if (shutdownStarted) return;
+  shutdownStarted = true;
+  const deadline = new Promise<void>((resolve) => setTimeout(resolve, 2_000));
+  await Promise.race([
+    Promise.allSettled([
+      closeHttpServer(activeServer),
+      oauthProxyStateStore?.close?.(),
+    ]).then(() => undefined),
+    deadline,
+  ]);
+  console.log(`MCP Inspector stopped (${signal}).`);
+  process.exit(0);
+}
+
+function closeHttpServer(
+  server: ReturnType<typeof serve> | undefined
+): Promise<void> {
+  if (!server) return Promise.resolve();
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+type OAuthStateStoreMode = "disabled" | "memory" | "redis";
+
+function parseOAuthStateStoreMode(
+  value: string | undefined,
+  redisUrl: string | undefined,
+  encryptionKey: string | undefined,
+  production: boolean
+): OAuthStateStoreMode {
+  const mode = value?.trim().toLowerCase();
+  if (mode && mode !== "disabled" && mode !== "memory" && mode !== "redis") {
+    throw new Error(
+      "INSPECTOR_OAUTH_STATE_STORE must be one of disabled, memory, or redis"
+    );
+  }
+  const resolved =
+    (mode as OAuthStateStoreMode | undefined) ??
+    (redisUrl || encryptionKey ? "redis" : production ? "disabled" : "memory");
+  if (resolved === "redis" && (!redisUrl || !encryptionKey)) {
+    throw new Error(
+      "Redis OAuth state mode requires INSPECTOR_OAUTH_REDIS_URL (or REDIS_URL) and INSPECTOR_OAUTH_ENCRYPTION_KEY"
+    );
+  }
+  return resolved;
+}
+
+function parsePreviousEncryptionKeys(
+  value: string | undefined
+): OAuthProxyEncryptionKey[] | undefined {
+  if (!value) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error(
+      "INSPECTOR_OAUTH_PREVIOUS_ENCRYPTION_KEYS_JSON must be valid JSON"
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "INSPECTOR_OAUTH_PREVIOUS_ENCRYPTION_KEYS_JSON must be an array"
+    );
+  }
+  return parsed.map((entry) => {
+    if (!entry || typeof entry !== "object") {
+      throw new Error("Invalid previous OAuth encryption key entry");
+    }
+    const record = entry as Record<string, unknown>;
+    if (typeof record.id !== "string" || typeof record.key !== "string") {
+      throw new Error("Invalid previous OAuth encryption key entry");
+    }
+    return {
+      id: record.id,
+      key: decodeOAuthProxyEncryptionKey(record.key),
+    };
+  });
+}
 
 function parseOrigins(value: string | undefined): string[] {
   if (!value) return [];
@@ -214,6 +308,11 @@ function createConfidentialClientResolver(
           (url): url is string => typeof url === "string"
         )
       : [];
+    const authorizationServers = Array.isArray(record.authorizationServers)
+      ? record.authorizationServers.filter(
+          (url): url is string => typeof url === "string"
+        )
+      : [];
     const clientId = record.clientId;
     const clientSecret = record.clientSecret;
     const authMethod = record.authMethod;
@@ -228,16 +327,24 @@ function createConfidentialClientResolver(
     }
     return {
       serverUrls: serverUrls.map((url) => canonicalUrl(url)),
+      authorizationServers: authorizationServers.map((url) =>
+        canonicalUrl(url)
+      ),
       clientId,
       clientSecret,
       authMethod: authMethod as "client_secret_basic" | "client_secret_post",
     };
   });
-  return ({ serverUrl, clientId }) => {
+  return ({ serverUrl, clientId, authorizationServer }) => {
     const match = clients.find(
       (client) =>
         client.clientId === clientId &&
-        client.serverUrls.some((url) => url === canonicalUrl(serverUrl))
+        client.serverUrls.some((url) => url === canonicalUrl(serverUrl)) &&
+        (client.authorizationServers.length === 0 ||
+          (authorizationServer !== undefined &&
+            client.authorizationServers.includes(
+              canonicalUrl(authorizationServer)
+            )))
     );
     return match
       ? {

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -135,6 +135,13 @@ registerInspectorShell(app, {
   manufactChatUrl: process.env.MANUFACT_CHAT_URL,
 });
 
+process.once("SIGTERM", () => {
+  void oauthProxyStateStore.close?.();
+});
+process.once("SIGINT", () => {
+  void oauthProxyStateStore.close?.();
+});
+
 async function startServer() {
   try {
     const port = await findAvailablePort(startPort);

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -99,8 +99,7 @@ const mcpAllowedOrigins = parseOrigins(
     process.env.INSPECTOR_OAUTH_ALLOWED_ORIGINS
 );
 const production = process.env.NODE_ENV === "production";
-const redisUrl =
-  process.env.INSPECTOR_OAUTH_REDIS_URL ?? process.env.REDIS_URL;
+const redisUrl = process.env.INSPECTOR_OAUTH_REDIS_URL ?? process.env.REDIS_URL;
 const encryptionKeyValue = process.env.INSPECTOR_OAUTH_ENCRYPTION_KEY;
 if (production && (!redisUrl || !encryptionKeyValue)) {
   throw new Error(
@@ -189,7 +188,9 @@ function createConfidentialClientResolver(
   try {
     parsed = JSON.parse(value);
   } catch {
-    throw new Error("INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be valid JSON");
+    throw new Error(
+      "INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be valid JSON"
+    );
   }
   if (!Array.isArray(parsed)) {
     throw new Error(
@@ -202,7 +203,9 @@ function createConfidentialClientResolver(
     }
     const record = entry as Record<string, unknown>;
     const serverUrls = Array.isArray(record.serverUrls)
-      ? record.serverUrls.filter((url): url is string => typeof url === "string")
+      ? record.serverUrls.filter(
+          (url): url is string => typeof url === "string"
+        )
       : [];
     const clientId = record.clientId;
     const clientSecret = record.clientSecret;
@@ -220,9 +223,7 @@ function createConfidentialClientResolver(
       serverUrls: serverUrls.map((url) => canonicalUrl(url)),
       clientId,
       clientSecret,
-      authMethod: authMethod as
-        | "client_secret_basic"
-        | "client_secret_post",
+      authMethod: authMethod as "client_secret_basic" | "client_secret_post",
     };
   });
   return ({ serverUrl, clientId }) => {

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -2,10 +2,15 @@
 
 import { serve } from "@hono/node-server";
 import { Hono } from "hono";
-import { cors } from "hono/cors";
 import open from "open";
 import { registerInspectorShell } from "./inspector-shell.js";
 import { registerInspectorProxyRoutes } from "./proxy-routes.js";
+import {
+  createMemoryOAuthProxyStateStore,
+  createRedisOAuthProxyStateStore,
+  decodeOAuthProxyEncryptionKey,
+} from "./proxy/index.js";
+import type { OAuthProxyConfidentialClientResolver } from "./proxy/oauth-proxy.js";
 import {
   findAvailablePort,
   formatErrorDiagnostic,
@@ -77,14 +82,6 @@ Examples:
 }
 
 const app = new Hono();
-
-app.use(
-  "*",
-  cors({
-    origin: "*",
-    exposeHeaders: ["*"],
-  })
-);
 // The CLI is primarily local dev tooling, where proxying to localhost MCP
 // servers is the main use case — but the published Docker image runs this same
 // CLI with NODE_ENV=production on a public port, where loopback proxying is
@@ -94,10 +91,44 @@ const allowLoopback = process.env.INSPECTOR_ALLOW_LOOPBACK
   ? process.env.INSPECTOR_ALLOW_LOOPBACK === "true"
   : process.env.NODE_ENV !== "production";
 
+const oauthAllowedOrigins = parseOrigins(
+  process.env.INSPECTOR_OAUTH_ALLOWED_ORIGINS
+);
+const mcpAllowedOrigins = parseOrigins(
+  process.env.INSPECTOR_MCP_ALLOWED_ORIGINS ??
+    process.env.INSPECTOR_OAUTH_ALLOWED_ORIGINS
+);
+const production = process.env.NODE_ENV === "production";
+const redisUrl =
+  process.env.INSPECTOR_OAUTH_REDIS_URL ?? process.env.REDIS_URL;
+const encryptionKeyValue = process.env.INSPECTOR_OAUTH_ENCRYPTION_KEY;
+if (production && (!redisUrl || !encryptionKeyValue)) {
+  throw new Error(
+    "Production Inspector OAuth requires INSPECTOR_OAUTH_REDIS_URL (or REDIS_URL) and INSPECTOR_OAUTH_ENCRYPTION_KEY"
+  );
+}
+if (production && oauthAllowedOrigins.length === 0) {
+  throw new Error(
+    "Production Inspector OAuth requires INSPECTOR_OAUTH_ALLOWED_ORIGINS"
+  );
+}
+const oauthProxyStateStore = redisUrl
+  ? createRedisOAuthProxyStateStore({
+      url: redisUrl,
+      encryptionKey: decodeOAuthProxyEncryptionKey(encryptionKeyValue ?? ""),
+    })
+  : createMemoryOAuthProxyStateStore();
+const oauthProxyConfidentialClientResolver = createConfidentialClientResolver(
+  process.env.INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON
+);
+
 registerInspectorProxyRoutes(app, {
   autoConnectUrl: mcpUrl,
-  oauthProxyAllowedOrigins: [],
+  oauthProxyAllowedOrigins: oauthAllowedOrigins,
+  mcpProxyAllowedOrigins: mcpAllowedOrigins,
   oauthProxyAllowLoopback: allowLoopback,
+  oauthProxyStateStore,
+  oauthProxyConfidentialClientResolver,
 });
 
 registerInspectorShell(app, {
@@ -141,3 +172,82 @@ async function startServer() {
 }
 
 startServer();
+
+function parseOrigins(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
+function createConfidentialClientResolver(
+  value: string | undefined
+): OAuthProxyConfidentialClientResolver | undefined {
+  if (!value) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new Error("INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be valid JSON");
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be an array"
+    );
+  }
+  const clients = parsed.map((entry) => {
+    if (!entry || typeof entry !== "object") {
+      throw new Error("Invalid Inspector confidential client entry");
+    }
+    const record = entry as Record<string, unknown>;
+    const serverUrls = Array.isArray(record.serverUrls)
+      ? record.serverUrls.filter((url): url is string => typeof url === "string")
+      : [];
+    const clientId = record.clientId;
+    const clientSecret = record.clientSecret;
+    const authMethod = record.authMethod;
+    if (
+      serverUrls.length === 0 ||
+      typeof clientId !== "string" ||
+      typeof clientSecret !== "string" ||
+      (authMethod !== "client_secret_basic" &&
+        authMethod !== "client_secret_post")
+    ) {
+      throw new Error("Invalid Inspector confidential client entry");
+    }
+    return {
+      serverUrls: serverUrls.map((url) => canonicalUrl(url)),
+      clientId,
+      clientSecret,
+      authMethod: authMethod as
+        | "client_secret_basic"
+        | "client_secret_post",
+    };
+  });
+  return ({ serverUrl, clientId }) => {
+    const match = clients.find(
+      (client) =>
+        client.clientId === clientId &&
+        client.serverUrls.some((url) => url === canonicalUrl(serverUrl))
+    );
+    return match
+      ? {
+          clientSecret: match.clientSecret,
+          authMethod: match.authMethod,
+        }
+      : undefined;
+  };
+}
+
+function canonicalUrl(value: string): string {
+  const url = new URL(value);
+  url.hash = "";
+  if (
+    (url.protocol === "https:" && url.port === "443") ||
+    (url.protocol === "http:" && url.port === "80")
+  ) {
+    url.port = "";
+  }
+  return url.toString().replace(/\/$/, "");
+}

--- a/libraries/typescript/packages/inspector/src/server/cli.ts
+++ b/libraries/typescript/packages/inspector/src/server/cli.ts
@@ -5,15 +5,13 @@ import { Hono } from "hono";
 import open from "open";
 import { registerInspectorShell } from "./inspector-shell.js";
 import { registerInspectorProxyRoutes } from "./proxy-routes.js";
+import { createConfidentialClientResolver } from "./cli-config.js";
 import {
   createMemoryOAuthProxyStateStore,
   createRedisOAuthProxyStateStore,
   decodeOAuthProxyEncryptionKey,
 } from "./proxy/index.js";
-import type {
-  OAuthProxyConfidentialClientResolver,
-  OAuthProxyEncryptionKey,
-} from "./proxy/index.js";
+import type { OAuthProxyEncryptionKey } from "./proxy/index.js";
 import {
   findAvailablePort,
   formatErrorDiagnostic,
@@ -279,90 +277,4 @@ function parseOrigins(value: string | undefined): string[] {
     .split(",")
     .map((origin) => origin.trim())
     .filter(Boolean);
-}
-
-function createConfidentialClientResolver(
-  value: string | undefined
-): OAuthProxyConfidentialClientResolver | undefined {
-  if (!value) return undefined;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(value);
-  } catch {
-    throw new Error(
-      "INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be valid JSON"
-    );
-  }
-  if (!Array.isArray(parsed)) {
-    throw new Error(
-      "INSPECTOR_OAUTH_CONFIDENTIAL_CLIENTS_JSON must be an array"
-    );
-  }
-  const clients = parsed.map((entry) => {
-    if (!entry || typeof entry !== "object") {
-      throw new Error("Invalid Inspector confidential client entry");
-    }
-    const record = entry as Record<string, unknown>;
-    const serverUrls = Array.isArray(record.serverUrls)
-      ? record.serverUrls.filter(
-          (url): url is string => typeof url === "string"
-        )
-      : [];
-    const authorizationServers = Array.isArray(record.authorizationServers)
-      ? record.authorizationServers.filter(
-          (url): url is string => typeof url === "string"
-        )
-      : [];
-    const clientId = record.clientId;
-    const clientSecret = record.clientSecret;
-    const authMethod = record.authMethod;
-    if (
-      serverUrls.length === 0 ||
-      typeof clientId !== "string" ||
-      typeof clientSecret !== "string" ||
-      (authMethod !== "client_secret_basic" &&
-        authMethod !== "client_secret_post")
-    ) {
-      throw new Error("Invalid Inspector confidential client entry");
-    }
-    return {
-      serverUrls: serverUrls.map((url) => canonicalUrl(url)),
-      authorizationServers: authorizationServers.map((url) =>
-        canonicalUrl(url)
-      ),
-      clientId,
-      clientSecret,
-      authMethod: authMethod as "client_secret_basic" | "client_secret_post",
-    };
-  });
-  return ({ serverUrl, clientId, authorizationServer }) => {
-    const match = clients.find(
-      (client) =>
-        client.clientId === clientId &&
-        client.serverUrls.some((url) => url === canonicalUrl(serverUrl)) &&
-        (client.authorizationServers.length === 0 ||
-          (authorizationServer !== undefined &&
-            client.authorizationServers.includes(
-              canonicalUrl(authorizationServer)
-            )))
-    );
-    return match
-      ? {
-          clientSecret: match.clientSecret,
-          authMethod: match.authMethod,
-        }
-      : undefined;
-  };
-}
-
-function canonicalUrl(value: string): string {
-  const url = new URL(value);
-  url.hash = "";
-  if (
-    (url.protocol === "https:" && url.port === "443") ||
-    (url.protocol === "http:" && url.port === "80")
-  ) {
-    url.port = "";
-  }
-  return url.toString().replace(/\/$/, "");
 }

--- a/libraries/typescript/packages/inspector/src/server/create-dev-api-app.ts
+++ b/libraries/typescript/packages/inspector/src/server/create-dev-api-app.ts
@@ -1,8 +1,16 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { registerInspectorProxyRoutes } from "./proxy-routes.js";
+import { INSPECTOR_RELAY_CAPABILITY_HEADER } from "./relay-auth.js";
 
-/** Hono app for inspector dev API routes (MCP proxy + OAuth BFF). */
+/**
+ * Hono app for the Inspector's local development API routes.
+ *
+ * This wrapper intentionally permits wildcard CORS and loopback targets for
+ * local tooling. Hosted or production relays must use `registerInspectorProxyRoutes`
+ * or `mountInspector` with explicit origins, authentication, and deployment
+ * policy instead of promoting this dev-only wrapper.
+ */
 export function createDevApiApp(): Hono {
   const app = new Hono();
 
@@ -19,6 +27,12 @@ export function createDevApiApp(): Hono {
         "Mcp-Session-Id",
         "mcp-session-id",
         "mcp-protocol-version",
+        "Mcp-Protocol-Version",
+        "Mcp-Method",
+        "Mcp-Name",
+        "DPoP",
+        INSPECTOR_RELAY_CAPABILITY_HEADER,
+        "Last-Event-ID",
         "X-Server-Id",
         "X-Requested-With",
       ],

--- a/libraries/typescript/packages/inspector/src/server/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/index.ts
@@ -18,6 +18,7 @@ export {
   createMemoryOAuthProxyStateStore,
   createRedisOAuthProxyStateStore,
   decodeOAuthProxyEncryptionKey,
+  type OAuthProxyEncryptionKey,
   type OAuthProxyStateStore,
 } from "./proxy/oauth-state-store.js";
 export type {

--- a/libraries/typescript/packages/inspector/src/server/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/index.ts
@@ -14,3 +14,13 @@ export {
   registerInspectorProxyRoutes,
   type InspectorProxyRoutesConfig,
 } from "./proxy-routes.js";
+export {
+  createMemoryOAuthProxyStateStore,
+  createRedisOAuthProxyStateStore,
+  decodeOAuthProxyEncryptionKey,
+  type OAuthProxyStateStore,
+} from "./proxy/oauth-state-store.js";
+export type {
+  OAuthProxyConfidentialClient,
+  OAuthProxyConfidentialClientResolver,
+} from "./proxy/oauth-proxy.js";

--- a/libraries/typescript/packages/inspector/src/server/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/index.ts
@@ -25,3 +25,8 @@ export type {
   OAuthProxyConfidentialClient,
   OAuthProxyConfidentialClientResolver,
 } from "./proxy/oauth-proxy.js";
+export {
+  INSPECTOR_RELAY_CAPABILITY_HEADER,
+  type InspectorRelayAuthenticator,
+  type InspectorRelayTarget,
+} from "./relay-auth.js";

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -6,6 +6,7 @@ import {
   registerInspectorProxyRoutes,
   type InspectorProxyRoutesConfig,
 } from "./proxy-routes.js";
+import type { InspectorRelayAuthenticator } from "./relay-auth.js";
 
 /** Web-standard handler returned by {@link mountInspector}. */
 export type InspectorFetchHandler = (
@@ -31,7 +32,7 @@ export interface MountInspectorOptions {
   /** Explicit cross-origin callers of the MCP proxy. Omission preserves legacy wildcard CORS. */
   mcpProxyAllowedOrigins?: readonly string[];
   /** Optional product authentication; upstream Authorization remains separate. */
-  authenticate?: InspectorProxyRoutesConfig["authenticate"];
+  authenticate?: InspectorRelayAuthenticator;
   /** Shared OAuth state store for a mounted multi-replica Inspector. */
   oauthProxyStateStore?: InspectorProxyRoutesConfig["oauthProxyStateStore"];
   /** Server-side confidential-client resolver for hosted OAuth. */

--- a/libraries/typescript/packages/inspector/src/server/middleware.ts
+++ b/libraries/typescript/packages/inspector/src/server/middleware.ts
@@ -28,6 +28,14 @@ export interface MountInspectorOptions {
   sandboxOrigin?: string | null;
   /** Explicit cross-origin callers of the OAuth BFF. Same-origin is implicit. */
   oauthProxyAllowedOrigins?: readonly string[];
+  /** Explicit cross-origin callers of the MCP proxy. Omission preserves legacy wildcard CORS. */
+  mcpProxyAllowedOrigins?: readonly string[];
+  /** Optional product authentication; upstream Authorization remains separate. */
+  authenticate?: InspectorProxyRoutesConfig["authenticate"];
+  /** Shared OAuth state store for a mounted multi-replica Inspector. */
+  oauthProxyStateStore?: InspectorProxyRoutesConfig["oauthProxyStateStore"];
+  /** Server-side confidential-client resolver for hosted OAuth. */
+  oauthProxyConfidentialClientResolver?: InspectorProxyRoutesConfig["oauthProxyConfidentialClientResolver"];
   /** Allow OAuth and MCP proxy requests to loopback targets (default `true`). */
   oauthProxyAllowLoopback?: boolean;
   /** Optional source label for logs when Inspector shares a dev server process. */
@@ -128,11 +136,16 @@ function registerInspectorRoutes(
 ): void {
   const routesConfig: InspectorProxyRoutesConfig = {
     oauthProxyAllowedOrigins: options?.oauthProxyAllowedOrigins ?? [],
+    mcpProxyAllowedOrigins: options?.mcpProxyAllowedOrigins,
     // A mounted inspector can end up publicly reachable (hosted deployments),
     // where loopback proxying is SSRF into the host's own services. Default to
     // blocking loopback; local dev tooling opts in explicitly.
     oauthProxyAllowLoopback: options?.oauthProxyAllowLoopback ?? false,
     logPrefix: options?.logPrefix,
+    authenticate: options?.authenticate,
+    oauthProxyStateStore: options?.oauthProxyStateStore,
+    oauthProxyConfidentialClientResolver:
+      options?.oauthProxyConfidentialClientResolver,
   };
   if (options?.autoConnectUrl !== undefined) {
     routesConfig.autoConnectUrl = options.autoConnectUrl;

--- a/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
@@ -1,15 +1,16 @@
-import type { Context, Hono } from "hono";
+import type { Hono } from "hono";
 import { RateLimiterMemory } from "rate-limiter-flexible";
 import {
   mountMcpProxy,
   mountOAuthProxy,
+  type InspectorRelayAuthenticator,
   type OAuthProxyConfidentialClientResolver,
   type OAuthProxyStateStore,
 } from "./proxy/index.js";
 import {
   INSPECTOR_API_RATE_LIMIT,
-  INSPECTOR_GLOBAL_API_RATE_LIMIT,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+  defaultInspectorGlobalRateLimiter,
 } from "./rate-limit.js";
 
 export type InspectorProxyRoutesConfig = {
@@ -32,7 +33,7 @@ export type InspectorProxyRoutesConfig = {
   /** Server-side provider configuration for confidential OAuth clients. */
   oauthProxyConfidentialClientResolver?: OAuthProxyConfidentialClientResolver;
   /** Authentication boundary for the product relay (upstream Authorization is separate). */
-  authenticate?: (c: Context) => Promise<boolean> | boolean;
+  authenticate?: InspectorRelayAuthenticator;
 };
 
 /**
@@ -50,18 +51,16 @@ export function registerInspectorProxyRoutes(
     points: INSPECTOR_API_RATE_LIMIT,
     duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
   });
-  const globalRateLimiter = new RateLimiterMemory({
-    points: INSPECTOR_GLOBAL_API_RATE_LIMIT,
-    duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
-  });
+  const globalRateLimiter = defaultInspectorGlobalRateLimiter;
 
   app.get(p("/inspector/health"), async (c) => {
-    if (config?.oauthProxyStateStore?.ready) {
+    const stateStore = config?.oauthProxyStateStore;
+    const stateStoreProbe = stateStore?.probe
+      ? stateStore.probe.bind(stateStore)
+      : stateStore?.ready?.bind(stateStore);
+    if (stateStoreProbe) {
       try {
-        await Promise.race([
-          config.oauthProxyStateStore.ready(),
-          healthTimeout(1_000),
-        ]);
+        await withHealthTimeout(stateStoreProbe, 1_000);
       } catch {
         return c.json({ status: "unavailable" }, 503);
       }
@@ -110,11 +109,21 @@ export function registerInspectorProxyRoutes(
   }
 }
 
-function healthTimeout(ms: number): Promise<never> {
-  return new Promise((_, reject) =>
-    setTimeout(
+async function withHealthTimeout(
+  operation: () => Promise<void>,
+  ms: number
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
       () => reject(new Error("Inspector state store readiness timeout")),
       ms
-    )
-  );
+    );
+    timer.unref?.();
+  });
+  try {
+    await Promise.race([operation(), timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }

--- a/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
@@ -77,8 +77,7 @@ export function registerInspectorProxyRoutes(
       allowLoopback,
       rateLimiter: apiRateLimiter,
       stateStore: config?.oauthProxyStateStore,
-      resolveConfidentialClient:
-        config?.oauthProxyConfidentialClientResolver,
+      resolveConfidentialClient: config?.oauthProxyConfidentialClientResolver,
     });
   }
 

--- a/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
@@ -1,4 +1,4 @@
-import type { Hono } from "hono";
+import type { Context, Hono } from "hono";
 import { RateLimiterMemory } from "rate-limiter-flexible";
 import {
   mountMcpProxy,
@@ -8,6 +8,7 @@ import {
 } from "./proxy/index.js";
 import {
   INSPECTOR_API_RATE_LIMIT,
+  INSPECTOR_GLOBAL_API_RATE_LIMIT,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
 } from "./rate-limit.js";
 
@@ -30,6 +31,8 @@ export type InspectorProxyRoutesConfig = {
   oauthProxyStateStore?: OAuthProxyStateStore;
   /** Server-side provider configuration for confidential OAuth clients. */
   oauthProxyConfidentialClientResolver?: OAuthProxyConfidentialClientResolver;
+  /** Authentication boundary for the product relay (upstream Authorization is separate). */
+  authenticate?: (c: Context) => Promise<boolean> | boolean;
 };
 
 /**
@@ -47,8 +50,22 @@ export function registerInspectorProxyRoutes(
     points: INSPECTOR_API_RATE_LIMIT,
     duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
   });
+  const globalRateLimiter = new RateLimiterMemory({
+    points: INSPECTOR_GLOBAL_API_RATE_LIMIT,
+    duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+  });
 
-  app.get(p("/inspector/health"), (c) => {
+  app.get(p("/inspector/health"), async (c) => {
+    if (config?.oauthProxyStateStore?.ready) {
+      try {
+        await Promise.race([
+          config.oauthProxyStateStore.ready(),
+          healthTimeout(1_000),
+        ]);
+      } catch {
+        return c.json({ status: "unavailable" }, 503);
+      }
+    }
     return c.json({
       status: "ok",
       protocol: "mcp-use-inspector-preview",
@@ -62,8 +79,10 @@ export function registerInspectorProxyRoutes(
       path: p("/inspector/api/proxy"),
       allowLoopback,
       rateLimiter: apiRateLimiter,
+      globalRateLimiter,
       logPrefix: config?.logPrefix,
       allowedOrigins: config?.mcpProxyAllowedOrigins,
+      authenticate: config?.authenticate,
     });
   }
 
@@ -76,8 +95,10 @@ export function registerInspectorProxyRoutes(
       allowedOrigins: config?.oauthProxyAllowedOrigins ?? [],
       allowLoopback,
       rateLimiter: apiRateLimiter,
+      globalRateLimiter,
       stateStore: config?.oauthProxyStateStore,
       resolveConfidentialClient: config?.oauthProxyConfidentialClientResolver,
+      authenticate: config?.authenticate,
     });
   }
 
@@ -87,4 +108,13 @@ export function registerInspectorProxyRoutes(
       return c.json({ autoConnectUrl: autoConnectUrl ?? null });
     });
   }
+}
+
+function healthTimeout(ms: number): Promise<never> {
+  return new Promise((_, reject) =>
+    setTimeout(
+      () => reject(new Error("Inspector state store readiness timeout")),
+      ms
+    )
+  );
 }

--- a/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy-routes.ts
@@ -1,6 +1,11 @@
 import type { Hono } from "hono";
 import { RateLimiterMemory } from "rate-limiter-flexible";
-import { mountMcpProxy, mountOAuthProxy } from "./proxy/index.js";
+import {
+  mountMcpProxy,
+  mountOAuthProxy,
+  type OAuthProxyConfidentialClientResolver,
+  type OAuthProxyStateStore,
+} from "./proxy/index.js";
 import {
   INSPECTOR_API_RATE_LIMIT,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
@@ -11,12 +16,20 @@ export type InspectorProxyRoutesConfig = {
   autoConnectUrl?: string | null;
   /** Explicit cross-origin callers of the OAuth BFF. Same-origin is implicit. */
   oauthProxyAllowedOrigins?: readonly string[];
+  /** Explicit cross-origin callers of the MCP CORS proxy. */
+  mcpProxyAllowedOrigins?: readonly string[];
   /** Allow the OAuth BFF to reach loopback servers in local development. */
   oauthProxyAllowLoopback?: boolean;
   /** Mount OAuth BFF routes (default true). */
   oauth?: boolean;
   /** Optional source label for logs when Inspector shares a dev server process. */
   logPrefix?: string;
+  /** Mount MCP CORS proxy routes (default true). */
+  mcp?: boolean;
+  /** Durable state shared by every OAuth proxy replica. */
+  oauthProxyStateStore?: OAuthProxyStateStore;
+  /** Server-side provider configuration for confidential OAuth clients. */
+  oauthProxyConfidentialClientResolver?: OAuthProxyConfidentialClientResolver;
 };
 
 /**
@@ -44,12 +57,15 @@ export function registerInspectorProxyRoutes(
     });
   });
 
-  mountMcpProxy(app, {
-    path: p("/inspector/api/proxy"),
-    allowLoopback,
-    rateLimiter: apiRateLimiter,
-    logPrefix: config?.logPrefix,
-  });
+  if (config?.mcp !== false) {
+    mountMcpProxy(app, {
+      path: p("/inspector/api/proxy"),
+      allowLoopback,
+      rateLimiter: apiRateLimiter,
+      logPrefix: config?.logPrefix,
+      allowedOrigins: config?.mcpProxyAllowedOrigins,
+    });
+  }
 
   if (mountOAuth) {
     mountOAuthProxy(app, {
@@ -60,6 +76,9 @@ export function registerInspectorProxyRoutes(
       allowedOrigins: config?.oauthProxyAllowedOrigins ?? [],
       allowLoopback,
       rateLimiter: apiRateLimiter,
+      stateStore: config?.oauthProxyStateStore,
+      resolveConfidentialClient:
+        config?.oauthProxyConfidentialClientResolver,
     });
   }
 

--- a/libraries/typescript/packages/inspector/src/server/proxy/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/index.ts
@@ -2,6 +2,11 @@ export { mountMcpProxy } from "./mcp-proxy.js";
 export { mountOAuthProxy } from "./oauth-proxy.js";
 export type { OAuthProxyConfidentialClientResolver } from "./oauth-proxy.js";
 export {
+  INSPECTOR_RELAY_CAPABILITY_HEADER,
+  type InspectorRelayAuthenticator,
+  type InspectorRelayTarget,
+} from "../relay-auth.js";
+export {
   createMemoryOAuthProxyStateStore,
   createRedisOAuthProxyStateStore,
   decodeOAuthProxyEncryptionKey,

--- a/libraries/typescript/packages/inspector/src/server/proxy/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/index.ts
@@ -1,8 +1,6 @@
 export { mountMcpProxy } from "./mcp-proxy.js";
 export { mountOAuthProxy } from "./oauth-proxy.js";
-export type {
-  OAuthProxyConfidentialClientResolver,
-} from "./oauth-proxy.js";
+export type { OAuthProxyConfidentialClientResolver } from "./oauth-proxy.js";
 export {
   createMemoryOAuthProxyStateStore,
   createRedisOAuthProxyStateStore,

--- a/libraries/typescript/packages/inspector/src/server/proxy/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/index.ts
@@ -5,5 +5,6 @@ export {
   createMemoryOAuthProxyStateStore,
   createRedisOAuthProxyStateStore,
   decodeOAuthProxyEncryptionKey,
+  type OAuthProxyEncryptionKey,
   type OAuthProxyStateStore,
 } from "./oauth-state-store.js";

--- a/libraries/typescript/packages/inspector/src/server/proxy/index.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/index.ts
@@ -1,2 +1,11 @@
 export { mountMcpProxy } from "./mcp-proxy.js";
 export { mountOAuthProxy } from "./oauth-proxy.js";
+export type {
+  OAuthProxyConfidentialClientResolver,
+} from "./oauth-proxy.js";
+export {
+  createMemoryOAuthProxyStateStore,
+  createRedisOAuthProxyStateStore,
+  decodeOAuthProxyEncryptionKey,
+  type OAuthProxyStateStore,
+} from "./oauth-state-store.js";

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -13,11 +13,19 @@ import { logger } from "hono/logger";
 import { RateLimiterMemory } from "rate-limiter-flexible";
 import {
   INSPECTOR_API_RATE_LIMIT,
-  INSPECTOR_GLOBAL_API_RATE_LIMIT,
+  defaultInspectorGlobalPreAuthRateLimiter,
+  defaultInspectorGlobalRateLimiter,
+  defaultInspectorPreAuthRateLimiter,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+  inspectorRelayPreAuthKey,
   inspectorServerRateLimitKey,
   inspectorRateLimitResponse,
 } from "../rate-limit.js";
+import {
+  INSPECTOR_RELAY_CAPABILITY_HEADER,
+  inspectorRelayTarget,
+  type InspectorRelayAuthenticator,
+} from "../relay-auth.js";
 // ponytail: vendored from mcp-use/src/server/middleware/mcp-proxy.ts — keep in sync manually.
 import { isSafeProxyTarget } from "./oauth-proxy.js";
 
@@ -40,13 +48,13 @@ interface McpProxyOptions {
    *
    * @example
    * ```typescript
-   * authenticate: async (c) => {
-   *   const apiKey = c.req.header("X-API-Key");
-   *   return apiKey === process.env.API_KEY;
+   * authenticate: async (c, target) => {
+   *   const capability = c.req.header("X-Inspector-Relay-Token");
+   *   return verifyCapability(capability, target);
    * }
    * ```
    */
-  authenticate?: (c: Context) => Promise<boolean> | boolean;
+  authenticate?: InspectorRelayAuthenticator;
 
   /**
    * Optional request validator to check if target URL is allowed
@@ -77,6 +85,10 @@ interface McpProxyOptions {
   rateLimiter?: RateLimiterMemory;
   /** Higher process-wide backstop against target-key rotation abuse. */
   globalRateLimiter?: RateLimiterMemory;
+  /** Per-client limiter protecting the product authentication callback. */
+  preAuthRateLimiter?: RateLimiterMemory;
+  /** Process-wide limiter protecting the product authentication callback. */
+  globalPreAuthRateLimiter?: RateLimiterMemory;
   /** Optional source label for logs when Inspector shares a dev server process. */
   logPrefix?: string;
   /** Explicit browser origins. Omission preserves legacy wildcard CORS; `[]` denies cross-origin callers. */
@@ -119,9 +131,9 @@ export function isOpenEndedSseResponse(
  * // With authentication
  * mountMcpProxy(app, {
  *   path: "/api/proxy",
- *   authenticate: async (c) => {
- *     const token = c.req.header("Authorization");
- *     return token === `Bearer ${process.env.SECRET_TOKEN}`;
+ *   authenticate: async (c, target) => {
+ *     const capability = c.req.header("X-Inspector-Relay-Token");
+ *     return verifyCapability(capability, target);
  *   },
  *   validateRequest: (targetUrl) => {
  *     // Only allow specific domains
@@ -145,11 +157,12 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
       duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
     });
   const globalRateLimiter =
-    options.globalRateLimiter ??
-    new RateLimiterMemory({
-      points: INSPECTOR_GLOBAL_API_RATE_LIMIT,
-      duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
-    });
+    options.globalRateLimiter ?? defaultInspectorGlobalRateLimiter;
+  const preAuthRateLimiter =
+    options.preAuthRateLimiter ?? defaultInspectorPreAuthRateLimiter;
+  const globalPreAuthRateLimiter =
+    options.globalPreAuthRateLimiter ??
+    defaultInspectorGlobalPreAuthRateLimiter;
   const rateLimit = async (c: Context, next: Next) => {
     try {
       // Keep independent budgets per actual target. Passing the Request object
@@ -185,6 +198,7 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
         "Mcp-Method",
         "Mcp-Name",
         "DPoP",
+        INSPECTOR_RELAY_CAPABILITY_HEADER,
         "Last-Event-ID",
         "X-Server-Id",
         "X-Requested-With",
@@ -214,13 +228,14 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
   // other request before it can consume either relay budget, so rejected
   // callers cannot exhaust a valid user's target bucket.
   app.use(`${basePath}/*`, async (c, next) => {
-    if (
-      c.req.method !== "OPTIONS" &&
-      options.authenticate &&
-      !(await options.authenticate(c))
-    ) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
+    const authenticationResponse = await authenticateTarget(
+      c,
+      inspectorRelayTarget(c.req.header("X-Target-URL"), c.req.method),
+      options.authenticate,
+      preAuthRateLimiter,
+      globalPreAuthRateLimiter
+    );
+    if (authenticationResponse) return authenticationResponse;
     return next();
   });
 
@@ -298,6 +313,7 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
           !lowerKey.startsWith("x-forwarded-") &&
           !lowerKey.startsWith("cf-") &&
           lowerKey !== "x-original-host" &&
+          lowerKey !== INSPECTOR_RELAY_CAPABILITY_HEADER.toLowerCase() &&
           lowerKey !== "host" &&
           lowerKey !== "origin" &&
           lowerKey !== "referer" &&
@@ -345,6 +361,29 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
         }
 
         const redirectUrl = new URL(location, currentUrl);
+        let nextMethod = currentMethod;
+        let nextBody = currentBody;
+        if (
+          response.status === 303 ||
+          ((response.status === 301 || response.status === 302) &&
+            currentMethod === "POST")
+        ) {
+          nextMethod = "GET";
+          nextBody = undefined;
+        }
+
+        // A redirect can change both the capability target and the effective
+        // method. Re-authenticate that exact destination before doing any
+        // validation or fetch so a valid capability cannot be replayed to a
+        // different target through an open redirect.
+        const authenticationResponse = await authenticateTarget(
+          c,
+          inspectorRelayTarget(redirectUrl.toString(), nextMethod),
+          options.authenticate,
+          preAuthRateLimiter,
+          globalPreAuthRateLimiter
+        );
+        if (authenticationResponse) return authenticationResponse;
         if (
           !(await isSafeProxyTarget(
             redirectUrl.toString(),
@@ -359,15 +398,13 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
           deleteHeader(headers, "authorization");
           deleteHeader(headers, "proxy-authorization");
         }
-        if (
-          response.status === 303 ||
-          ((response.status === 301 || response.status === 302) &&
-            currentMethod === "POST")
-        ) {
-          currentMethod = "GET";
-          currentBody = undefined;
+        if (nextMethod !== currentMethod) {
+          currentMethod = nextMethod;
+          currentBody = nextBody;
           deleteHeader(headers, "content-type");
           deleteHeader(headers, "content-length");
+        } else {
+          currentBody = nextBody;
         }
         currentUrl = redirectUrl.toString();
       }
@@ -440,6 +477,31 @@ function deleteHeader(headers: Record<string, string>, name: string): void {
   for (const key of Object.keys(headers)) {
     if (key.toLowerCase() === name) delete headers[key];
   }
+}
+
+async function authenticateTarget(
+  c: Context,
+  target: ReturnType<typeof inspectorRelayTarget>,
+  authenticate: InspectorRelayAuthenticator | undefined,
+  preAuthRateLimiter: RateLimiterMemory,
+  globalPreAuthRateLimiter: RateLimiterMemory
+): Promise<Response | undefined> {
+  if (c.req.method === "OPTIONS" || !authenticate) return undefined;
+  try {
+    await preAuthRateLimiter.consume(
+      inspectorRelayPreAuthKey(
+        c.req.header("CF-Connecting-IP"),
+        c.req.header("X-Forwarded-For")
+      )
+    );
+    await globalPreAuthRateLimiter.consume("inspector-relay:preauth:global");
+  } catch (error) {
+    return inspectorRateLimitResponse(c, error);
+  }
+  if (!(await authenticate(c, target))) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+  return undefined;
 }
 
 async function proxyResponse(response: Response): Promise<Response> {

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -75,6 +75,8 @@ interface McpProxyOptions {
   rateLimiter?: RateLimiterMemory;
   /** Optional source label for logs when Inspector shares a dev server process. */
   logPrefix?: string;
+  /** Explicit browser origins; an empty list preserves the anonymous wildcard default. */
+  allowedOrigins?: readonly string[];
 }
 
 /** Whether an MCP response must remain streaming instead of being buffered. */
@@ -155,7 +157,7 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
   app.use(
     `${basePath}/*`,
     cors({
-      origin: "*",
+      origin: createCorsOriginResolver(options.allowedOrigins ?? []),
       allowHeaders: [
         "Authorization",
         "Content-Type",
@@ -165,10 +167,21 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
         "Mcp-Session-Id",
         "mcp-session-id",
         "mcp-protocol-version",
+        "Mcp-Protocol-Version",
+        "Mcp-Method",
+        "Mcp-Name",
+        "Last-Event-ID",
         "X-Server-Id",
         "X-Requested-With",
       ],
-      exposeHeaders: ["*"],
+      exposeHeaders: [
+        "Mcp-Session-Id",
+        "Mcp-Protocol-Version",
+        "WWW-Authenticate",
+        "Location",
+        "Retry-After",
+        "X-Accel-Buffering",
+      ],
     })
   );
 
@@ -377,6 +390,29 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
       );
     }
   });
+}
+
+function createCorsOriginResolver(
+  allowedOrigins: readonly string[]
+): "*" | ((origin: string) => string) {
+  if (allowedOrigins.length === 0) return "*";
+  const origins = new Set(allowedOrigins.map(normalizeOrigin));
+  return (origin: string) => {
+    try {
+      const normalized = normalizeOrigin(origin);
+      return origins.has(normalized) ? normalized : "";
+    } catch {
+      return "";
+    }
+  };
+}
+
+function normalizeOrigin(origin: string): string {
+  const url = new URL(origin);
+  if (url.pathname !== "/" || url.search || url.hash) {
+    throw new Error(`MCP proxy allowed origin must be an origin: ${origin}`);
+  }
+  return url.origin;
 }
 
 function deleteHeader(headers: Record<string, string>, name: string): void {

--- a/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/mcp-proxy.ts
@@ -13,7 +13,9 @@ import { logger } from "hono/logger";
 import { RateLimiterMemory } from "rate-limiter-flexible";
 import {
   INSPECTOR_API_RATE_LIMIT,
+  INSPECTOR_GLOBAL_API_RATE_LIMIT,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+  inspectorServerRateLimitKey,
   inspectorRateLimitResponse,
 } from "../rate-limit.js";
 // ponytail: vendored from mcp-use/src/server/middleware/mcp-proxy.ts — keep in sync manually.
@@ -73,9 +75,11 @@ interface McpProxyOptions {
   enableLogging?: boolean;
   /** Shared process-local limiter for Inspector proxy and OAuth routes. */
   rateLimiter?: RateLimiterMemory;
+  /** Higher process-wide backstop against target-key rotation abuse. */
+  globalRateLimiter?: RateLimiterMemory;
   /** Optional source label for logs when Inspector shares a dev server process. */
   logPrefix?: string;
-  /** Explicit browser origins; an empty list preserves the anonymous wildcard default. */
+  /** Explicit browser origins. Omission preserves legacy wildcard CORS; `[]` denies cross-origin callers. */
   allowedOrigins?: readonly string[];
 }
 
@@ -140,11 +144,21 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
       points: INSPECTOR_API_RATE_LIMIT,
       duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
     });
+  const globalRateLimiter =
+    options.globalRateLimiter ??
+    new RateLimiterMemory({
+      points: INSPECTOR_GLOBAL_API_RATE_LIMIT,
+      duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+    });
   const rateLimit = async (c: Context, next: Next) => {
     try {
-      // RateLimiterMemory prefixes and stringifies keys. The Hono request
-      // wrapper therefore maps every request to one mounted-instance budget.
-      await rateLimiter.consume(c.req as unknown as string);
+      // Keep independent budgets per actual target. Passing the Request object
+      // here stringifies every request to "[object Request]" and creates one
+      // accidental process-wide bucket.
+      await globalRateLimiter.consume("inspector-api:global");
+      await rateLimiter.consume(
+        inspectorServerRateLimitKey("mcp", c.req.header("X-Target-URL"))
+      );
     } catch (error) {
       return inspectorRateLimitResponse(c, error);
     }
@@ -157,7 +171,7 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
   app.use(
     `${basePath}/*`,
     cors({
-      origin: createCorsOriginResolver(options.allowedOrigins ?? []),
+      origin: createCorsOriginResolver(options.allowedOrigins),
       allowHeaders: [
         "Authorization",
         "Content-Type",
@@ -170,6 +184,7 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
         "Mcp-Protocol-Version",
         "Mcp-Method",
         "Mcp-Name",
+        "DPoP",
         "Last-Event-ID",
         "X-Server-Id",
         "X-Requested-With",
@@ -195,19 +210,25 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
     );
   }
 
+  // CORS preflights do not carry the browser's capability. Authenticate every
+  // other request before it can consume either relay budget, so rejected
+  // callers cannot exhaust a valid user's target bucket.
+  app.use(`${basePath}/*`, async (c, next) => {
+    if (
+      c.req.method !== "OPTIONS" &&
+      options.authenticate &&
+      !(await options.authenticate(c))
+    ) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    return next();
+  });
+
   app.use(`${basePath}/*`, rateLimit);
 
   // Handle all HTTP methods for the proxy
   app.all(`${basePath}/*`, async (c) => {
     try {
-      // Optional authentication
-      if (options.authenticate) {
-        const isAuthenticated = await options.authenticate(c);
-        if (!isAuthenticated) {
-          return c.json({ error: "Unauthorized" }, 401);
-        }
-      }
-
       const targetUrl = c.req.header("X-Target-URL");
 
       if (!targetUrl) {
@@ -393,9 +414,9 @@ export function mountMcpProxy(app: Hono, options: McpProxyOptions = {}): void {
 }
 
 function createCorsOriginResolver(
-  allowedOrigins: readonly string[]
+  allowedOrigins: readonly string[] | undefined
 ): "*" | ((origin: string) => string) {
-  if (allowedOrigins.length === 0) return "*";
+  if (allowedOrigins === undefined) return "*";
   const origins = new Set(allowedOrigins.map(normalizeOrigin));
   return (origin: string) => {
     try {

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -16,11 +16,20 @@ import type { Context, Hono } from "hono";
 import { RateLimiterMemory } from "rate-limiter-flexible";
 import {
   INSPECTOR_API_RATE_LIMIT,
-  INSPECTOR_GLOBAL_API_RATE_LIMIT,
+  defaultInspectorGlobalPreAuthRateLimiter,
+  defaultInspectorGlobalRateLimiter,
+  defaultInspectorPreAuthRateLimiter,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+  inspectorRelayPreAuthKey,
   inspectorServerRateLimitKey,
   inspectorRateLimitResponse,
 } from "../rate-limit.js";
+import {
+  INSPECTOR_RELAY_CAPABILITY_HEADER,
+  inspectorRelayTarget,
+  type InspectorRelayAuthenticator,
+  type InspectorRelayTarget,
+} from "../relay-auth.js";
 import {
   createMemoryOAuthProxyStateStore,
   type OAuthProxyStateStore,
@@ -104,7 +113,7 @@ interface OAuthProxyOptions {
   /** Optional source label for logs when Inspector shares a dev server process. */
   logPrefix?: string;
   /** Optional authentication applied before any outbound request. */
-  authenticate?: (c: Context) => Promise<boolean> | boolean;
+  authenticate?: InspectorRelayAuthenticator;
   /** Optional deployment policy applied after built-in URL and network checks. */
   validateServerUrl?: (
     serverUrl: string,
@@ -114,6 +123,10 @@ interface OAuthProxyOptions {
   rateLimiter?: RateLimiterMemory;
   /** Higher process-wide backstop against target-key rotation abuse. */
   globalRateLimiter?: RateLimiterMemory;
+  /** Per-client limiter protecting the product authentication callback. */
+  preAuthRateLimiter?: RateLimiterMemory;
+  /** Process-wide limiter protecting the product authentication callback. */
+  globalPreAuthRateLimiter?: RateLimiterMemory;
   /** Durable store shared by every Inspector replica. */
   stateStore?: OAuthProxyStateStore;
   /** Server-side resolver for configured confidential clients (never browser-visible). */
@@ -166,10 +179,9 @@ export function mountOAuthProxy(
       points: INSPECTOR_API_RATE_LIMIT,
       duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
     }),
-    globalRateLimiter = new RateLimiterMemory({
-      points: INSPECTOR_GLOBAL_API_RATE_LIMIT,
-      duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
-    }),
+    globalRateLimiter = defaultInspectorGlobalRateLimiter,
+    preAuthRateLimiter = defaultInspectorPreAuthRateLimiter,
+    globalPreAuthRateLimiter = defaultInspectorGlobalPreAuthRateLimiter,
     stateStore,
     resolveConfidentialClient,
   } = options;
@@ -190,8 +202,29 @@ export function mountOAuthProxy(
     await next();
     if (origin) setCorsHeaders(c.res.headers, origin);
   });
+  app.use(`${basePath}/*`, async (c, next) => {
+    if (c.req.method === "OPTIONS" || !authenticate) return next();
+    try {
+      await preAuthRateLimiter.consume(
+        inspectorRelayPreAuthKey(
+          c.req.header("CF-Connecting-IP"),
+          c.req.header("X-Forwarded-For")
+        )
+      );
+      await globalPreAuthRateLimiter.consume("inspector-relay:preauth:global");
+    } catch (error) {
+      return inspectorRateLimitResponse(c, error);
+    }
+    return next();
+  });
   app.get(`${basePath}/metadata`, async (c) => {
-    if (!(await isAuthenticated(c, authenticate))) {
+    if (
+      !(await isAuthenticated(
+        c,
+        authenticate,
+        inspectorRelayTarget(c.req.query("url"), "GET")
+      ))
+    ) {
       return c.json({ error: "Unauthorized" }, 401);
     }
 
@@ -242,7 +275,7 @@ export function mountOAuthProxy(
               timeoutMs,
               maxResponseBodyBytes
             );
-            await saveBinding(durableStateStore, bindings, key, latest);
+            return saveBinding(durableStateStore, bindings, key, latest);
           }
           return latest;
         });
@@ -313,10 +346,6 @@ export function mountOAuthProxy(
   });
 
   app.post(`${basePath}/proxy`, async (c) => {
-    if (!(await isAuthenticated(c, authenticate))) {
-      return c.json({ error: "Unauthorized" }, 401);
-    }
-
     let request: ProxyRequest;
     try {
       request = JSON.parse(
@@ -332,6 +361,16 @@ export function mountOAuthProxy(
         },
         error instanceof BodyTooLargeError ? 413 : 400
       );
+    }
+
+    if (
+      !(await isAuthenticated(
+        c,
+        authenticate,
+        inspectorRelayTarget(request.url, "POST")
+      ))
+    ) {
+      return c.json({ error: "Unauthorized" }, 401);
     }
 
     const serverUrlResult = await validateUrl(request.serverUrl, allowLoopback);
@@ -385,7 +424,7 @@ export function mountOAuthProxy(
               timeoutMs,
               maxResponseBodyBytes
             );
-            await saveBinding(durableStateStore, bindings, bindingKey, latest);
+            return saveBinding(durableStateStore, bindings, bindingKey, latest);
           }
           return latest;
         });
@@ -469,36 +508,31 @@ export function mountOAuthProxy(
           }
         }
       }
-      if (endpoint.kind === "registration" && upstream.ok) {
+      if (endpoint.kind === "registration") {
         if (
           !contentType.includes("json") ||
           !responseBody ||
           typeof responseBody !== "object" ||
           Array.isArray(responseBody)
         ) {
+          // DCR responses can contain provider-issued credentials even on an
+          // error status. Never return a primitive or array body verbatim.
           return c.json(
             { error: "OAuth registration response is invalid" },
             502
           );
         }
-        responseBody = await retainConfidentialClient({
-          responseBody: responseBody as Record<string, unknown>,
-          binding,
-          bindingKey,
-          authorizationServer: endpoint.authorizationServer,
-          targetUrl: target.toString(),
-          clients: confidentialClients,
-          stateStore: durableStateStore,
-        });
-      } else if (
-        endpoint.kind === "registration" &&
-        responseBody &&
-        typeof responseBody === "object" &&
-        !Array.isArray(responseBody)
-      ) {
-        responseBody = sanitizeDcrResponse(
-          responseBody as Record<string, unknown>
-        );
+        responseBody = upstream.ok
+          ? await retainConfidentialClient({
+              responseBody: responseBody as Record<string, unknown>,
+              binding,
+              bindingKey,
+              authorizationServer: endpoint.authorizationServer,
+              targetUrl: target.toString(),
+              clients: confidentialClients,
+              stateStore: durableStateStore,
+            })
+          : sanitizeDcrResponse(responseBody as Record<string, unknown>);
       }
       return c.json({
         status: upstream.status,
@@ -846,6 +880,7 @@ function filterRequestHeaders(value: unknown): Headers {
     return result;
   for (const [name, rawValue] of Object.entries(value)) {
     const lower = name.toLowerCase();
+    if (lower === INSPECTOR_RELAY_CAPABILITY_HEADER.toLowerCase()) continue;
     if (SAFE_REQUEST_HEADERS.has(lower) && typeof rawValue === "string") {
       result.set(lower, rawValue);
     }
@@ -1087,8 +1122,20 @@ async function applyConfidentialClientAuthentication(options: {
   if (!client) return body;
   if (isExpired(client.expiresAt)) {
     clients.delete(key);
-    await storeDelete(stateStore, key);
-    return body;
+    const deleted = await storeDeleteIfVersion(stateStore, key, client);
+    if (!deleted) {
+      const latest = normalizeConfidentialClient(
+        await storeGet<unknown>(stateStore, key)
+      );
+      if (latest && !isExpired(latest.expiresAt)) {
+        cacheConfidentialClient(clients, key, latest);
+        client = latest;
+      } else {
+        return body;
+      }
+    } else {
+      return body;
+    }
   }
 
   params.delete("client_secret");
@@ -1264,7 +1311,28 @@ async function loadBinding(
       return local;
     }
     if (!local || Date.now() - local.updatedAt > BINDING_TTL_MS) {
-      await storeDelete(stateStore, bindingStoreKey(key));
+      const deleted = await storeDeleteIfVersion(
+        stateStore,
+        bindingStoreKey(key),
+        binding
+      );
+      if (!deleted) {
+        // Another replica may have refreshed the binding after the stale read
+        // but before the compare-and-delete. Adopt that value instead of
+        // allowing an unconditional cleanup to erase the fresh state.
+        const latest = await storeGet<SerializedBinding>(
+          stateStore,
+          bindingStoreKey(key)
+        );
+        if (latest !== undefined) {
+          const latestBinding = deserializeBinding(latest);
+          if (Date.now() - latestBinding.updatedAt <= BINDING_TTL_MS) {
+            bindings.set(key, latestBinding);
+            pruneBindings(bindings);
+            return latestBinding;
+          }
+        }
+      }
     } else {
       return local;
     }
@@ -1282,7 +1350,7 @@ async function saveBinding(
   bindings: Map<string, Binding>,
   key: string,
   binding: Binding
-): Promise<void> {
+): Promise<Binding> {
   const now = Date.now();
   const next: Binding = {
     ...binding,
@@ -1302,17 +1370,21 @@ async function saveBinding(
     );
     if (latest !== undefined) {
       const latestBinding = deserializeBinding(latest);
-      bindings.set(
-        key,
-        compareVersions(next, latestBinding) < 0 ? latestBinding : next
-      );
+      const authoritative =
+        compareVersions(next, latestBinding) <= 0 ? latestBinding : next;
+      bindings.set(key, authoritative);
+      pruneBindings(bindings);
+      return authoritative;
     } else {
       bindings.set(key, next);
+      pruneBindings(bindings);
+      return next;
     }
   } else {
     bindings.set(key, next);
+    pruneBindings(bindings);
+    return next;
   }
-  pruneBindings(bindings);
 }
 
 function emptyBinding(): Binding {
@@ -1504,7 +1576,7 @@ function corsResponse(origin: string | undefined): Response {
   headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
   headers.set(
     "Access-Control-Allow-Headers",
-    "Accept, Authorization, Content-Type, DPoP"
+    `Accept, Authorization, Content-Type, DPoP, ${INSPECTOR_RELAY_CAPABILITY_HEADER}`
   );
   headers.set("Access-Control-Max-Age", "600");
   return new Response(null, { status: 204, headers });
@@ -1517,9 +1589,10 @@ function setCorsHeaders(headers: Headers, origin: string): void {
 
 async function isAuthenticated(
   c: Context,
-  authenticate: OAuthProxyOptions["authenticate"]
+  authenticate: OAuthProxyOptions["authenticate"],
+  target: InspectorRelayTarget | undefined
 ): Promise<boolean> {
-  return authenticate ? authenticate(c) : true;
+  return authenticate ? authenticate(c, target) : true;
 }
 
 function isRedirect(status: number): boolean {
@@ -1661,12 +1734,17 @@ async function storeSetIfNewer<T>(
   }
 }
 
-async function storeDelete(
+async function storeDeleteIfVersion(
   store: OAuthProxyStateStore,
-  key: string
-): Promise<void> {
+  key: string,
+  expected: { revision: number; updatedAt: number }
+): Promise<boolean> {
   try {
-    await store.delete(key);
+    // Stores without the optional atomic primitive must not perform an
+    // unsafe get-then-delete. Expiry remains enforced by the store TTL.
+    return store.deleteIfVersion
+      ? await store.deleteIfVersion(key, expected)
+      : false;
   } catch {
     throw new OAuthProxyStateStoreError("OAuth proxy state delete failed");
   }

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -12,11 +12,13 @@
 import { lookup } from "node:dns/promises";
 import { Buffer } from "node:buffer";
 import { isIP } from "node:net";
-import type { Context, Hono, Next } from "hono";
+import type { Context, Hono } from "hono";
 import { RateLimiterMemory } from "rate-limiter-flexible";
 import {
   INSPECTOR_API_RATE_LIMIT,
+  INSPECTOR_GLOBAL_API_RATE_LIMIT,
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+  inspectorServerRateLimitKey,
   inspectorRateLimitResponse,
 } from "../rate-limit.js";
 import {
@@ -32,9 +34,15 @@ type OAuthEndpointKind =
 
 type Binding = {
   authorizationServers: Set<string>;
-  endpoints: Map<string, OAuthEndpointKind>;
+  endpoints: Map<string, BoundEndpoint>;
   tokenEndpointAuthMethods: Set<string>;
+  revision: number;
   updatedAt: number;
+};
+
+type BoundEndpoint = {
+  kind: OAuthEndpointKind;
+  authorizationServer?: string;
 };
 
 type ProtectedResourceMetadataTarget = {
@@ -46,12 +54,15 @@ type ProtectedResourceMetadataTarget = {
 type ConfidentialClient = {
   clientSecret: string;
   authMethod: "client_secret_basic" | "client_secret_post";
-  expiresAt: number;
+  expiresAt: number | null;
+  revision: number;
+  updatedAt: number;
 };
 
 export type OAuthProxyConfidentialClient = {
   clientSecret: string;
   authMethod: "client_secret_basic" | "client_secret_post";
+  /** `0` means no expiry, matching OAuth DCR semantics. */
   expiresAt?: number;
 };
 
@@ -59,6 +70,7 @@ export type OAuthProxyConfidentialClientResolver = (options: {
   serverUrl: string;
   targetUrl: string;
   clientId: string;
+  authorizationServer?: string;
 }) =>
   | OAuthProxyConfidentialClient
   | undefined
@@ -100,6 +112,8 @@ interface OAuthProxyOptions {
   ) => Promise<boolean> | boolean;
   /** Shared process-local limiter for Inspector proxy and OAuth routes. */
   rateLimiter?: RateLimiterMemory;
+  /** Higher process-wide backstop against target-key rotation abuse. */
+  globalRateLimiter?: RateLimiterMemory;
   /** Durable store shared by every Inspector replica. */
   stateStore?: OAuthProxyStateStore;
   /** Server-side resolver for configured confidential clients (never browser-visible). */
@@ -152,6 +166,10 @@ export function mountOAuthProxy(
       points: INSPECTOR_API_RATE_LIMIT,
       duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
     }),
+    globalRateLimiter = new RateLimiterMemory({
+      points: INSPECTOR_GLOBAL_API_RATE_LIMIT,
+      duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+    }),
     stateStore,
     resolveConfidentialClient,
   } = options;
@@ -159,16 +177,7 @@ export function mountOAuthProxy(
   const origins = new Set(allowedOrigins.map(normalizeOrigin));
   const bindings = new Map<string, Binding>();
   const confidentialClients = new Map<string, ConfidentialClient>();
-  const rateLimit = async (c: Context, next: Next) => {
-    try {
-      // RateLimiterMemory prefixes and stringifies keys. The Hono request
-      // wrapper therefore maps every request to one mounted-instance budget.
-      await configuredRateLimiter.consume(c.req as unknown as string);
-    } catch (error) {
-      return inspectorRateLimitResponse(c, error);
-    }
-    return next();
-  };
+  const bindingLocks = new Map<string, Promise<void>>();
 
   app.use(`${basePath}/*`, async (c, next) => {
     const origin = c.req.header("Origin");
@@ -181,8 +190,6 @@ export function mountOAuthProxy(
     await next();
     if (origin) setCorsHeaders(c.res.headers, origin);
   });
-  app.use(`${basePath}/*`, rateLimit);
-
   app.get(`${basePath}/metadata`, async (c) => {
     if (!(await isAuthenticated(c, authenticate))) {
       return c.json({ error: "Unauthorized" }, 401);
@@ -196,6 +203,13 @@ export function mountOAuthProxy(
       return c.json({ error: serverUrlResult.error }, 400);
     }
     const serverUrl = serverUrlResult.url;
+    const rateLimitResponse = await consumeRateLimit(
+      c,
+      configuredRateLimiter,
+      globalRateLimiter,
+      inspectorServerRateLimitKey("oauth", serverUrl.toString())
+    );
+    if (rateLimitResponse) return rateLimitResponse;
     if (
       validateServerUrl &&
       !(await validateServerUrl(serverUrl.toString(), c))
@@ -213,23 +227,29 @@ export function mountOAuthProxy(
     try {
       binding = await loadBinding(durableStateStore, bindings, key);
     } catch (error) {
-      return proxyError(c, error, enableLogging);
+      return proxyError(c, error, enableLogging, logPrefix);
     }
     let metadataKind = classifyMetadataTarget(serverUrl, target, binding);
     if (!metadataKind && binding.authorizationServers.size === 0) {
       try {
-        await hydrateBinding(
-          serverUrl,
-          binding,
-          allowLoopback,
-          timeoutMs,
-          maxResponseBodyBytes
-        );
-        await saveBinding(durableStateStore, bindings, key, binding);
+        binding = await withKeyLock(bindingLocks, key, async () => {
+          const latest = await loadBinding(durableStateStore, bindings, key);
+          if (latest.authorizationServers.size === 0) {
+            await hydrateBinding(
+              serverUrl,
+              latest,
+              allowLoopback,
+              timeoutMs,
+              maxResponseBodyBytes
+            );
+            await saveBinding(durableStateStore, bindings, key, latest);
+          }
+          return latest;
+        });
         metadataKind = classifyMetadataTarget(serverUrl, target, binding);
       } catch (error) {
         if (error instanceof OAuthProxyStateStoreError) {
-          return proxyError(c, error, enableLogging);
+          return proxyError(c, error, enableLogging, logPrefix);
         }
         // The requested target remains unauthorized below.
       }
@@ -319,6 +339,13 @@ export function mountOAuthProxy(
       return c.json({ error: serverUrlResult.error }, 400);
     }
     const serverUrl = serverUrlResult.url;
+    const rateLimitResponse = await consumeRateLimit(
+      c,
+      configuredRateLimiter,
+      globalRateLimiter,
+      inspectorServerRateLimitKey("oauth", serverUrl.toString())
+    );
+    if (rateLimitResponse) return rateLimitResponse;
     if (
       validateServerUrl &&
       !(await validateServerUrl(serverUrl.toString(), c))
@@ -340,24 +367,34 @@ export function mountOAuthProxy(
     try {
       binding = await loadBinding(durableStateStore, bindings, bindingKey);
     } catch (error) {
-      return proxyError(c, error, enableLogging);
+      return proxyError(c, error, enableLogging, logPrefix);
     }
     if (binding.endpoints.size === 0) {
       try {
-        await hydrateBinding(
-          serverUrl,
-          binding,
-          allowLoopback,
-          timeoutMs,
-          maxResponseBodyBytes
-        );
-        await saveBinding(durableStateStore, bindings, bindingKey, binding);
+        binding = await withKeyLock(bindingLocks, bindingKey, async () => {
+          const latest = await loadBinding(
+            durableStateStore,
+            bindings,
+            bindingKey
+          );
+          if (latest.endpoints.size === 0) {
+            await hydrateBinding(
+              serverUrl,
+              latest,
+              allowLoopback,
+              timeoutMs,
+              maxResponseBodyBytes
+            );
+            await saveBinding(durableStateStore, bindings, bindingKey, latest);
+          }
+          return latest;
+        });
       } catch (error) {
         return proxyError(c, error, enableLogging, logPrefix);
       }
     }
-    const endpointKind = binding.endpoints.get(canonicalUrl(target));
-    if (!endpointKind) {
+    const endpoint = binding.endpoints.get(canonicalUrl(target));
+    if (!endpoint) {
       return c.json(
         { error: "OAuth endpoint is not bound to this MCP server" },
         403
@@ -367,7 +404,7 @@ export function mountOAuthProxy(
     try {
       const headers = filterRequestHeaders(request.headers);
       let body = serializeBody(request.body, headers);
-      if (endpointKind === "registration") {
+      if (endpoint.kind === "registration") {
         const publicOrigin = normalizeOrigin(
           c.req.header("Origin") ?? new URL(c.req.url).origin
         );
@@ -385,6 +422,7 @@ export function mountOAuthProxy(
           stateStore: durableStateStore,
           serverUrl: serverUrl.toString(),
           targetUrl: target.toString(),
+          authorizationServer: endpoint.authorizationServer,
           resolveConfidentialClient,
         });
       }
@@ -394,7 +432,7 @@ export function mountOAuthProxy(
         return c.json({ error: "OAuth request body too large" }, 413);
       }
 
-      log(enableLogging, logPrefix, `POST ${endpointKind} ${target}`);
+      log(enableLogging, logPrefix, `POST ${endpoint.kind} ${target}`);
       const upstream = await safeFetch(target, {
         method: "POST",
         headers,
@@ -412,27 +450,55 @@ export function mountOAuthProxy(
       const responseHeaders = filterResponseHeaders(upstream.headers);
       const contentType = upstream.headers.get("content-type") ?? "";
       let responseBody: unknown = raw;
+      if (endpoint.kind === "registration" && !contentType.includes("json")) {
+        // DCR responses are JSON. Do not pass an unexpected plaintext response
+        // through, since it may contain a provider-issued secret.
+        return c.json({ error: "OAuth registration response is invalid" }, 502);
+      }
       if (contentType.includes("json")) {
         try {
           responseBody = JSON.parse(raw);
         } catch {
-          // Preserve malformed upstream bodies; the OAuth client will reject them.
+          if (endpoint.kind === "registration") {
+            // A malformed successful DCR response may contain a plaintext
+            // client_secret. Never echo it to the browser.
+            return c.json(
+              { error: "OAuth registration response is invalid" },
+              502
+            );
+          }
         }
       }
-      if (
-        endpointKind === "registration" &&
-        upstream.ok &&
-        responseBody &&
-        typeof responseBody === "object" &&
-        !Array.isArray(responseBody)
-      ) {
+      if (endpoint.kind === "registration" && upstream.ok) {
+        if (
+          !contentType.includes("json") ||
+          !responseBody ||
+          typeof responseBody !== "object" ||
+          Array.isArray(responseBody)
+        ) {
+          return c.json(
+            { error: "OAuth registration response is invalid" },
+            502
+          );
+        }
         responseBody = await retainConfidentialClient({
           responseBody: responseBody as Record<string, unknown>,
           binding,
           bindingKey,
+          authorizationServer: endpoint.authorizationServer,
+          targetUrl: target.toString(),
           clients: confidentialClients,
           stateStore: durableStateStore,
         });
+      } else if (
+        endpoint.kind === "registration" &&
+        responseBody &&
+        typeof responseBody === "object" &&
+        !Array.isArray(responseBody)
+      ) {
+        responseBody = sanitizeDcrResponse(
+          responseBody as Record<string, unknown>
+        );
       }
       return c.json({
         status: upstream.status,
@@ -692,7 +758,10 @@ async function bindAuthorizationServer(
     if ("error" in result) {
       throw new InvalidUpstreamError(`Unsafe ${field}: ${result.error}`);
     }
-    binding.endpoints.set(canonicalUrl(result.url), kind);
+    binding.endpoints.set(canonicalUrl(result.url), {
+      kind,
+      authorizationServer: expectedIssuer,
+    });
   }
 }
 
@@ -825,22 +894,53 @@ function serializeBody(body: unknown, headers: Headers): string | undefined {
   return JSON.stringify(body);
 }
 
-function confidentialClientKey(bindingKey: string, clientId: string): string {
-  return `client:${Buffer.from(`${bindingKey}\u0000${clientId}`, "utf8").toString("base64url")}`;
+function sanitizeDcrResponse(
+  responseBody: Record<string, unknown>
+): Record<string, unknown> {
+  const browserSafe = { ...responseBody };
+  delete browserSafe.client_secret;
+  delete browserSafe.client_secret_expires_at;
+  return browserSafe;
+}
+
+function confidentialClientKey(
+  bindingKey: string,
+  authorizationServer: string | undefined,
+  clientId: string
+): string {
+  return `client:${Buffer.from(
+    `${bindingKey}\u0000${authorizationServer ?? "unknown"}\u0000${clientId}`,
+    "utf8"
+  ).toString("base64url")}`;
 }
 
 async function retainConfidentialClient(options: {
   responseBody: Record<string, unknown>;
   binding: Binding;
   bindingKey: string;
+  authorizationServer?: string;
+  targetUrl: string;
   clients: Map<string, ConfidentialClient>;
   stateStore: OAuthProxyStateStore;
 }): Promise<Record<string, unknown>> {
-  const { responseBody, binding, bindingKey, clients, stateStore } = options;
+  const {
+    responseBody,
+    binding,
+    bindingKey,
+    authorizationServer,
+    targetUrl,
+    clients,
+    stateStore,
+  } = options;
   const clientId = responseBody.client_id;
   const clientSecret = responseBody.client_secret;
   if (typeof clientId !== "string" || typeof clientSecret !== "string") {
-    return responseBody;
+    // A successful DCR response must never echo a secret that we could not
+    // bind to a valid client ID. This also handles partially malformed JSON.
+    const browserSafe = { ...responseBody };
+    delete browserSafe.client_secret;
+    delete browserSafe.client_secret_expires_at;
+    return browserSafe;
   }
 
   const returnedMethod = responseBody.token_endpoint_auth_method;
@@ -852,28 +952,41 @@ async function retainConfidentialClient(options: {
         ? "client_secret_basic"
         : "client_secret_post";
   const upstreamExpiry = responseBody.client_secret_expires_at;
-  const expiresAt =
+  const expiresAt: number | null =
     upstreamExpiry === 0
-      ? Date.now() + CONFIDENTIAL_CLIENT_TTL_MS
+      ? null
       : typeof upstreamExpiry === "number" && upstreamExpiry > 0
         ? upstreamExpiry * 1000
         : Date.now() + CONFIDENTIAL_CLIENT_TTL_MS;
 
   pruneConfidentialClients(clients);
+  const key = confidentialClientKey(
+    bindingKey,
+    authorizationServer ?? targetUrl,
+    clientId
+  );
+  const previous = clients.get(key);
   const client = {
     clientSecret,
     authMethod,
     expiresAt,
+    revision: Math.max((previous?.revision ?? 0) + 1, Date.now()),
+    updatedAt: Date.now(),
   } satisfies ConfidentialClient;
-  const key = confidentialClientKey(bindingKey, clientId);
-  clients.set(key, client);
-  await storeSet(stateStore, key, client, Math.max(1, expiresAt - Date.now()));
-  while (clients.size > MAX_CONFIDENTIAL_CLIENTS) {
-    const oldest = clients.keys().next().value as string | undefined;
-    if (!oldest) break;
-    clients.delete(oldest);
-    await storeDelete(stateStore, oldest);
+  const persisted = await storeSetIfNewer(
+    stateStore,
+    key,
+    client,
+    clientTtl(client)
+  );
+  if (!persisted) {
+    const latest = await storeGet<unknown>(stateStore, key);
+    const latestClient = normalizeConfidentialClient(latest);
+    if (latestClient && compareVersions(client, latestClient) < 0) {
+      cacheConfidentialClient(clients, key, latestClient);
+    }
   }
+  cacheConfidentialClient(clients, key, client);
 
   const browserSafe = { ...responseBody };
   delete browserSafe.client_secret;
@@ -886,6 +999,7 @@ async function applyConfidentialClientAuthentication(options: {
   body: string | undefined;
   headers: Headers;
   bindingKey: string;
+  authorizationServer?: string;
   clients: Map<string, ConfidentialClient>;
   stateStore: OAuthProxyStateStore;
   serverUrl: string;
@@ -900,6 +1014,7 @@ async function applyConfidentialClientAuthentication(options: {
     stateStore,
     serverUrl,
     targetUrl,
+    authorizationServer,
     resolveConfidentialClient,
   } = options;
   if (
@@ -915,39 +1030,62 @@ async function applyConfidentialClientAuthentication(options: {
   const clientId = params.get("client_id");
   if (!clientId) return body;
 
-  const key = confidentialClientKey(bindingKey, clientId);
-  const persistedClient = await storeGet<unknown>(stateStore, key);
-  let client: ConfidentialClient | undefined;
-  if (isConfidentialClient(persistedClient)) {
+  const key = confidentialClientKey(
+    bindingKey,
+    authorizationServer ?? targetUrl,
+    clientId
+  );
+  let localClient = clients.get(key);
+  if (localClient && isExpired(localClient.expiresAt)) {
+    clients.delete(key);
+    localClient = undefined;
+  }
+  const persistedClient = normalizeConfidentialClient(
+    await storeGet<unknown>(stateStore, key)
+  );
+  let client: ConfidentialClient | undefined = localClient;
+  if (
+    persistedClient &&
+    (!client || compareVersions(client, persistedClient) < 0)
+  ) {
     client = persistedClient;
-    clients.set(key, persistedClient);
-  } else {
-    client = clients.get(key);
+    cacheConfidentialClient(clients, key, persistedClient);
   }
   if (client === undefined && resolveConfidentialClient) {
     const resolved = await resolveConfidentialClient({
       serverUrl,
       targetUrl,
       clientId,
+      authorizationServer,
     });
     if (resolved) {
       client = {
         clientSecret: resolved.clientSecret,
         authMethod: resolved.authMethod,
         expiresAt:
-          resolved.expiresAt ?? Date.now() + CONFIDENTIAL_CLIENT_TTL_MS,
+          resolved.expiresAt === 0
+            ? null
+            : (resolved.expiresAt ?? Date.now() + CONFIDENTIAL_CLIENT_TTL_MS),
+        revision: Date.now(),
+        updatedAt: Date.now(),
       };
-      clients.set(key, client);
-      await storeSet(
+      const persisted = await storeSetIfNewer(
         stateStore,
         key,
         client,
-        Math.max(1, client.expiresAt - Date.now())
+        clientTtl(client)
       );
+      if (!persisted) {
+        const latest = normalizeConfidentialClient(
+          await storeGet<unknown>(stateStore, key)
+        );
+        if (latest && compareVersions(client, latest) < 0) client = latest;
+      }
+      cacheConfidentialClient(clients, key, client);
     }
   }
   if (!client) return body;
-  if (client.expiresAt <= Date.now()) {
+  if (isExpired(client.expiresAt)) {
     clients.delete(key);
     await storeDelete(stateStore, key);
     return body;
@@ -977,20 +1115,69 @@ function pruneConfidentialClients(
 ): void {
   const now = Date.now();
   for (const [key, client] of clients) {
-    if (client.expiresAt <= now) clients.delete(key);
+    if (isExpired(client.expiresAt, now)) clients.delete(key);
   }
 }
 
-function isConfidentialClient(value: unknown): value is ConfidentialClient {
-  return Boolean(
-    value &&
-    typeof value === "object" &&
-    typeof (value as ConfidentialClient).clientSecret === "string" &&
-    ((value as ConfidentialClient).authMethod === "client_secret_basic" ||
-      (value as ConfidentialClient).authMethod === "client_secret_post") &&
-    typeof (value as ConfidentialClient).expiresAt === "number" &&
-    Number.isFinite((value as ConfidentialClient).expiresAt)
-  );
+function isExpired(expiresAt: number | null, now = Date.now()): boolean {
+  return expiresAt !== null && expiresAt <= now;
+}
+
+function clientTtl(client: ConfidentialClient): number | undefined {
+  return client.expiresAt === null
+    ? undefined
+    : Math.max(1, client.expiresAt - Date.now());
+}
+
+function cacheConfidentialClient(
+  clients: Map<string, ConfidentialClient>,
+  key: string,
+  client: ConfidentialClient
+): void {
+  const local = clients.get(key);
+  if (!local || compareVersions(local, client) < 0) clients.set(key, client);
+  pruneConfidentialClients(clients);
+  while (clients.size > MAX_CONFIDENTIAL_CLIENTS) {
+    const oldest = clients.keys().next().value as string | undefined;
+    if (oldest === undefined) break;
+    clients.delete(oldest);
+  }
+}
+
+function normalizeConfidentialClient(
+  value: unknown
+): ConfidentialClient | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.clientSecret !== "string" ||
+    (record.authMethod !== "client_secret_basic" &&
+      record.authMethod !== "client_secret_post")
+  ) {
+    return undefined;
+  }
+  const expiresAt = record.expiresAt;
+  if (
+    expiresAt !== null &&
+    (typeof expiresAt !== "number" || !Number.isFinite(expiresAt))
+  ) {
+    return undefined;
+  }
+  const revision =
+    typeof record.revision === "number" && Number.isFinite(record.revision)
+      ? record.revision
+      : 0;
+  const updatedAt =
+    typeof record.updatedAt === "number" && Number.isFinite(record.updatedAt)
+      ? record.updatedAt
+      : 0;
+  return {
+    clientSecret: record.clientSecret,
+    authMethod: record.authMethod,
+    expiresAt: expiresAt as number | null,
+    revision,
+    updatedAt,
+  };
 }
 
 async function readRequestCapped(
@@ -1067,11 +1254,20 @@ async function loadBinding(
   );
   if (persisted !== undefined) {
     const binding = deserializeBinding(persisted);
+    const local = bindings.get(key);
     if (Date.now() - binding.updatedAt <= BINDING_TTL_MS) {
-      bindings.set(key, binding);
-      return binding;
+      if (!local || compareVersions(local, binding) < 0) {
+        bindings.set(key, binding);
+        pruneBindings(bindings);
+        return binding;
+      }
+      return local;
     }
-    await storeDelete(stateStore, bindingStoreKey(key));
+    if (!local || Date.now() - local.updatedAt > BINDING_TTL_MS) {
+      await storeDelete(stateStore, bindingStoreKey(key));
+    } else {
+      return local;
+    }
   }
   const existing = bindings.get(key);
   if (existing && Date.now() - existing.updatedAt <= BINDING_TTL_MS) {
@@ -1087,13 +1283,35 @@ async function saveBinding(
   key: string,
   binding: Binding
 ): Promise<void> {
-  bindings.set(key, binding);
-  await storeSet(
+  const now = Date.now();
+  const next: Binding = {
+    ...binding,
+    revision: Math.max(binding.revision + 1, now),
+    updatedAt: now,
+  };
+  const persisted = await storeSetIfNewer(
     stateStore,
     bindingStoreKey(key),
-    serializeBinding(binding),
+    serializeBinding(next),
     BINDING_TTL_MS
   );
+  if (persisted === false) {
+    const latest = await storeGet<SerializedBinding>(
+      stateStore,
+      bindingStoreKey(key)
+    );
+    if (latest !== undefined) {
+      const latestBinding = deserializeBinding(latest);
+      bindings.set(
+        key,
+        compareVersions(next, latestBinding) < 0 ? latestBinding : next
+      );
+    } else {
+      bindings.set(key, next);
+    }
+  } else {
+    bindings.set(key, next);
+  }
   pruneBindings(bindings);
 }
 
@@ -1102,14 +1320,16 @@ function emptyBinding(): Binding {
     authorizationServers: new Set(),
     endpoints: new Map(),
     tokenEndpointAuthMethods: new Set(),
+    revision: 0,
     updatedAt: Date.now(),
   };
 }
 
 type SerializedBinding = {
   authorizationServers: string[];
-  endpoints: Array<[string, OAuthEndpointKind]>;
+  endpoints: Array<[string, OAuthEndpointKind | BoundEndpoint]>;
   tokenEndpointAuthMethods: string[];
+  revision?: number;
   updatedAt: number;
 };
 
@@ -1118,6 +1338,7 @@ function serializeBinding(binding: Binding): SerializedBinding {
     authorizationServers: [...binding.authorizationServers],
     endpoints: [...binding.endpoints.entries()],
     tokenEndpointAuthMethods: [...binding.tokenEndpointAuthMethods],
+    revision: binding.revision,
     updatedAt: binding.updatedAt,
   };
 }
@@ -1127,20 +1348,63 @@ function deserializeBinding(value: SerializedBinding): Binding {
     !Array.isArray(value.authorizationServers) ||
     !Array.isArray(value.endpoints) ||
     !Array.isArray(value.tokenEndpointAuthMethods) ||
-    typeof value.updatedAt !== "number"
+    !value.authorizationServers.every(
+      (entry): entry is string => typeof entry === "string"
+    ) ||
+    !value.tokenEndpointAuthMethods.every(
+      (entry): entry is string => typeof entry === "string"
+    ) ||
+    !Number.isFinite(value.updatedAt) ||
+    (value.revision !== undefined &&
+      (!Number.isFinite(value.revision) || value.revision < 0))
   ) {
     throw new InvalidUpstreamError("OAuth proxy state is invalid");
   }
+  const endpoints = new Map<string, BoundEndpoint>();
+  for (const entry of value.endpoints) {
+    if (!Array.isArray(entry) || typeof entry[0] !== "string") {
+      throw new InvalidUpstreamError("OAuth proxy state is invalid");
+    }
+    const endpoint = entry[1];
+    if (typeof endpoint === "string" && isOAuthEndpointKind(endpoint)) {
+      endpoints.set(entry[0], { kind: endpoint });
+    } else if (
+      endpoint &&
+      typeof endpoint === "object" &&
+      typeof endpoint.kind === "string" &&
+      isOAuthEndpointKind(endpoint.kind)
+    ) {
+      endpoints.set(entry[0], {
+        kind: endpoint.kind,
+        authorizationServer:
+          typeof endpoint.authorizationServer === "string"
+            ? endpoint.authorizationServer
+            : undefined,
+      });
+    } else {
+      throw new InvalidUpstreamError("OAuth proxy state is invalid");
+    }
+  }
   return {
     authorizationServers: new Set(value.authorizationServers),
-    endpoints: new Map(value.endpoints),
+    endpoints,
     tokenEndpointAuthMethods: new Set(value.tokenEndpointAuthMethods),
+    revision: value.revision ?? value.updatedAt,
     updatedAt: value.updatedAt,
   };
 }
 
 function bindingStoreKey(key: string): string {
   return `binding:${Buffer.from(key, "utf8").toString("base64url")}`;
+}
+
+function isOAuthEndpointKind(value: string): value is OAuthEndpointKind {
+  return (
+    value === "registration" ||
+    value === "token" ||
+    value === "revocation" ||
+    value === "introspection"
+  );
 }
 
 function pruneBindings(bindings: Map<string, Binding>): void {
@@ -1153,6 +1417,14 @@ function pruneBindings(bindings: Map<string, Binding>): void {
     if (!oldest) break;
     bindings.delete(oldest);
   }
+}
+
+function compareVersions(
+  a: { revision: number; updatedAt: number },
+  b: { revision: number; updatedAt: number }
+): number {
+  if (a.revision !== b.revision) return a.revision - b.revision;
+  return a.updatedAt - b.updatedAt;
 }
 
 function canonicalUrl(url: URL): string {
@@ -1232,7 +1504,7 @@ function corsResponse(origin: string | undefined): Response {
   headers.set("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
   headers.set(
     "Access-Control-Allow-Headers",
-    "Accept, Authorization, Content-Type"
+    "Accept, Authorization, Content-Type, DPoP"
   );
   headers.set("Access-Control-Max-Age", "600");
   return new Response(null, { status: 204, headers });
@@ -1363,25 +1635,29 @@ async function storeGet<T>(
 ): Promise<T | undefined> {
   try {
     return await store.get<T>(key);
-  } catch (error) {
-    throw new OAuthProxyStateStoreError(
-      error instanceof Error ? error.message : "OAuth proxy state read failed"
-    );
+  } catch {
+    // Store errors can contain Redis URLs, hostnames, or other sensitive
+    // provider details. Keep the public/logged error deliberately generic.
+    throw new OAuthProxyStateStoreError("OAuth proxy state read failed");
   }
 }
 
-async function storeSet<T>(
+async function storeSetIfNewer<T>(
   store: OAuthProxyStateStore,
   key: string,
   value: T,
-  ttlMs: number
-): Promise<void> {
+  ttlMs?: number
+): Promise<boolean> {
   try {
+    if (store.setIfNewer) return await store.setIfNewer(key, value, ttlMs);
+    const current = await store.get<unknown>(key);
+    if (current !== undefined && compareUnknownVersions(current, value) >= 0) {
+      return false;
+    }
     await store.set(key, value, ttlMs);
-  } catch (error) {
-    throw new OAuthProxyStateStoreError(
-      error instanceof Error ? error.message : "OAuth proxy state write failed"
-    );
+    return true;
+  } catch {
+    throw new OAuthProxyStateStoreError("OAuth proxy state write failed");
   }
 }
 
@@ -1391,9 +1667,62 @@ async function storeDelete(
 ): Promise<void> {
   try {
     await store.delete(key);
+  } catch {
+    throw new OAuthProxyStateStoreError("OAuth proxy state delete failed");
+  }
+}
+
+function compareUnknownVersions(a: unknown, b: unknown): number {
+  const version = (value: unknown) => {
+    if (!value || typeof value !== "object")
+      return { revision: 0, updatedAt: 0 };
+    const record = value as Record<string, unknown>;
+    return {
+      revision:
+        typeof record.revision === "number" && Number.isFinite(record.revision)
+          ? record.revision
+          : 0,
+      updatedAt:
+        typeof record.updatedAt === "number" &&
+        Number.isFinite(record.updatedAt)
+          ? record.updatedAt
+          : 0,
+    };
+  };
+  return compareVersions(version(a), version(b));
+}
+
+async function consumeRateLimit(
+  c: Context,
+  limiter: RateLimiterMemory,
+  globalLimiter: RateLimiterMemory,
+  key: string
+): Promise<Response | undefined> {
+  try {
+    await globalLimiter.consume("inspector-api:global");
+    await limiter.consume(key);
+    return undefined;
   } catch (error) {
-    throw new OAuthProxyStateStoreError(
-      error instanceof Error ? error.message : "OAuth proxy state delete failed"
-    );
+    return inspectorRateLimitResponse(c, error);
+  }
+}
+
+async function withKeyLock<T>(
+  locks: Map<string, Promise<void>>,
+  key: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const previous = locks.get(key);
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  locks.set(key, current);
+  if (previous) await previous.catch(() => undefined);
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (locks.get(key) === current) locks.delete(key);
   }
 }

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -916,9 +916,14 @@ async function applyConfidentialClientAuthentication(options: {
   if (!clientId) return body;
 
   const key = confidentialClientKey(bindingKey, clientId);
-  let client = await storeGet<ConfidentialClient>(stateStore, key);
-  if (client !== undefined) clients.set(key, client);
-  else client = clients.get(key);
+  const persistedClient = await storeGet<unknown>(stateStore, key);
+  let client: ConfidentialClient | undefined;
+  if (isConfidentialClient(persistedClient)) {
+    client = persistedClient;
+    clients.set(key, persistedClient);
+  } else {
+    client = clients.get(key);
+  }
   if (client === undefined && resolveConfidentialClient) {
     const resolved = await resolveConfidentialClient({
       serverUrl,
@@ -974,6 +979,18 @@ function pruneConfidentialClients(
   for (const [key, client] of clients) {
     if (client.expiresAt <= now) clients.delete(key);
   }
+}
+
+function isConfidentialClient(value: unknown): value is ConfidentialClient {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    typeof (value as ConfidentialClient).clientSecret === "string" &&
+    ((value as ConfidentialClient).authMethod === "client_secret_basic" ||
+      (value as ConfidentialClient).authMethod === "client_secret_post") &&
+    typeof (value as ConfidentialClient).expiresAt === "number" &&
+    Number.isFinite((value as ConfidentialClient).expiresAt)
+  );
 }
 
 async function readRequestCapped(
@@ -1106,6 +1123,14 @@ function serializeBinding(binding: Binding): SerializedBinding {
 }
 
 function deserializeBinding(value: SerializedBinding): Binding {
+  if (
+    !Array.isArray(value.authorizationServers) ||
+    !Array.isArray(value.endpoints) ||
+    !Array.isArray(value.tokenEndpointAuthMethods) ||
+    typeof value.updatedAt !== "number"
+  ) {
+    throw new InvalidUpstreamError("OAuth proxy state is invalid");
+  }
   return {
     authorizationServers: new Set(value.authorizationServers),
     endpoints: new Map(value.endpoints),

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -19,6 +19,10 @@ import {
   INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
   inspectorRateLimitResponse,
 } from "../rate-limit.js";
+import {
+  createMemoryOAuthProxyStateStore,
+  type OAuthProxyStateStore,
+} from "./oauth-state-store.js";
 
 type OAuthEndpointKind =
   | "registration"
@@ -44,6 +48,21 @@ type ConfidentialClient = {
   authMethod: "client_secret_basic" | "client_secret_post";
   expiresAt: number;
 };
+
+export type OAuthProxyConfidentialClient = {
+  clientSecret: string;
+  authMethod: "client_secret_basic" | "client_secret_post";
+  expiresAt?: number;
+};
+
+export type OAuthProxyConfidentialClientResolver = (options: {
+  serverUrl: string;
+  targetUrl: string;
+  clientId: string;
+}) =>
+  | OAuthProxyConfidentialClient
+  | undefined
+  | Promise<OAuthProxyConfidentialClient | undefined>;
 
 type ProxyRequest = {
   serverUrl?: unknown;
@@ -81,6 +100,10 @@ interface OAuthProxyOptions {
   ) => Promise<boolean> | boolean;
   /** Shared process-local limiter for Inspector proxy and OAuth routes. */
   rateLimiter?: RateLimiterMemory;
+  /** Durable store shared by every Inspector replica. */
+  stateStore?: OAuthProxyStateStore;
+  /** Server-side resolver for configured confidential clients (never browser-visible). */
+  resolveConfidentialClient?: OAuthProxyConfidentialClientResolver;
 }
 
 const SAFE_REQUEST_HEADERS = new Set([
@@ -129,7 +152,10 @@ export function mountOAuthProxy(
       points: INSPECTOR_API_RATE_LIMIT,
       duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
     }),
+    stateStore,
+    resolveConfidentialClient,
   } = options;
+  const durableStateStore = stateStore ?? createMemoryOAuthProxyStateStore();
   const origins = new Set(allowedOrigins.map(normalizeOrigin));
   const bindings = new Map<string, Binding>();
   const confidentialClients = new Map<string, ConfidentialClient>();
@@ -183,7 +209,12 @@ export function mountOAuthProxy(
     }
     const target = targetResult.url;
     const key = canonicalUrl(serverUrl);
-    const binding = getBinding(bindings, key);
+    let binding: Binding;
+    try {
+      binding = await loadBinding(durableStateStore, bindings, key);
+    } catch (error) {
+      return proxyError(c, error, enableLogging);
+    }
     let metadataKind = classifyMetadataTarget(serverUrl, target, binding);
     if (!metadataKind && binding.authorizationServers.size === 0) {
       try {
@@ -194,9 +225,12 @@ export function mountOAuthProxy(
           timeoutMs,
           maxResponseBodyBytes
         );
-        bindings.set(key, binding);
+        await saveBinding(durableStateStore, bindings, key, binding);
         metadataKind = classifyMetadataTarget(serverUrl, target, binding);
-      } catch {
+      } catch (error) {
+        if (error instanceof OAuthProxyStateStoreError) {
+          return proxyError(c, error, enableLogging);
+        }
         // The requested target remains unauthorized below.
       }
     }
@@ -247,8 +281,7 @@ export function mountOAuthProxy(
         );
       }
       binding.updatedAt = Date.now();
-      bindings.set(key, binding);
-      pruneBindings(bindings);
+      await saveBinding(durableStateStore, bindings, key, binding);
 
       return c.body(raw, 200, {
         "Content-Type":
@@ -303,7 +336,12 @@ export function mountOAuthProxy(
     }
 
     const bindingKey = canonicalUrl(serverUrl);
-    const binding = getBinding(bindings, bindingKey);
+    let binding: Binding;
+    try {
+      binding = await loadBinding(durableStateStore, bindings, bindingKey);
+    } catch (error) {
+      return proxyError(c, error, enableLogging);
+    }
     if (binding.endpoints.size === 0) {
       try {
         await hydrateBinding(
@@ -313,8 +351,12 @@ export function mountOAuthProxy(
           timeoutMs,
           maxResponseBodyBytes
         );
-        bindings.set(bindingKey, binding);
-        pruneBindings(bindings);
+        await saveBinding(
+          durableStateStore,
+          bindings,
+          bindingKey,
+          binding
+        );
       } catch (error) {
         return proxyError(c, error, enableLogging, logPrefix);
       }
@@ -340,11 +382,15 @@ export function mountOAuthProxy(
           new URL(callbackPath, publicOrigin).toString()
         );
       } else {
-        body = applyConfidentialClientAuthentication({
+        body = await applyConfidentialClientAuthentication({
           body,
           headers,
           bindingKey,
           clients: confidentialClients,
+          stateStore: durableStateStore,
+          serverUrl: serverUrl.toString(),
+          targetUrl: target.toString(),
+          resolveConfidentialClient,
         });
       }
       if (
@@ -385,11 +431,12 @@ export function mountOAuthProxy(
         typeof responseBody === "object" &&
         !Array.isArray(responseBody)
       ) {
-        responseBody = retainConfidentialClient({
+        responseBody = await retainConfidentialClient({
           responseBody: responseBody as Record<string, unknown>,
           binding,
           bindingKey,
           clients: confidentialClients,
+          stateStore: durableStateStore,
         });
       }
       return c.json({
@@ -784,16 +831,17 @@ function serializeBody(body: unknown, headers: Headers): string | undefined {
 }
 
 function confidentialClientKey(bindingKey: string, clientId: string): string {
-  return `${bindingKey}\u0000${clientId}`;
+  return `client:${Buffer.from(`${bindingKey}\u0000${clientId}`, "utf8").toString("base64url")}`;
 }
 
-function retainConfidentialClient(options: {
+async function retainConfidentialClient(options: {
   responseBody: Record<string, unknown>;
   binding: Binding;
   bindingKey: string;
   clients: Map<string, ConfidentialClient>;
-}): Record<string, unknown> {
-  const { responseBody, binding, bindingKey, clients } = options;
+  stateStore: OAuthProxyStateStore;
+}): Promise<Record<string, unknown>> {
+  const { responseBody, binding, bindingKey, clients, stateStore } = options;
   const clientId = responseBody.client_id;
   const clientSecret = responseBody.client_secret;
   if (typeof clientId !== "string" || typeof clientSecret !== "string") {
@@ -811,21 +859,30 @@ function retainConfidentialClient(options: {
   const upstreamExpiry = responseBody.client_secret_expires_at;
   const expiresAt =
     upstreamExpiry === 0
-      ? Number.POSITIVE_INFINITY
+      ? Date.now() + CONFIDENTIAL_CLIENT_TTL_MS
       : typeof upstreamExpiry === "number" && upstreamExpiry > 0
         ? upstreamExpiry * 1000
         : Date.now() + CONFIDENTIAL_CLIENT_TTL_MS;
 
   pruneConfidentialClients(clients);
-  clients.set(confidentialClientKey(bindingKey, clientId), {
+  const client = {
     clientSecret,
     authMethod,
     expiresAt,
-  });
+  } satisfies ConfidentialClient;
+  const key = confidentialClientKey(bindingKey, clientId);
+  clients.set(key, client);
+  await storeSet(
+    stateStore,
+    key,
+    client,
+    Math.max(1, expiresAt - Date.now())
+  );
   while (clients.size > MAX_CONFIDENTIAL_CLIENTS) {
     const oldest = clients.keys().next().value as string | undefined;
     if (!oldest) break;
     clients.delete(oldest);
+    await storeDelete(stateStore, oldest);
   }
 
   const browserSafe = { ...responseBody };
@@ -835,13 +892,26 @@ function retainConfidentialClient(options: {
   return browserSafe;
 }
 
-function applyConfidentialClientAuthentication(options: {
+async function applyConfidentialClientAuthentication(options: {
   body: string | undefined;
   headers: Headers;
   bindingKey: string;
   clients: Map<string, ConfidentialClient>;
-}): string | undefined {
-  const { body, headers, bindingKey, clients } = options;
+  stateStore: OAuthProxyStateStore;
+  serverUrl: string;
+  targetUrl: string;
+  resolveConfidentialClient?: OAuthProxyConfidentialClientResolver;
+}): Promise<string | undefined> {
+  const {
+    body,
+    headers,
+    bindingKey,
+    clients,
+    stateStore,
+    serverUrl,
+    targetUrl,
+    resolveConfidentialClient,
+  } = options;
   if (
     !body ||
     !(headers.get("content-type") ?? "").includes(
@@ -856,10 +926,37 @@ function applyConfidentialClientAuthentication(options: {
   if (!clientId) return body;
 
   const key = confidentialClientKey(bindingKey, clientId);
-  const client = clients.get(key);
+  let client = clients.get(key);
+  if (client === undefined) {
+    client = await storeGet<ConfidentialClient>(stateStore, key);
+    if (client !== undefined) clients.set(key, client);
+  }
+  if (client === undefined && resolveConfidentialClient) {
+    const resolved = await resolveConfidentialClient({
+      serverUrl,
+      targetUrl,
+      clientId,
+    });
+    if (resolved) {
+      client = {
+        clientSecret: resolved.clientSecret,
+        authMethod: resolved.authMethod,
+        expiresAt:
+          resolved.expiresAt ?? Date.now() + CONFIDENTIAL_CLIENT_TTL_MS,
+      };
+      clients.set(key, client);
+      await storeSet(
+        stateStore,
+        key,
+        client,
+        Math.max(1, client.expiresAt - Date.now())
+      );
+    }
+  }
   if (!client) return body;
   if (client.expiresAt <= Date.now()) {
     clients.delete(key);
+    await storeDelete(stateStore, key);
     return body;
   }
 
@@ -954,18 +1051,83 @@ function parseObject(value: string): Record<string, unknown> {
   return parsed as Record<string, unknown>;
 }
 
-function getBinding(bindings: Map<string, Binding>, key: string): Binding {
+async function loadBinding(
+  stateStore: OAuthProxyStateStore,
+  bindings: Map<string, Binding>,
+  key: string
+): Promise<Binding> {
+  const persisted = await storeGet<SerializedBinding>(
+    stateStore,
+    bindingStoreKey(key)
+  );
+  if (persisted !== undefined) {
+    const binding = deserializeBinding(persisted);
+    if (Date.now() - binding.updatedAt <= BINDING_TTL_MS) {
+      bindings.set(key, binding);
+      return binding;
+    }
+    await storeDelete(stateStore, bindingStoreKey(key));
+  }
   const existing = bindings.get(key);
   if (existing && Date.now() - existing.updatedAt <= BINDING_TTL_MS) {
     return existing;
   }
   bindings.delete(key);
+  return emptyBinding();
+}
+
+async function saveBinding(
+  stateStore: OAuthProxyStateStore,
+  bindings: Map<string, Binding>,
+  key: string,
+  binding: Binding
+): Promise<void> {
+  bindings.set(key, binding);
+  await storeSet(
+    stateStore,
+    bindingStoreKey(key),
+    serializeBinding(binding),
+    BINDING_TTL_MS
+  );
+  pruneBindings(bindings);
+}
+
+function emptyBinding(): Binding {
   return {
     authorizationServers: new Set(),
     endpoints: new Map(),
     tokenEndpointAuthMethods: new Set(),
     updatedAt: Date.now(),
   };
+}
+
+type SerializedBinding = {
+  authorizationServers: string[];
+  endpoints: Array<[string, OAuthEndpointKind]>;
+  tokenEndpointAuthMethods: string[];
+  updatedAt: number;
+};
+
+function serializeBinding(binding: Binding): SerializedBinding {
+  return {
+    authorizationServers: [...binding.authorizationServers],
+    endpoints: [...binding.endpoints.entries()],
+    tokenEndpointAuthMethods: [...binding.tokenEndpointAuthMethods],
+    updatedAt: binding.updatedAt,
+  };
+}
+
+function deserializeBinding(value: SerializedBinding): Binding {
+  return {
+    authorizationServers: new Set(value.authorizationServers),
+    endpoints: new Map(value.endpoints),
+    tokenEndpointAuthMethods: new Set(value.tokenEndpointAuthMethods),
+    updatedAt: value.updatedAt,
+  };
+}
+
+function bindingStoreKey(key: string): string {
+  return `binding:${Buffer.from(key, "utf8").toString("base64url")}`;
 }
 
 function pruneBindings(bindings: Map<string, Binding>): void {
@@ -1163,6 +1325,9 @@ function proxyError(
       message
     );
   }
+  if (error instanceof OAuthProxyStateStoreError) {
+    return c.json({ error: "OAuth proxy state store unavailable" }, 503);
+  }
   if (error instanceof BodyTooLargeError) {
     return c.json({ error: "Upstream response too large" }, 502);
   }
@@ -1177,3 +1342,47 @@ function proxyError(
 
 class BodyTooLargeError extends Error {}
 class InvalidUpstreamError extends Error {}
+class OAuthProxyStateStoreError extends Error {}
+
+async function storeGet<T>(
+  store: OAuthProxyStateStore,
+  key: string
+): Promise<T | undefined> {
+  try {
+    return await store.get<T>(key);
+  } catch (error) {
+    throw new OAuthProxyStateStoreError(
+      error instanceof Error ? error.message : "OAuth proxy state read failed"
+    );
+  }
+}
+
+async function storeSet<T>(
+  store: OAuthProxyStateStore,
+  key: string,
+  value: T,
+  ttlMs: number
+): Promise<void> {
+  try {
+    await store.set(key, value, ttlMs);
+  } catch (error) {
+    throw new OAuthProxyStateStoreError(
+      error instanceof Error ? error.message : "OAuth proxy state write failed"
+    );
+  }
+}
+
+async function storeDelete(
+  store: OAuthProxyStateStore,
+  key: string
+): Promise<void> {
+  try {
+    await store.delete(key);
+  } catch (error) {
+    throw new OAuthProxyStateStoreError(
+      error instanceof Error
+        ? error.message
+        : "OAuth proxy state delete failed"
+    );
+  }
+}

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -351,12 +351,7 @@ export function mountOAuthProxy(
           timeoutMs,
           maxResponseBodyBytes
         );
-        await saveBinding(
-          durableStateStore,
-          bindings,
-          bindingKey,
-          binding
-        );
+        await saveBinding(durableStateStore, bindings, bindingKey, binding);
       } catch (error) {
         return proxyError(c, error, enableLogging, logPrefix);
       }
@@ -872,12 +867,7 @@ async function retainConfidentialClient(options: {
   } satisfies ConfidentialClient;
   const key = confidentialClientKey(bindingKey, clientId);
   clients.set(key, client);
-  await storeSet(
-    stateStore,
-    key,
-    client,
-    Math.max(1, expiresAt - Date.now())
-  );
+  await storeSet(stateStore, key, client, Math.max(1, expiresAt - Date.now()));
   while (clients.size > MAX_CONFIDENTIAL_CLIENTS) {
     const oldest = clients.keys().next().value as string | undefined;
     if (!oldest) break;
@@ -1380,9 +1370,7 @@ async function storeDelete(
     await store.delete(key);
   } catch (error) {
     throw new OAuthProxyStateStoreError(
-      error instanceof Error
-        ? error.message
-        : "OAuth proxy state delete failed"
+      error instanceof Error ? error.message : "OAuth proxy state delete failed"
     );
   }
 }

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-proxy.ts
@@ -916,11 +916,9 @@ async function applyConfidentialClientAuthentication(options: {
   if (!clientId) return body;
 
   const key = confidentialClientKey(bindingKey, clientId);
-  let client = clients.get(key);
-  if (client === undefined) {
-    client = await storeGet<ConfidentialClient>(stateStore, key);
-    if (client !== undefined) clients.set(key, client);
-  }
+  let client = await storeGet<ConfidentialClient>(stateStore, key);
+  if (client !== undefined) clients.set(key, client);
+  else client = clients.get(key);
   if (client === undefined && resolveConfidentialClient) {
     const resolved = await resolveConfidentialClient({
       serverUrl,

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
@@ -22,7 +22,14 @@ export interface OAuthProxyStateStore {
   set<T>(key: string, value: T, ttlMs?: number): Promise<void>;
   setIfNewer?<T>(key: string, value: T, ttlMs?: number): Promise<boolean>;
   delete(key: string): Promise<void>;
+  /** Delete only when the stored version still equals the expected version. */
+  deleteIfVersion?(
+    key: string,
+    expected: { revision: number; updatedAt: number }
+  ): Promise<boolean>;
   ready?(): Promise<void>;
+  /** Active connectivity probe for health/readiness endpoints. */
+  probe?(): Promise<void>;
   close?(): Promise<void>;
 }
 
@@ -91,7 +98,23 @@ export function createMemoryOAuthProxyStateStore(): OAuthProxyStateStore {
     async delete(key: string): Promise<void> {
       values.delete(key);
     },
+    async deleteIfVersion(
+      key: string,
+      expected: { revision: number; updatedAt: number }
+    ): Promise<boolean> {
+      const current = values.get(key);
+      if (!current || current.expiresAt <= Date.now()) {
+        values.delete(key);
+        return false;
+      }
+      if (compareStateVersion(current.value, expected) !== 0) return false;
+      values.delete(key);
+      return true;
+    },
     async ready(): Promise<void> {
+      // The memory store is always ready.
+    },
+    async probe(): Promise<void> {
       // The memory store is always ready.
     },
     async close(): Promise<void> {
@@ -256,8 +279,48 @@ export function createRedisOAuthProxyStateStore(options: {
       await ready();
       await client.del(keyPrefix + key);
     },
+    async deleteIfVersion(
+      key: string,
+      expected: { revision: number; updatedAt: number }
+    ): Promise<boolean> {
+      return runTransaction(async () => {
+        const fullKey = keyPrefix + key;
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          await transactionReady();
+          await transactionClient.watch(fullKey);
+          try {
+            const raw = await transactionClient.get(fullKey);
+            if (raw === null) {
+              await transactionClient.unwatch();
+              return false;
+            }
+            const current = await decrypt(raw, keys);
+            if (compareStateVersion(current, expected) !== 0) {
+              await transactionClient.unwatch();
+              return false;
+            }
+            const transaction = transactionClient.multi();
+            transaction.del(fullKey);
+            try {
+              const result = await transaction.exec();
+              if (result !== null) return true;
+            } catch (error) {
+              if (!isRedisWatchConflict(error)) throw error;
+            }
+          } finally {
+            await transactionClient.unwatch().catch(() => undefined);
+          }
+        }
+        throw new Error("Redis state deletion conflicted repeatedly");
+      });
+    },
     async ready(): Promise<void> {
       await ready();
+    },
+    async probe(): Promise<void> {
+      await ready();
+      const result = await client.ping();
+      if (result !== "PONG") throw new Error("Redis readiness check failed");
     },
     async close(): Promise<void> {
       closing = true;

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
@@ -77,7 +77,9 @@ export function createRedisOAuthProxyStateStore(options: {
     },
     async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
       const encoded = await encrypt(value, options.encryptionKey);
-      await (await ready()).set(keyPrefix + key, encoded, {
+      await (
+        await ready()
+      ).set(keyPrefix + key, encoded, {
         PX: Math.max(1, Math.ceil(ttlMs)),
       });
     },

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
@@ -1,24 +1,53 @@
+import { Buffer } from "node:buffer";
 import { createClient } from "redis";
+
+/** A key used to encrypt newly written state and decrypt rotated state. */
+export type OAuthProxyEncryptionKey = {
+  /** Stable non-secret key identifier stored in the envelope. */
+  id: string;
+  /** Exactly 32 bytes for AES-256-GCM. */
+  key: Uint8Array;
+};
 
 /**
  * Durable state boundary used by the hosted OAuth BFF.
  *
- * Implementations must apply the supplied TTL and must not log values. The
- * proxy stores only metadata bindings and confidential-client credentials at
- * this boundary; browser-visible OAuth responses are always sanitized before
- * they leave the proxy.
+ * Values must never be logged by an implementation. `setIfNewer` is optional
+ * for small custom stores; the Redis implementation uses WATCH/MULTI so an
+ * older replica cannot overwrite newer state. `ready` is called during
+ * application startup and performs a real connectivity check.
  */
 export interface OAuthProxyStateStore {
   get<T>(key: string): Promise<T | undefined>;
-  set<T>(key: string, value: T, ttlMs: number): Promise<void>;
+  set<T>(key: string, value: T, ttlMs?: number): Promise<void>;
+  setIfNewer?<T>(key: string, value: T, ttlMs?: number): Promise<boolean>;
   delete(key: string): Promise<void>;
+  ready?(): Promise<void>;
   close?(): Promise<void>;
 }
 
+type StoredValue = { value: unknown; expiresAt: number };
+const MAX_MEMORY_ENTRIES = 2_000;
+const MEMORY_CLEANUP_INTERVAL_MS = 60_000;
+
 /** Process-local fallback for local development and unit tests. */
 export function createMemoryOAuthProxyStateStore(): OAuthProxyStateStore {
-  const values = new Map<string, { value: unknown; expiresAt: number }>();
-  return {
+  const values = new Map<string, StoredValue>();
+  const cleanup = () => {
+    const now = Date.now();
+    for (const [key, entry] of values) {
+      if (entry.expiresAt <= now) values.delete(key);
+    }
+    while (values.size > MAX_MEMORY_ENTRIES) {
+      const oldest = values.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      values.delete(oldest);
+    }
+  };
+  const timer = setInterval(cleanup, MEMORY_CLEANUP_INTERVAL_MS);
+  timer.unref?.();
+
+  const store: OAuthProxyStateStore = {
     async get<T>(key: string): Promise<T | undefined> {
       const entry = values.get(key);
       if (!entry || entry.expiresAt <= Date.now()) {
@@ -27,109 +56,320 @@ export function createMemoryOAuthProxyStateStore(): OAuthProxyStateStore {
       }
       return structuredClone(entry.value) as T;
     },
-    async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    async set<T>(key: string, value: T, ttlMs?: number): Promise<void> {
       values.set(key, {
         value: structuredClone(value),
-        expiresAt: Date.now() + Math.max(1, ttlMs),
+        expiresAt:
+          ttlMs === undefined || !Number.isFinite(ttlMs)
+            ? Number.POSITIVE_INFINITY
+            : Date.now() + Math.max(1, Math.ceil(ttlMs)),
       });
+      cleanup();
+    },
+    async setIfNewer<T>(key: string, value: T, ttlMs?: number) {
+      const current = values.get(key);
+      if (current && current.expiresAt <= Date.now()) {
+        values.delete(key);
+      }
+      if (
+        current &&
+        current.expiresAt > Date.now() &&
+        compareStateVersion(current.value, value) >= 0
+      ) {
+        return false;
+      }
+      values.set(key, {
+        value: structuredClone(value),
+        expiresAt:
+          ttlMs === undefined || !Number.isFinite(ttlMs)
+            ? Number.POSITIVE_INFINITY
+            : Date.now() + Math.max(1, Math.ceil(ttlMs)),
+      });
+      cleanup();
+      return true;
     },
     async delete(key: string): Promise<void> {
       values.delete(key);
     },
+    async ready(): Promise<void> {
+      // The memory store is always ready.
+    },
+    async close(): Promise<void> {
+      clearInterval(timer);
+      values.clear();
+    },
   };
+  return store;
 }
 
 /**
- * Redis-backed store for Railway/production deployments.
+ * Redis-backed store for hosted Inspector deployments.
  *
- * Values are encrypted with AES-256-GCM before persistence. The encryption key
- * is supplied by the deployment secret manager and never returned to callers.
+ * State is encrypted with AES-256-GCM before persistence. New writes use the
+ * primary key and reads accept the primary plus any explicitly supplied old
+ * keys, which permits key rotation without exposing credentials. Redis is
+ * connected lazily for library callers, while `ready()` performs connect +
+ * PING for standalone startup readiness.
  */
 export function createRedisOAuthProxyStateStore(options: {
   url: string;
   encryptionKey: Uint8Array;
+  encryptionKeyId?: string;
+  decryptionKeys?: readonly OAuthProxyEncryptionKey[];
   keyPrefix?: string;
+  shutdownTimeoutMs?: number;
 }): OAuthProxyStateStore {
   if (!options.url) throw new TypeError("Redis URL is required");
-  if (options.encryptionKey.byteLength !== 32) {
-    throw new TypeError("OAuth proxy encryption key must be 32 bytes");
-  }
-
+  const keys = normalizeEncryptionKeys({
+    id: options.encryptionKeyId,
+    key: options.encryptionKey,
+    previous: options.decryptionKeys,
+  });
   const client = createClient({ url: options.url });
-  // Redis requires an error listener; keep diagnostics out of logs because
-  // connection URLs can contain credentials.
+  // Redis requires an error listener. Do not print diagnostics because a
+  // client error can contain the connection URL and its credentials.
   client.on("error", () => undefined);
   const keyPrefix = options.keyPrefix ?? "mcp-use:inspector:oauth:";
+  const shutdownTimeoutMs = Math.max(1, options.shutdownTimeoutMs ?? 2_000);
   let connecting: Promise<void> | undefined;
-  const ready = async () => {
-    if (!client.isReady) {
-      connecting ??= client.connect().then(() => undefined);
-      await connecting;
-    }
-    return client;
+  // WATCH state is connection-scoped. Keep one duplicate for all CAS work and
+  // serialize its transactions in-process; WATCH/MULTI still arbitrates with
+  // writers from other replicas without opening a socket per request.
+  const transactionClient = client.duplicate();
+  transactionClient.on("error", () => undefined);
+  let transactionConnecting: Promise<void> | undefined;
+  let transactionTail = Promise.resolve();
+  let closing = false;
+
+  const connectAndPing = async (): Promise<void> => {
+    if (closing) throw new Error("OAuth state store is closed");
+    if (!client.isOpen) await client.connect();
+    // A disconnected node-redis client may remain open but not ready while it
+    // is reconnecting. PING is the readiness gate and is intentionally not
+    // replaced by isOpen (which only means a socket was opened).
+    const result = await client.ping();
+    if (result !== "PONG") throw new Error("Redis readiness check failed");
+  };
+  const ready = async (): Promise<void> => {
+    if (closing) throw new Error("OAuth state store is closed");
+    if (client.isReady) return;
+    connecting ??= connectAndPing().finally(() => {
+      connecting = undefined;
+    });
+    await connecting;
   };
 
-  return {
-    async get<T>(key: string): Promise<T | undefined> {
-      const raw = await (await ready()).get(keyPrefix + key);
-      if (raw === null) return undefined;
-      return (await decrypt(raw, options.encryptionKey)) as T;
-    },
-    async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
-      const encoded = await encrypt(value, options.encryptionKey);
-      await (
-        await ready()
-      ).set(keyPrefix + key, encoded, {
+  const transactionReady = async (): Promise<void> => {
+    if (closing) throw new Error("OAuth state store is closed");
+    if (transactionClient.isReady) return;
+    transactionConnecting ??= (async () => {
+      if (!transactionClient.isOpen) await transactionClient.connect();
+      const result = await transactionClient.ping();
+      if (result !== "PONG") throw new Error("Redis readiness check failed");
+    })().finally(() => {
+      transactionConnecting = undefined;
+    });
+    await transactionConnecting;
+  };
+
+  const runTransaction = async <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = transactionTail.then(operation, operation);
+    transactionTail = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  };
+
+  const write = async (
+    fullKey: string,
+    encoded: string,
+    ttlMs: number | undefined,
+    transaction: RedisStringWriter = client
+  ) => {
+    if (ttlMs === undefined || !Number.isFinite(ttlMs)) {
+      await transaction.set(fullKey, encoded);
+    } else {
+      await transaction.set(fullKey, encoded, {
         PX: Math.max(1, Math.ceil(ttlMs)),
+      });
+    }
+  };
+
+  const store: OAuthProxyStateStore = {
+    async get<T>(key: string): Promise<T | undefined> {
+      await ready();
+      const raw = await client.get(keyPrefix + key);
+      if (raw === null) return undefined;
+      return (await decrypt(raw, keys)) as T;
+    },
+    async set<T>(key: string, value: T, ttlMs?: number): Promise<void> {
+      await ready();
+      await write(keyPrefix + key, await encrypt(value, keys[0]), ttlMs);
+    },
+    async setIfNewer<T>(
+      key: string,
+      value: T,
+      ttlMs?: number
+    ): Promise<boolean> {
+      return runTransaction(async () => {
+        const fullKey = keyPrefix + key;
+        const encoded = await encrypt(value, keys[0]);
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          await transactionReady();
+          await transactionClient.watch(fullKey);
+          try {
+            const raw = await transactionClient.get(fullKey);
+            if (raw !== null) {
+              const current = await decrypt(raw, keys);
+              if (compareStateVersion(current, value) >= 0) {
+                await transactionClient.unwatch();
+                return false;
+              }
+            }
+            const transaction = transactionClient.multi();
+            await write(
+              fullKey,
+              encoded,
+              ttlMs,
+              transaction as unknown as RedisStringWriter
+            );
+            try {
+              const result = await transaction.exec();
+              if (result !== null) return true;
+            } catch (error) {
+              // node-redis rejects EXEC when another replica changed a
+              // watched key. Treat that as an optimistic retry, not a store
+              // outage; unrelated command errors still propagate.
+              if (!isRedisWatchConflict(error)) throw error;
+            }
+          } finally {
+            // `exec()` already clears WATCH; this is harmless for a conflict or
+            // an exception and prevents a watch leaking into a later operation.
+            await transactionClient.unwatch().catch(() => undefined);
+          }
+        }
+        throw new Error("Redis state update conflicted repeatedly");
       });
     },
     async delete(key: string): Promise<void> {
-      await (await ready()).del(keyPrefix + key);
+      await ready();
+      await client.del(keyPrefix + key);
+    },
+    async ready(): Promise<void> {
+      await ready();
     },
     async close(): Promise<void> {
-      if (client.isOpen) await client.quit();
+      closing = true;
+      const pending = connecting;
+      if (pending) {
+        await Promise.race([
+          pending.catch(() => undefined),
+          timeout(shutdownTimeoutMs),
+        ]);
+      }
+      const pendingTransaction = transactionConnecting;
+      if (pendingTransaction) {
+        await Promise.race([
+          pendingTransaction.catch(() => undefined),
+          timeout(shutdownTimeoutMs),
+        ]);
+      }
+      await Promise.race([transactionTail, timeout(shutdownTimeoutMs)]);
+      await Promise.all([
+        closeRedisClient(client, shutdownTimeoutMs),
+        closeRedisClient(transactionClient, shutdownTimeoutMs),
+      ]);
     },
   };
+  return store;
+}
+
+type RedisStringWriter = {
+  set(key: string, value: string, options?: { PX: number }): Promise<unknown>;
+};
+
+async function closeRedisClient(
+  client: {
+    isOpen: boolean;
+    quit(): Promise<unknown>;
+    destroy(): unknown;
+  },
+  timeoutMs: number
+): Promise<void> {
+  if (!client.isOpen) return;
+  await Promise.race([
+    client.quit().catch(() => undefined),
+    timeout(timeoutMs).then(() => {
+      client.destroy();
+    }),
+  ]);
 }
 
 export function decodeOAuthProxyEncryptionKey(value: string): Uint8Array {
   const normalized = value.trim();
-  let decoded: Uint8Array;
-  try {
-    decoded = Uint8Array.from(Buffer.from(normalized, "base64"));
-  } catch {
+  if (!normalized || !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)) {
     throw new TypeError("OAuth proxy encryption key must be base64");
   }
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  const decoded = Uint8Array.from(Buffer.from(padded, "base64"));
   if (decoded.byteLength !== 32) {
     throw new TypeError("OAuth proxy encryption key must decode to 32 bytes");
   }
   return decoded;
 }
 
-async function encrypt(value: unknown, key: Uint8Array): Promise<string> {
+function normalizeEncryptionKeys(options: {
+  id: string | undefined;
+  key: Uint8Array;
+  previous: readonly OAuthProxyEncryptionKey[] | undefined;
+}): OAuthProxyEncryptionKey[] {
+  const primary = {
+    id: options.id?.trim() || "current",
+    key: options.key,
+  } satisfies OAuthProxyEncryptionKey;
+  const all = [primary, ...(options.previous ?? [])];
+  const seen = new Set<string>();
+  for (const entry of all) {
+    if (!entry.id || seen.has(entry.id) || entry.key.byteLength !== 32) {
+      throw new TypeError(
+        "OAuth proxy encryption keys must have unique IDs and 32-byte keys"
+      );
+    }
+    seen.add(entry.id);
+  }
+  return all.map((entry) => ({
+    id: entry.id,
+    key: Uint8Array.from(entry.key),
+  }));
+}
+
+async function encrypt(
+  value: unknown,
+  key: OAuthProxyEncryptionKey
+): Promise<string> {
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const plaintext = new TextEncoder().encode(JSON.stringify(value));
-  const cryptoKey = await crypto.subtle.importKey(
-    "raw",
-    toArrayBuffer(key),
-    { name: "AES-GCM", length: 256 },
-    false,
-    ["encrypt"]
-  );
+  const cryptoKey = await importKey(key.key, "encrypt");
   const ciphertext = new Uint8Array(
     await crypto.subtle.encrypt({ name: "AES-GCM", iv }, cryptoKey, plaintext)
   );
   return JSON.stringify({
     v: 1,
+    kid: key.id,
     iv: Buffer.from(iv).toString("base64url"),
     ciphertext: Buffer.from(ciphertext).toString("base64url"),
   });
 }
 
-async function decrypt(value: string, key: Uint8Array): Promise<unknown> {
+async function decrypt(
+  value: string,
+  keys: readonly OAuthProxyEncryptionKey[]
+): Promise<unknown> {
   try {
     const envelope = JSON.parse(value) as {
       v?: unknown;
+      kid?: unknown;
       iv?: unknown;
       ciphertext?: unknown;
     };
@@ -140,26 +380,74 @@ async function decrypt(value: string, key: Uint8Array): Promise<unknown> {
     ) {
       throw new Error("Invalid OAuth proxy state envelope");
     }
-    const cryptoKey = await crypto.subtle.importKey(
-      "raw",
-      toArrayBuffer(key),
-      { name: "AES-GCM", length: 256 },
-      false,
-      ["decrypt"]
-    );
-    const plaintext = await crypto.subtle.decrypt(
-      { name: "AES-GCM", iv: Buffer.from(envelope.iv, "base64url") },
-      cryptoKey,
-      Buffer.from(envelope.ciphertext, "base64url")
-    );
-    return JSON.parse(new TextDecoder().decode(plaintext));
+    const candidates =
+      typeof envelope.kid === "string"
+        ? keys.filter((key) => key.id === envelope.kid)
+        : keys;
+    if (candidates.length === 0) throw new Error("Unknown OAuth state key");
+    for (const key of candidates) {
+      try {
+        const plaintext = await crypto.subtle.decrypt(
+          { name: "AES-GCM", iv: Buffer.from(envelope.iv, "base64url") },
+          await importKey(key.key, "decrypt"),
+          Buffer.from(envelope.ciphertext, "base64url")
+        );
+        return JSON.parse(new TextDecoder().decode(plaintext));
+      } catch {
+        // A rotated key is expected to fail until the matching key is tried.
+      }
+    }
   } catch {
-    throw new Error("Unable to decrypt OAuth proxy state");
+    // Never include ciphertext, keys, or Redis values in the error.
   }
+  throw new Error("Unable to decrypt OAuth proxy state");
 }
 
-function toArrayBuffer(value: Uint8Array): ArrayBuffer {
-  const copy = new ArrayBuffer(value.byteLength);
-  new Uint8Array(copy).set(value);
-  return copy;
+async function importKey(
+  key: Uint8Array,
+  usage: "encrypt" | "decrypt"
+): Promise<CryptoKey> {
+  const copy = new ArrayBuffer(key.byteLength);
+  new Uint8Array(copy).set(key);
+  return crypto.subtle.importKey(
+    "raw",
+    copy,
+    { name: "AES-GCM", length: 256 },
+    false,
+    [usage]
+  );
+}
+
+function compareStateVersion(a: unknown, b: unknown): number {
+  const av = stateVersion(a);
+  const bv = stateVersion(b);
+  if (av.revision !== bv.revision) return av.revision - bv.revision;
+  return av.updatedAt - bv.updatedAt;
+}
+
+function stateVersion(value: unknown): { revision: number; updatedAt: number } {
+  if (!value || typeof value !== "object") return { revision: 0, updatedAt: 0 };
+  const record = value as Record<string, unknown>;
+  return {
+    revision:
+      typeof record.revision === "number" && Number.isFinite(record.revision)
+        ? record.revision
+        : 0,
+    updatedAt:
+      typeof record.updatedAt === "number" && Number.isFinite(record.updatedAt)
+        ? record.updatedAt
+        : 0,
+  };
+}
+
+function timeout(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRedisWatchConflict(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "WatchError" ||
+      /watched keys? has been changed/i.test(error.message))
+  );
 }

--- a/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
+++ b/libraries/typescript/packages/inspector/src/server/proxy/oauth-state-store.ts
@@ -1,0 +1,163 @@
+import { createClient } from "redis";
+
+/**
+ * Durable state boundary used by the hosted OAuth BFF.
+ *
+ * Implementations must apply the supplied TTL and must not log values. The
+ * proxy stores only metadata bindings and confidential-client credentials at
+ * this boundary; browser-visible OAuth responses are always sanitized before
+ * they leave the proxy.
+ */
+export interface OAuthProxyStateStore {
+  get<T>(key: string): Promise<T | undefined>;
+  set<T>(key: string, value: T, ttlMs: number): Promise<void>;
+  delete(key: string): Promise<void>;
+  close?(): Promise<void>;
+}
+
+/** Process-local fallback for local development and unit tests. */
+export function createMemoryOAuthProxyStateStore(): OAuthProxyStateStore {
+  const values = new Map<string, { value: unknown; expiresAt: number }>();
+  return {
+    async get<T>(key: string): Promise<T | undefined> {
+      const entry = values.get(key);
+      if (!entry || entry.expiresAt <= Date.now()) {
+        values.delete(key);
+        return undefined;
+      }
+      return structuredClone(entry.value) as T;
+    },
+    async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+      values.set(key, {
+        value: structuredClone(value),
+        expiresAt: Date.now() + Math.max(1, ttlMs),
+      });
+    },
+    async delete(key: string): Promise<void> {
+      values.delete(key);
+    },
+  };
+}
+
+/**
+ * Redis-backed store for Railway/production deployments.
+ *
+ * Values are encrypted with AES-256-GCM before persistence. The encryption key
+ * is supplied by the deployment secret manager and never returned to callers.
+ */
+export function createRedisOAuthProxyStateStore(options: {
+  url: string;
+  encryptionKey: Uint8Array;
+  keyPrefix?: string;
+}): OAuthProxyStateStore {
+  if (!options.url) throw new TypeError("Redis URL is required");
+  if (options.encryptionKey.byteLength !== 32) {
+    throw new TypeError("OAuth proxy encryption key must be 32 bytes");
+  }
+
+  const client = createClient({ url: options.url });
+  // Redis requires an error listener; keep diagnostics out of logs because
+  // connection URLs can contain credentials.
+  client.on("error", () => undefined);
+  const keyPrefix = options.keyPrefix ?? "mcp-use:inspector:oauth:";
+  let connecting: Promise<void> | undefined;
+  const ready = async () => {
+    if (!client.isReady) {
+      connecting ??= client.connect().then(() => undefined);
+      await connecting;
+    }
+    return client;
+  };
+
+  return {
+    async get<T>(key: string): Promise<T | undefined> {
+      const raw = await (await ready()).get(keyPrefix + key);
+      if (raw === null) return undefined;
+      return (await decrypt(raw, options.encryptionKey)) as T;
+    },
+    async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+      const encoded = await encrypt(value, options.encryptionKey);
+      await (await ready()).set(keyPrefix + key, encoded, {
+        PX: Math.max(1, Math.ceil(ttlMs)),
+      });
+    },
+    async delete(key: string): Promise<void> {
+      await (await ready()).del(keyPrefix + key);
+    },
+    async close(): Promise<void> {
+      if (client.isOpen) await client.quit();
+    },
+  };
+}
+
+export function decodeOAuthProxyEncryptionKey(value: string): Uint8Array {
+  const normalized = value.trim();
+  let decoded: Uint8Array;
+  try {
+    decoded = Uint8Array.from(Buffer.from(normalized, "base64"));
+  } catch {
+    throw new TypeError("OAuth proxy encryption key must be base64");
+  }
+  if (decoded.byteLength !== 32) {
+    throw new TypeError("OAuth proxy encryption key must decode to 32 bytes");
+  }
+  return decoded;
+}
+
+async function encrypt(value: unknown, key: Uint8Array): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = new TextEncoder().encode(JSON.stringify(value));
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    toArrayBuffer(key),
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt"]
+  );
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt({ name: "AES-GCM", iv }, cryptoKey, plaintext)
+  );
+  return JSON.stringify({
+    v: 1,
+    iv: Buffer.from(iv).toString("base64url"),
+    ciphertext: Buffer.from(ciphertext).toString("base64url"),
+  });
+}
+
+async function decrypt(value: string, key: Uint8Array): Promise<unknown> {
+  try {
+    const envelope = JSON.parse(value) as {
+      v?: unknown;
+      iv?: unknown;
+      ciphertext?: unknown;
+    };
+    if (
+      envelope.v !== 1 ||
+      typeof envelope.iv !== "string" ||
+      typeof envelope.ciphertext !== "string"
+    ) {
+      throw new Error("Invalid OAuth proxy state envelope");
+    }
+    const cryptoKey = await crypto.subtle.importKey(
+      "raw",
+      toArrayBuffer(key),
+      { name: "AES-GCM", length: 256 },
+      false,
+      ["decrypt"]
+    );
+    const plaintext = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: Buffer.from(envelope.iv, "base64url") },
+      cryptoKey,
+      Buffer.from(envelope.ciphertext, "base64url")
+    );
+    return JSON.parse(new TextDecoder().decode(plaintext));
+  } catch {
+    throw new Error("Unable to decrypt OAuth proxy state");
+  }
+}
+
+function toArrayBuffer(value: Uint8Array): ArrayBuffer {
+  const copy = new ArrayBuffer(value.byteLength);
+  new Uint8Array(copy).set(value);
+  return copy;
+}

--- a/libraries/typescript/packages/inspector/src/server/rate-limit.ts
+++ b/libraries/typescript/packages/inspector/src/server/rate-limit.ts
@@ -1,10 +1,30 @@
 import type { Context } from "hono";
+import { createHash } from "node:crypto";
+import { RateLimiterMemory } from "rate-limiter-flexible";
 
 export const INSPECTOR_ASSET_RATE_LIMIT = 600;
 export const INSPECTOR_API_RATE_LIMIT = 120;
 /** Backstop across every proxied target in one Inspector process. */
 export const INSPECTOR_GLOBAL_API_RATE_LIMIT = 1_200;
+/** Small per-client budget protecting the embedding application's auth hook. */
+export const INSPECTOR_PREAUTH_RATE_LIMIT = 60;
+/** Process-wide pre-auth backstop against IP/key rotation DoS. */
+export const INSPECTOR_GLOBAL_PREAUTH_RATE_LIMIT = 6_000;
 export const INSPECTOR_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+/** Shared defaults: every mounted relay in one process uses the same budgets. */
+export const defaultInspectorGlobalRateLimiter = new RateLimiterMemory({
+  points: INSPECTOR_GLOBAL_API_RATE_LIMIT,
+  duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+});
+export const defaultInspectorPreAuthRateLimiter = new RateLimiterMemory({
+  points: INSPECTOR_PREAUTH_RATE_LIMIT,
+  duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+});
+export const defaultInspectorGlobalPreAuthRateLimiter = new RateLimiterMemory({
+  points: INSPECTOR_GLOBAL_PREAUTH_RATE_LIMIT,
+  duration: INSPECTOR_RATE_LIMIT_WINDOW_SECONDS,
+});
 
 /**
  * Build a bounded, non-sensitive limiter key for one logical upstream server.
@@ -21,11 +41,28 @@ export function inspectorServerRateLimitKey(
     if (url.protocol !== "http:" && url.protocol !== "https:") {
       return `${namespace}:unknown`;
     }
-    const pathname = url.pathname.replace(/\/+$/, "") || "/";
+    const rawPathname = url.pathname.replace(/\/+$/, "") || "/";
+    const pathname =
+      rawPathname.length > 256
+        ? `/__path_hash/${createHash("sha256").update(rawPathname).digest("hex")}`
+        : rawPathname;
     return `${namespace}:${url.origin}${pathname}`;
   } catch {
     return `${namespace}:unknown`;
   }
+}
+
+/** Build a bounded non-secret pre-auth key from edge-provided client identity. */
+export function inspectorRelayPreAuthKey(
+  cloudflareConnectingIp: string | undefined,
+  forwardedFor: string | undefined
+): string {
+  const identity =
+    cloudflareConnectingIp?.trim() || forwardedFor?.split(",", 1)[0]?.trim();
+  const digest = createHash("sha256")
+    .update(identity || "unknown")
+    .digest("hex");
+  return `inspector-relay:preauth:${digest}`;
 }
 
 /** Return the standard Inspector response for an exhausted route budget. */

--- a/libraries/typescript/packages/inspector/src/server/rate-limit.ts
+++ b/libraries/typescript/packages/inspector/src/server/rate-limit.ts
@@ -2,7 +2,31 @@ import type { Context } from "hono";
 
 export const INSPECTOR_ASSET_RATE_LIMIT = 600;
 export const INSPECTOR_API_RATE_LIMIT = 120;
+/** Backstop across every proxied target in one Inspector process. */
+export const INSPECTOR_GLOBAL_API_RATE_LIMIT = 1_200;
 export const INSPECTOR_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+/**
+ * Build a bounded, non-sensitive limiter key for one logical upstream server.
+ * Query strings, fragments, credentials, and malformed values never become
+ * keys or let callers evade a server's budget by varying irrelevant values.
+ */
+export function inspectorServerRateLimitKey(
+  namespace: "mcp" | "oauth",
+  value: string | undefined
+): string {
+  if (!value) return `${namespace}:unknown`;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      return `${namespace}:unknown`;
+    }
+    const pathname = url.pathname.replace(/\/+$/, "") || "/";
+    return `${namespace}:${url.origin}${pathname}`;
+  } catch {
+    return `${namespace}:unknown`;
+  }
+}
 
 /** Return the standard Inspector response for an exhausted route budget. */
 export function inspectorRateLimitResponse(c: Context, error: unknown) {

--- a/libraries/typescript/packages/inspector/src/server/relay-auth.ts
+++ b/libraries/typescript/packages/inspector/src/server/relay-auth.ts
@@ -1,0 +1,51 @@
+import type { Context } from "hono";
+
+/** Browser-facing capability header for the product relay. */
+export const INSPECTOR_RELAY_CAPABILITY_HEADER = "X-Inspector-Relay-Token";
+
+/** Non-secret target context supplied to the embedding application's verifier. */
+export type InspectorRelayTarget = {
+  /** URL origin of the requested upstream target. */
+  origin: string;
+  /** URL pathname of the requested upstream target; query and fragment are omitted. */
+  pathname: string;
+  /** Effective HTTP method that the relay will forward upstream. */
+  method: string;
+};
+
+/**
+ * Product authentication hook for relay capabilities.
+ *
+ * Existing one-argument `(c) => boolean` callbacks remain valid. Hosted
+ * deployments should use the second argument to bind a short-lived
+ * capability to the target origin/path and effective method.
+ */
+export type InspectorRelayAuthenticator = (
+  c: Context,
+  target: InspectorRelayTarget | undefined
+) => Promise<boolean> | boolean;
+
+/** Parse only the target identity needed by authentication, without network I/O. */
+export function inspectorRelayTarget(
+  value: unknown,
+  method: string
+): InspectorRelayTarget | undefined {
+  if (typeof value !== "string" || value.length === 0) return undefined;
+  try {
+    const url = new URL(value);
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username ||
+      url.password
+    ) {
+      return undefined;
+    }
+    return {
+      origin: url.origin,
+      pathname: url.pathname || "/",
+      method: method.toUpperCase(),
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/libraries/typescript/packages/inspector/tests/unit/cli-config.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/cli-config.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { createConfidentialClientResolver } from "../../src/server/cli-config";
+
+const serverUrl = "https://mcp.example.com/mcp";
+const issuer = "https://login.example.com";
+
+describe("Inspector CLI confidential-client configuration", () => {
+  it("rejects malformed authorizationServers instead of widening scope", () => {
+    const base = {
+      serverUrls: [serverUrl],
+      clientId: "client",
+      clientSecret: "secret",
+      authMethod: "client_secret_post",
+    };
+
+    expect(() =>
+      createConfidentialClientResolver(
+        JSON.stringify([{ ...base, authorizationServers: [issuer, 42] }])
+      )
+    ).toThrow("Invalid Inspector confidential client entry");
+    expect(() =>
+      createConfidentialClientResolver(
+        JSON.stringify([{ ...base, authorizationServers: issuer }])
+      )
+    ).toThrow("Invalid Inspector confidential client entry");
+  });
+
+  it("treats omitted authorizationServers as unrestricted for compatibility", () => {
+    const resolver = createConfidentialClientResolver(
+      JSON.stringify([
+        {
+          serverUrls: [serverUrl],
+          clientId: "client",
+          clientSecret: "secret",
+          authMethod: "client_secret_post",
+        },
+      ])
+    );
+    expect(
+      resolver?.({
+        serverUrl,
+        targetUrl: "https://login.other.example/token",
+        clientId: "client",
+        authorizationServer: "https://login.other.example",
+      })
+    ).toMatchObject({ clientSecret: "secret" });
+  });
+});

--- a/libraries/typescript/packages/inspector/tests/unit/create-dev-api-app.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/create-dev-api-app.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { createDevApiApp } from "../../src/server/create-dev-api-app.js";
+
+describe("Inspector dev API CORS", () => {
+  it("allows relay capabilities and DPoP in the shared dev preflight", async () => {
+    const app = createDevApiApp();
+    const response = await app.fetch(
+      new Request("http://localhost/inspector/api/proxy", {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://inspector.example.com",
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers":
+            "authorization, dpop, x-inspector-relay-token, x-target-url",
+        },
+      })
+    );
+
+    expect(response.status).toBe(204);
+    const allowHeaders = response.headers.get("access-control-allow-headers");
+    for (const header of [
+      "Authorization",
+      "Content-Type",
+      "Accept",
+      "X-Target-URL",
+      "X-MCP-Target",
+      "Mcp-Session-Id",
+      "mcp-session-id",
+      "mcp-protocol-version",
+      "Mcp-Protocol-Version",
+      "Mcp-Method",
+      "Mcp-Name",
+      "DPoP",
+      "X-Inspector-Relay-Token",
+      "Last-Event-ID",
+      "X-Server-Id",
+      "X-Requested-With",
+    ]) {
+      expect(allowHeaders).toContain(header);
+    }
+  });
+});

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -25,24 +25,24 @@ describe("Inspector MCP proxy request isolation", () => {
           "Access-Control-Request-Method": "POST",
           "Access-Control-Request-Headers": "mcp-method, x-target-url",
         },
-      }),
+      })
     );
     expect(allowed.status).toBe(204);
     expect(allowed.headers.get("access-control-allow-origin")).toBe(
-      "https://mochipi.dev",
+      "https://mochipi.dev"
     );
     expect(allowed.headers.get("access-control-allow-headers")).toContain(
-      "Mcp-Method",
+      "Mcp-Method"
     );
 
     const denied = await app.fetch(
       new Request(proxyUrl, {
         method: "OPTIONS",
         headers: { Origin: "https://attacker.example" },
-      }),
+      })
     );
     expect(denied.headers.get("access-control-allow-origin")).not.toBe(
-      "https://attacker.example",
+      "https://attacker.example"
     );
   });
 

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -9,6 +9,43 @@ afterEach(() => {
 });
 
 describe("Inspector MCP proxy request isolation", () => {
+  it("allows only configured browser origins and MCP protocol headers", async () => {
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+      allowedOrigins: ["https://manufact.com", "https://mochipi.dev"],
+    });
+
+    const allowed = await app.fetch(
+      new Request(proxyUrl, {
+        method: "OPTIONS",
+        headers: {
+          Origin: "https://mochipi.dev",
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": "mcp-method, x-target-url",
+        },
+      }),
+    );
+    expect(allowed.status).toBe(204);
+    expect(allowed.headers.get("access-control-allow-origin")).toBe(
+      "https://mochipi.dev",
+    );
+    expect(allowed.headers.get("access-control-allow-headers")).toContain(
+      "Mcp-Method",
+    );
+
+    const denied = await app.fetch(
+      new Request(proxyUrl, {
+        method: "OPTIONS",
+        headers: { Origin: "https://attacker.example" },
+      }),
+    );
+    expect(denied.headers.get("access-control-allow-origin")).not.toBe(
+      "https://attacker.example",
+    );
+  });
+
   it("prefixes proxy logs only when sharing the dev server process", async () => {
     vi.stubGlobal(
       "fetch",
@@ -28,9 +65,7 @@ describe("Inspector MCP proxy request isolation", () => {
     await embedded.fetch(request());
     expect(logSpy.mock.calls).not.toHaveLength(0);
     expect(
-      logSpy.mock.calls.every(([line]) =>
-        String(line).startsWith("[inspector]")
-      )
+      logSpy.mock.calls.every(([line]) => String(line).startsWith("[inspector]"))
     ).toBe(true);
 
     logSpy.mockClear();
@@ -39,9 +74,7 @@ describe("Inspector MCP proxy request isolation", () => {
     await standalone.fetch(request());
     expect(logSpy.mock.calls).not.toHaveLength(0);
     expect(
-      logSpy.mock.calls.every(
-        ([line]) => !String(line).startsWith("[inspector]")
-      )
+      logSpy.mock.calls.every(([line]) => !String(line).startsWith("[inspector]"))
     ).toBe(true);
     logSpy.mockRestore();
   });

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import RateLimiterMemory from "rate-limiter-flexible/lib/RateLimiterMemory.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mountMcpProxy } from "../../src/server/proxy/mcp-proxy";
 
@@ -9,6 +10,39 @@ afterEach(() => {
 });
 
 describe("Inspector MCP proxy request isolation", () => {
+  it("distinguishes omitted origins (legacy wildcard) from an explicit empty list", async () => {
+    const legacy = new Hono();
+    mountMcpProxy(legacy, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+    });
+    const legacyPreflight = await legacy.fetch(
+      new Request(proxyUrl, {
+        method: "OPTIONS",
+        headers: { Origin: "https://legacy.example" },
+      })
+    );
+    expect(legacyPreflight.headers.get("access-control-allow-origin")).toBe(
+      "*"
+    );
+
+    const explicit = new Hono();
+    mountMcpProxy(explicit, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+      allowedOrigins: [],
+    });
+    const explicitPreflight = await explicit.fetch(
+      new Request(proxyUrl, {
+        method: "OPTIONS",
+        headers: { Origin: "https://legacy.example" },
+      })
+    );
+    expect(
+      explicitPreflight.headers.get("access-control-allow-origin")
+    ).toBeNull();
+  });
+
   it("allows only configured browser origins and MCP protocol headers", async () => {
     const app = new Hono();
     mountMcpProxy(app, {
@@ -65,7 +99,9 @@ describe("Inspector MCP proxy request isolation", () => {
     await embedded.fetch(request());
     expect(logSpy.mock.calls).not.toHaveLength(0);
     expect(
-      logSpy.mock.calls.every(([line]) => String(line).startsWith("[inspector]"))
+      logSpy.mock.calls.every(([line]) =>
+        String(line).startsWith("[inspector]")
+      )
     ).toBe(true);
 
     logSpy.mockClear();
@@ -74,7 +110,9 @@ describe("Inspector MCP proxy request isolation", () => {
     await standalone.fetch(request());
     expect(logSpy.mock.calls).not.toHaveLength(0);
     expect(
-      logSpy.mock.calls.every(([line]) => !String(line).startsWith("[inspector]"))
+      logSpy.mock.calls.every(
+        ([line]) => !String(line).startsWith("[inspector]")
+      )
     ).toBe(true);
     logSpy.mockRestore();
   });
@@ -117,6 +155,41 @@ describe("Inspector MCP proxy request isolation", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("set-cookie")).toBeNull();
     expect(fetchFn).toHaveBeenCalledOnce();
+  });
+
+  it("authenticates before consuming the target budget", async () => {
+    const fetchFn = vi.fn<typeof fetch>(async (_input, init) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer upstream-token");
+      return new Response("ok");
+    });
+    vi.stubGlobal("fetch", fetchFn);
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+      rateLimiter: new RateLimiterMemory({ points: 1, duration: 60 }),
+      authenticate: (c) =>
+        c.req.header("X-Inspector-Relay-Token") === "relay-token",
+    });
+
+    const denied = await app.fetch(
+      new Request(proxyUrl, {
+        headers: { "X-Target-URL": "https://93.184.216.34/mcp" },
+      })
+    );
+    expect(denied.status).toBe(401);
+
+    const allowed = await app.fetch(
+      new Request(proxyUrl, {
+        headers: {
+          "X-Target-URL": "https://93.184.216.34/mcp",
+          Authorization: "Bearer upstream-token",
+          "X-Inspector-Relay-Token": "relay-token",
+        },
+      })
+    );
+    expect(allowed.status).toBe(200);
   });
 
   it("removes bearer authorization across a cross-origin redirect", async () => {

--- a/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/mcp-proxy-security.test.ts
@@ -57,7 +57,8 @@ describe("Inspector MCP proxy request isolation", () => {
         headers: {
           Origin: "https://mochipi.dev",
           "Access-Control-Request-Method": "POST",
-          "Access-Control-Request-Headers": "mcp-method, x-target-url",
+          "Access-Control-Request-Headers":
+            "mcp-method, x-target-url, x-inspector-relay-token",
         },
       })
     );
@@ -68,6 +69,9 @@ describe("Inspector MCP proxy request isolation", () => {
     expect(allowed.headers.get("access-control-allow-headers")).toContain(
       "Mcp-Method"
     );
+    expect(allowed.headers.get("access-control-allow-headers")).toContain(
+      "X-Inspector-Relay-Token"
+    );
 
     const denied = await app.fetch(
       new Request(proxyUrl, {
@@ -75,9 +79,7 @@ describe("Inspector MCP proxy request isolation", () => {
         headers: { Origin: "https://attacker.example" },
       })
     );
-    expect(denied.headers.get("access-control-allow-origin")).not.toBe(
-      "https://attacker.example"
-    );
+    expect(denied.headers.get("access-control-allow-origin")).toBeNull();
   });
 
   it("prefixes proxy logs only when sharing the dev server process", async () => {
@@ -158,9 +160,11 @@ describe("Inspector MCP proxy request isolation", () => {
   });
 
   it("authenticates before consuming the target budget", async () => {
+    const authTargets: unknown[] = [];
     const fetchFn = vi.fn<typeof fetch>(async (_input, init) => {
       const headers = new Headers(init?.headers);
       expect(headers.get("authorization")).toBe("Bearer upstream-token");
+      expect(headers.get("x-inspector-relay-token")).toBeNull();
       return new Response("ok");
     });
     vi.stubGlobal("fetch", fetchFn);
@@ -169,8 +173,10 @@ describe("Inspector MCP proxy request isolation", () => {
       path: "/inspector/api/proxy",
       enableLogging: false,
       rateLimiter: new RateLimiterMemory({ points: 1, duration: 60 }),
-      authenticate: (c) =>
-        c.req.header("X-Inspector-Relay-Token") === "relay-token",
+      authenticate: (c, target) => {
+        authTargets.push(target);
+        return c.req.header("X-Inspector-Relay-Token") === "relay-token";
+      },
     });
 
     const denied = await app.fetch(
@@ -190,6 +196,42 @@ describe("Inspector MCP proxy request isolation", () => {
       })
     );
     expect(allowed.status).toBe(200);
+    expect(authTargets).toEqual([
+      { origin: "https://93.184.216.34", pathname: "/mcp", method: "GET" },
+      { origin: "https://93.184.216.34", pathname: "/mcp", method: "GET" },
+    ]);
+  });
+
+  it("isolates the pre-auth client budget from the authenticated target budget", async () => {
+    const fetchFn = vi.fn<typeof fetch>(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchFn);
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+      rateLimiter: new RateLimiterMemory({ points: 1, duration: 60 }),
+      preAuthRateLimiter: new RateLimiterMemory({ points: 1, duration: 60 }),
+      globalPreAuthRateLimiter: new RateLimiterMemory({
+        points: 10,
+        duration: 60,
+      }),
+      authenticate: (c) =>
+        c.req.header("X-Inspector-Relay-Token") === "relay-token",
+    });
+
+    const request = (ip: string, token?: string) =>
+      new Request(proxyUrl, {
+        headers: {
+          "X-Target-URL": "https://93.184.216.34/mcp",
+          "CF-Connecting-IP": ip,
+          ...(token ? { "X-Inspector-Relay-Token": token } : {}),
+        },
+      });
+    expect((await app.fetch(request("198.51.100.10"))).status).toBe(401);
+    expect(
+      (await app.fetch(request("198.51.100.11", "relay-token"))).status
+    ).toBe(200);
+    expect(fetchFn).toHaveBeenCalledOnce();
   });
 
   it("removes bearer authorization across a cross-origin redirect", async () => {
@@ -229,6 +271,53 @@ describe("Inspector MCP proxy request isolation", () => {
 
     expect(response.status).toBe(200);
     expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("reauthenticates redirect destinations with their effective method", async () => {
+    const authTargets: unknown[] = [];
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockImplementationOnce(
+        async () =>
+          new Response(null, {
+            status: 302,
+            headers: { Location: "https://93.184.216.35/unauthorized" },
+          })
+      )
+      .mockImplementationOnce(async () => new Response("must not fetch"));
+    vi.stubGlobal("fetch", fetchFn);
+    const app = new Hono();
+    mountMcpProxy(app, {
+      path: "/inspector/api/proxy",
+      enableLogging: false,
+      authenticate: (_c, target) => {
+        authTargets.push(target);
+        return target?.pathname !== "/unauthorized";
+      },
+    });
+
+    const response = await app.fetch(
+      new Request(proxyUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Target-URL": "https://93.184.216.34/mcp",
+          "X-Inspector-Relay-Token": "relay-token",
+        },
+        body: "{}",
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(authTargets).toEqual([
+      { origin: "https://93.184.216.34", pathname: "/mcp", method: "POST" },
+      {
+        origin: "https://93.184.216.35",
+        pathname: "/unauthorized",
+        method: "GET",
+      },
+    ]);
   });
 
   it("forwards an empty 204 response without constructing an invalid body", async () => {

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
@@ -6,12 +6,16 @@ import type { OAuthProxyStateStore } from "../../src/server/proxy/oauth-state-st
 const inspectorOrigin = "https://inspector.example.com";
 const serverUrl = "https://93.184.216.34/mcp";
 const issuer = "https://93.184.216.35";
+const issuer2 = "https://93.184.216.36";
 const resourceMetadataUrl =
   "https://93.184.216.34/.well-known/oauth-protected-resource/mcp";
 const authorizationMetadataUrl =
   "https://93.184.216.35/.well-known/oauth-authorization-server";
+const authorizationMetadataUrl2 =
+  "https://93.184.216.36/.well-known/oauth-authorization-server";
 const registrationUrl = "https://93.184.216.35/oauth/register";
 const tokenUrl = "https://93.184.216.35/oauth/token";
+const tokenUrl2 = "https://93.184.216.36/oauth/token";
 
 function jsonResponse(value: unknown, status = 200): Response {
   return new Response(JSON.stringify(value), {
@@ -20,19 +24,24 @@ function jsonResponse(value: unknown, status = 200): Response {
   });
 }
 
-function metadataRequest(url: string): Request {
+function metadataRequest(url: string, headers: HeadersInit = {}): Request {
   return new Request(
     `${inspectorOrigin}/oauth/metadata?serverUrl=${encodeURIComponent(serverUrl)}&url=${encodeURIComponent(url)}`,
-    { headers: { Origin: inspectorOrigin } }
+    { headers: { Origin: inspectorOrigin, ...headers } }
   );
 }
 
-function proxyRequest(url: string, body: unknown): Request {
+function proxyRequest(
+  url: string,
+  body: unknown,
+  options: { headers?: HeadersInit; requestHeaders?: HeadersInit } = {}
+): Request {
   return new Request(`${inspectorOrigin}/oauth/proxy`, {
     method: "POST",
     headers: {
       Origin: inspectorOrigin,
       "Content-Type": "application/json",
+      ...options.headers,
     },
     body: JSON.stringify({
       serverUrl,
@@ -43,6 +52,7 @@ function proxyRequest(url: string, body: unknown): Request {
           url === registrationUrl
             ? "application/json"
             : "application/x-www-form-urlencoded",
+        ...options.requestHeaders,
       },
       body,
     }),
@@ -65,6 +75,7 @@ function sharedStateStore(): OAuthProxyStateStore {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
@@ -80,6 +91,7 @@ describe("Inspector OAuth BFF confidential clients", () => {
           Origin: inspectorOrigin,
           "X-Forwarded-Host": "inspector.example.com",
           "X-Forwarded-Proto": "https",
+          "Access-Control-Request-Headers": "x-inspector-relay-token",
         },
       })
     );
@@ -91,11 +103,17 @@ describe("Inspector OAuth BFF confidential clients", () => {
     expect(response.headers.get("access-control-allow-headers")).toContain(
       "DPoP"
     );
+    expect(response.headers.get("access-control-allow-headers")).toContain(
+      "X-Inspector-Relay-Token"
+    );
   });
 
   it("keeps DCR secrets off the browser and restores client_secret_post", async () => {
+    const authTargets: unknown[] = [];
     const fetchFn = vi.fn<typeof fetch>(async (input, init) => {
       const url = input.toString();
+      const upstreamHeaders = new Headers(init?.headers);
+      expect(upstreamHeaders.get("x-inspector-relay-token")).toBeNull();
       if (url === resourceMetadataUrl) {
         return jsonResponse({
           resource: serverUrl,
@@ -111,6 +129,9 @@ describe("Inspector OAuth BFF confidential clients", () => {
         });
       }
       if (url === registrationUrl) {
+        expect(upstreamHeaders.get("authorization")).toBe(
+          "Bearer upstream-token"
+        );
         expect(JSON.parse(String(init?.body))).toMatchObject({
           redirect_uris: [`${inspectorOrigin}/oauth/callback`],
         });
@@ -134,21 +155,41 @@ describe("Inspector OAuth BFF confidential clients", () => {
     vi.stubGlobal("fetch", fetchFn);
 
     const app = new Hono();
-    mountOAuthProxy(app, { basePath: "/oauth", enableLogging: false });
+    mountOAuthProxy(app, {
+      basePath: "/oauth",
+      enableLogging: false,
+      authenticate: (c, target) => {
+        authTargets.push(target);
+        return c.req.header("X-Inspector-Relay-Token") === "relay-token";
+      },
+    });
 
-    expect((await app.fetch(metadataRequest(resourceMetadataUrl))).status).toBe(
-      200
-    );
+    const relayHeaders = { "X-Inspector-Relay-Token": "relay-token" };
     expect(
-      (await app.fetch(metadataRequest(authorizationMetadataUrl))).status
+      (await app.fetch(metadataRequest(resourceMetadataUrl, relayHeaders)))
+        .status
+    ).toBe(200);
+    expect(
+      (await app.fetch(metadataRequest(authorizationMetadataUrl, relayHeaders)))
+        .status
     ).toBe(200);
 
     const registration = await app.fetch(
-      proxyRequest(registrationUrl, {
-        client_name: "Inspector",
-        redirect_uris: [`${inspectorOrigin}/mcp/inspector/oauth/callback`],
-        token_endpoint_auth_method: "none",
-      })
+      proxyRequest(
+        registrationUrl,
+        {
+          client_name: "Inspector",
+          redirect_uris: [`${inspectorOrigin}/mcp/inspector/oauth/callback`],
+          token_endpoint_auth_method: "none",
+        },
+        {
+          headers: relayHeaders,
+          requestHeaders: {
+            Authorization: "Bearer upstream-token",
+            "X-Inspector-Relay-Token": "nested-capability-must-not-forward",
+          },
+        }
+      )
     );
     const registrationEnvelope = await registration.json();
     expect(registrationEnvelope).toMatchObject({
@@ -163,16 +204,42 @@ describe("Inspector OAuth BFF confidential clients", () => {
     );
 
     const token = await app.fetch(
-      proxyRequest(tokenUrl, {
-        grant_type: "authorization_code",
-        code: "redacted",
-        client_id: "confidential-client",
-      })
+      proxyRequest(
+        tokenUrl,
+        {
+          grant_type: "authorization_code",
+          code: "redacted",
+          client_id: "confidential-client",
+        },
+        { headers: relayHeaders }
+      )
     );
     expect(await token.json()).toMatchObject({
       status: 200,
       body: { access_token: "redacted", token_type: "Bearer" },
     });
+    expect(authTargets).toEqual([
+      {
+        origin: "https://93.184.216.34",
+        pathname: "/.well-known/oauth-protected-resource/mcp",
+        method: "GET",
+      },
+      {
+        origin: "https://93.184.216.35",
+        pathname: "/.well-known/oauth-authorization-server",
+        method: "GET",
+      },
+      {
+        origin: "https://93.184.216.35",
+        pathname: "/oauth/register",
+        method: "POST",
+      },
+      {
+        origin: "https://93.184.216.35",
+        pathname: "/oauth/token",
+        method: "POST",
+      },
+    ]);
   });
 
   it("does not echo a secret from a malformed successful DCR response", async () => {
@@ -211,6 +278,46 @@ describe("Inspector OAuth BFF confidential clients", () => {
 
     const response = await app.fetch(
       proxyRequest(registrationUrl, { client_name: "malformed" })
+    );
+    const responseBody = await response.text();
+    expect(response.status).toBe(502);
+    expect(responseBody).not.toContain(leakedSecret);
+  });
+
+  it("does not return array DCR error bodies containing a secret", async () => {
+    const leakedSecret = "array-response-secret";
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const url = input.toString();
+      if (url === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: serverUrl,
+          authorization_servers: [issuer],
+        });
+      }
+      if (url === authorizationMetadataUrl) {
+        return jsonResponse({
+          issuer,
+          registration_endpoint: registrationUrl,
+        });
+      }
+      if (url === registrationUrl) {
+        return jsonResponse([{ client_secret: leakedSecret }], 400);
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchFn);
+
+    const app = new Hono();
+    mountOAuthProxy(app, { basePath: "/oauth", enableLogging: false });
+    expect((await app.fetch(metadataRequest(resourceMetadataUrl))).status).toBe(
+      200
+    );
+    expect(
+      (await app.fetch(metadataRequest(authorizationMetadataUrl))).status
+    ).toBe(200);
+
+    const response = await app.fetch(
+      proxyRequest(registrationUrl, { client_name: "array-error" })
     );
     const responseBody = await response.text();
     expect(response.status).toBe(502);
@@ -320,5 +427,166 @@ describe("Inspector OAuth BFF confidential clients", () => {
     expect(responseBody).not.toContain(secret);
     expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
     errorSpy.mockRestore();
+  });
+
+  it("does not delete a refreshed binding after stale cleanup loses its CAS", async () => {
+    const now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const staleBinding = {
+      authorizationServers: [issuer],
+      endpoints: [[tokenUrl, { kind: "token", authorizationServer: issuer }]],
+      tokenEndpointAuthMethods: [],
+      revision: 1,
+      updatedAt: now - 10 * 60 * 1000 - 1,
+    };
+    let durableBinding: unknown = staleBinding;
+    const freshBinding = {
+      ...staleBinding,
+      revision: 2,
+      updatedAt: now,
+    };
+    const deleteIfVersion = vi.fn(async () => {
+      durableBinding = structuredClone(freshBinding);
+      return false;
+    });
+    const deleteBinding = vi.fn(async () => {
+      durableBinding = undefined;
+    });
+    const stateStore: OAuthProxyStateStore = {
+      async get<T>() {
+        return structuredClone(durableBinding) as T | undefined;
+      },
+      async set() {},
+      async setIfNewer(_key, value) {
+        durableBinding = structuredClone(value);
+        return true;
+      },
+      async delete() {
+        await deleteBinding();
+      },
+      deleteIfVersion,
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async (input) => {
+        if (input.toString() === authorizationMetadataUrl) {
+          return jsonResponse({ issuer, token_endpoint: tokenUrl });
+        }
+        return new Response("not found", { status: 404 });
+      })
+    );
+
+    const app = new Hono();
+    mountOAuthProxy(app, {
+      basePath: "/oauth",
+      enableLogging: false,
+      stateStore,
+    });
+
+    const response = await app.fetch(metadataRequest(authorizationMetadataUrl));
+    expect(response.status).toBe(200);
+    expect(deleteIfVersion).toHaveBeenCalledOnce();
+    expect(deleteBinding).not.toHaveBeenCalled();
+    expect(durableBinding).toMatchObject({ revision: now, updatedAt: now });
+  });
+
+  it("adopts durable state after a rejected binding write before the next save", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const url = input.toString();
+      if (url === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: serverUrl,
+          authorization_servers: [issuer],
+        });
+      }
+      if (url === authorizationMetadataUrl) {
+        return jsonResponse({
+          issuer,
+          token_endpoint: tokenUrl,
+        });
+      }
+      if (url === authorizationMetadataUrl2) {
+        return jsonResponse({
+          issuer: issuer2,
+          token_endpoint: tokenUrl2,
+        });
+      }
+      if (url === tokenUrl2) return jsonResponse({ access_token: "second" });
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchFn);
+
+    let bindingReads = 0;
+    let durableBinding: unknown = {
+      authorizationServers: [issuer2],
+      endpoints: [[tokenUrl2, { kind: "token", authorizationServer: issuer2 }]],
+      tokenEndpointAuthMethods: [],
+      revision: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    };
+    const casResults: boolean[] = [];
+    let bindingSetCalls = 0;
+    const setIfNewer = vi.fn(
+      async (key: string, value: unknown): Promise<boolean> => {
+        if (!key.startsWith("binding:")) {
+          casResults.push(true);
+          return true;
+        }
+        bindingSetCalls += 1;
+        if (bindingSetCalls === 1) {
+          casResults.push(false);
+          return false;
+        }
+        durableBinding = structuredClone(value);
+        casResults.push(true);
+        return true;
+      }
+    );
+    const stateStore: OAuthProxyStateStore = {
+      async get<T>(key: string) {
+        if (!key.startsWith("binding:")) return undefined;
+        bindingReads += 1;
+        if (bindingReads <= 2) return undefined;
+        return structuredClone(durableBinding) as T;
+      },
+      async set<T>(key: string, value: T) {
+        if (key.startsWith("binding:")) durableBinding = structuredClone(value);
+      },
+      setIfNewer,
+      async delete() {},
+    };
+    const firstReplica = new Hono();
+    const secondReplica = new Hono();
+    mountOAuthProxy(firstReplica, {
+      basePath: "/oauth",
+      enableLogging: false,
+      stateStore,
+    });
+    mountOAuthProxy(secondReplica, {
+      basePath: "/oauth",
+      enableLogging: false,
+      stateStore,
+    });
+
+    expect(
+      (await firstReplica.fetch(metadataRequest(authorizationMetadataUrl2)))
+        .status
+    ).toBe(200);
+    expect(setIfNewer).toHaveBeenCalledTimes(2);
+    expect(casResults).toEqual([false, true]);
+    expect(durableBinding).toMatchObject({
+      revision: 1_700_000_000_001,
+      updatedAt: 1_700_000_000_000,
+    });
+
+    const token = await secondReplica.fetch(
+      proxyRequest(tokenUrl2, { grant_type: "authorization_code" })
+    );
+    expect(token.status).toBe(200);
+    expect(await token.json()).toMatchObject({
+      status: 200,
+      body: { access_token: "second" },
+    });
   });
 });

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mountOAuthProxy } from "../../src/server/proxy/oauth-proxy";
+import type { OAuthProxyStateStore } from "../../src/server/proxy/oauth-state-store";
 
 const inspectorOrigin = "https://inspector.example.com";
 const serverUrl = "https://93.184.216.34/mcp";
@@ -46,6 +47,21 @@ function proxyRequest(url: string, body: unknown): Request {
       body,
     }),
   });
+}
+
+function sharedStateStore(): OAuthProxyStateStore {
+  const values = new Map<string, unknown>();
+  return {
+    async get<T>(key: string) {
+      return values.get(key) as T | undefined;
+    },
+    async set<T>(key: string, value: T) {
+      values.set(key, structuredClone(value));
+    },
+    async delete(key: string) {
+      values.delete(key);
+    },
+  };
 }
 
 afterEach(() => {
@@ -153,6 +169,69 @@ describe("Inspector OAuth BFF confidential clients", () => {
     expect(await token.json()).toMatchObject({
       status: 200,
       body: { access_token: "redacted", token_type: "Bearer" },
+    });
+  });
+
+  it("shares bindings and DCR credentials across proxy replicas", async () => {
+    const fetchFn = vi.fn<typeof fetch>(async (input, init) => {
+      const url = input.toString();
+      if (url === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: serverUrl,
+          authorization_servers: [issuer],
+        });
+      }
+      if (url === authorizationMetadataUrl) {
+        return jsonResponse({
+          issuer,
+          registration_endpoint: registrationUrl,
+          token_endpoint: tokenUrl,
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+        });
+      }
+      if (url === registrationUrl) {
+        return jsonResponse({
+          client_id: "shared-client",
+          client_secret: "shared-secret",
+          client_secret_expires_at: 0,
+          token_endpoint_auth_method: "client_secret_post",
+        });
+      }
+      if (url === tokenUrl) {
+        const params = new URLSearchParams(String(init?.body));
+        expect(params.get("client_secret")).toBe("shared-secret");
+        return jsonResponse({ access_token: "shared-token" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchFn);
+
+    const stateStore = sharedStateStore();
+    const firstReplica = new Hono();
+    const secondReplica = new Hono();
+    mountOAuthProxy(firstReplica, { basePath: "/oauth", enableLogging: false, stateStore });
+    mountOAuthProxy(secondReplica, { basePath: "/oauth", enableLogging: false, stateStore });
+
+    expect((await firstReplica.fetch(metadataRequest(resourceMetadataUrl))).status).toBe(200);
+    expect((await firstReplica.fetch(metadataRequest(authorizationMetadataUrl))).status).toBe(200);
+
+    const registration = await firstReplica.fetch(
+      proxyRequest(registrationUrl, { client_name: "shared" }),
+    );
+    expect((await registration.json()).body).toMatchObject({
+      client_id: "shared-client",
+      token_endpoint_auth_method: "none",
+    });
+
+    const token = await secondReplica.fetch(
+      proxyRequest(tokenUrl, {
+        grant_type: "authorization_code",
+        client_id: "shared-client",
+      }),
+    );
+    expect(await token.json()).toMatchObject({
+      status: 200,
+      body: { access_token: "shared-token" },
     });
   });
 });

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
@@ -209,14 +209,27 @@ describe("Inspector OAuth BFF confidential clients", () => {
     const stateStore = sharedStateStore();
     const firstReplica = new Hono();
     const secondReplica = new Hono();
-    mountOAuthProxy(firstReplica, { basePath: "/oauth", enableLogging: false, stateStore });
-    mountOAuthProxy(secondReplica, { basePath: "/oauth", enableLogging: false, stateStore });
+    mountOAuthProxy(firstReplica, {
+      basePath: "/oauth",
+      enableLogging: false,
+      stateStore,
+    });
+    mountOAuthProxy(secondReplica, {
+      basePath: "/oauth",
+      enableLogging: false,
+      stateStore,
+    });
 
-    expect((await firstReplica.fetch(metadataRequest(resourceMetadataUrl))).status).toBe(200);
-    expect((await firstReplica.fetch(metadataRequest(authorizationMetadataUrl))).status).toBe(200);
+    expect(
+      (await firstReplica.fetch(metadataRequest(resourceMetadataUrl))).status
+    ).toBe(200);
+    expect(
+      (await firstReplica.fetch(metadataRequest(authorizationMetadataUrl)))
+        .status
+    ).toBe(200);
 
     const registration = await firstReplica.fetch(
-      proxyRequest(registrationUrl, { client_name: "shared" }),
+      proxyRequest(registrationUrl, { client_name: "shared" })
     );
     expect((await registration.json()).body).toMatchObject({
       client_id: "shared-client",
@@ -227,7 +240,7 @@ describe("Inspector OAuth BFF confidential clients", () => {
       proxyRequest(tokenUrl, {
         grant_type: "authorization_code",
         client_id: "shared-client",
-      }),
+      })
     );
     expect(await token.json()).toMatchObject({
       status: 200,

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-proxy-confidential.test.ts
@@ -88,6 +88,9 @@ describe("Inspector OAuth BFF confidential clients", () => {
     expect(response.headers.get("access-control-allow-origin")).toBe(
       inspectorOrigin
     );
+    expect(response.headers.get("access-control-allow-headers")).toContain(
+      "DPoP"
+    );
   });
 
   it("keeps DCR secrets off the browser and restores client_secret_post", async () => {
@@ -172,6 +175,48 @@ describe("Inspector OAuth BFF confidential clients", () => {
     });
   });
 
+  it("does not echo a secret from a malformed successful DCR response", async () => {
+    const leakedSecret = "malformed-response-secret";
+    const fetchFn = vi.fn<typeof fetch>(async (input) => {
+      const url = input.toString();
+      if (url === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: serverUrl,
+          authorization_servers: [issuer],
+        });
+      }
+      if (url === authorizationMetadataUrl) {
+        return jsonResponse({
+          issuer,
+          registration_endpoint: registrationUrl,
+        });
+      }
+      if (url === registrationUrl) {
+        return new Response(`{"client_secret":"${leakedSecret}"`, {
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchFn);
+
+    const app = new Hono();
+    mountOAuthProxy(app, { basePath: "/oauth", enableLogging: false });
+    expect((await app.fetch(metadataRequest(resourceMetadataUrl))).status).toBe(
+      200
+    );
+    expect(
+      (await app.fetch(metadataRequest(authorizationMetadataUrl))).status
+    ).toBe(200);
+
+    const response = await app.fetch(
+      proxyRequest(registrationUrl, { client_name: "malformed" })
+    );
+    const responseBody = await response.text();
+    expect(response.status).toBe(502);
+    expect(responseBody).not.toContain(leakedSecret);
+  });
+
   it("shares bindings and DCR credentials across proxy replicas", async () => {
     const fetchFn = vi.fn<typeof fetch>(async (input, init) => {
       const url = input.toString();
@@ -246,5 +291,34 @@ describe("Inspector OAuth BFF confidential clients", () => {
       status: 200,
       body: { access_token: "shared-token" },
     });
+  });
+
+  it("does not expose state-store error details in logs or responses", async () => {
+    const secret = "redis-password-must-not-leak";
+    const stateStore: OAuthProxyStateStore = {
+      async get() {
+        throw new Error(`connection failed: ${secret}`);
+      },
+      async set() {
+        throw new Error(secret);
+      },
+      async delete() {
+        throw new Error(secret);
+      },
+    };
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const app = new Hono();
+    mountOAuthProxy(app, {
+      basePath: "/oauth",
+      stateStore,
+      enableLogging: true,
+    });
+
+    const response = await app.fetch(metadataRequest(resourceMetadataUrl));
+    const responseBody = await response.text();
+    expect(response.status).toBe(503);
+    expect(responseBody).not.toContain(secret);
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(secret);
+    errorSpy.mockRestore();
   });
 });

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-state-store-redis.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-state-store-redis.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRedisOAuthProxyStateStore,
+  type OAuthProxyEncryptionKey,
+} from "../../src/server/proxy/oauth-state-store";
+
+const redisUrl = process.env.INSPECTOR_REDIS_TEST_URL;
+const describeRedis = describe.skipIf(!redisUrl);
+
+const oldKey = Uint8Array.from({ length: 32 }, (_, index) => index + 1);
+const newKey = Uint8Array.from({ length: 32 }, (_, index) => index + 33);
+const previousKey: OAuthProxyEncryptionKey = { id: "old", key: oldKey };
+
+describeRedis("Redis Inspector OAuth state store", () => {
+  it("round-trips encrypted state, rotates keys, arbitrates CAS, and closes", async () => {
+    const prefix = `mcp-use:test:${process.pid}:${Date.now()}:`;
+    const oldStore = createRedisOAuthProxyStateStore({
+      url: redisUrl!,
+      encryptionKey: oldKey,
+      encryptionKeyId: "old",
+      decryptionKeys: [{ id: "new", key: newKey }],
+      keyPrefix: prefix,
+    });
+    const rotatedStore = createRedisOAuthProxyStateStore({
+      url: redisUrl!,
+      encryptionKey: newKey,
+      encryptionKeyId: "new",
+      decryptionKeys: [previousKey],
+      keyPrefix: prefix,
+    });
+    const wrongKeyStore = createRedisOAuthProxyStateStore({
+      url: redisUrl!,
+      encryptionKey: newKey,
+      encryptionKeyId: "new-only",
+      keyPrefix: prefix,
+    });
+
+    try {
+      await oldStore.ready?.();
+      await rotatedStore.ready?.();
+      await wrongKeyStore.ready?.();
+
+      await oldStore.set("rotation", { revision: 1, updatedAt: 1 });
+      expect(await rotatedStore.get("rotation")).toEqual({
+        revision: 1,
+        updatedAt: 1,
+      });
+      await expect(wrongKeyStore.get("rotation")).rejects.toThrow(
+        "Unable to decrypt OAuth proxy state"
+      );
+
+      const results = await Promise.all([
+        oldStore.setIfNewer?.("cas", { revision: 1, updatedAt: 1 }),
+        rotatedStore.setIfNewer?.("cas", { revision: 2, updatedAt: 2 }),
+      ]);
+      expect(results).toContain(true);
+      expect(await rotatedStore.get("cas")).toEqual({
+        revision: 2,
+        updatedAt: 2,
+      });
+    } finally {
+      await oldStore.delete("rotation").catch(() => undefined);
+      await oldStore.delete("cas").catch(() => undefined);
+      await Promise.all([
+        oldStore.close?.(),
+        rotatedStore.close?.(),
+        wrongKeyStore.close?.(),
+      ]);
+    }
+  });
+});

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-state-store-redis.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-state-store-redis.test.ts
@@ -39,6 +39,7 @@ describeRedis("Redis Inspector OAuth state store", () => {
       await oldStore.ready?.();
       await rotatedStore.ready?.();
       await wrongKeyStore.ready?.();
+      await rotatedStore.probe?.();
 
       await oldStore.set("rotation", { revision: 1, updatedAt: 1 });
       expect(await rotatedStore.get("rotation")).toEqual({
@@ -58,9 +59,24 @@ describeRedis("Redis Inspector OAuth state store", () => {
         revision: 2,
         updatedAt: 2,
       });
+
+      await rotatedStore.set("delete-cas", { revision: 3, updatedAt: 3 });
+      expect(
+        await rotatedStore.deleteIfVersion?.("delete-cas", {
+          revision: 2,
+          updatedAt: 4,
+        })
+      ).toBe(false);
+      expect(
+        await rotatedStore.deleteIfVersion?.("delete-cas", {
+          revision: 3,
+          updatedAt: 3,
+        })
+      ).toBe(true);
     } finally {
       await oldStore.delete("rotation").catch(() => undefined);
       await oldStore.delete("cas").catch(() => undefined);
+      await oldStore.delete("delete-cas").catch(() => undefined);
       await Promise.all([
         oldStore.close?.(),
         rotatedStore.close?.(),

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-state-store.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-state-store.test.ts
@@ -1,0 +1,52 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it } from "vitest";
+import {
+  createMemoryOAuthProxyStateStore,
+  decodeOAuthProxyEncryptionKey,
+} from "../../src/server/proxy/oauth-state-store";
+
+describe("Inspector OAuth state stores", () => {
+  it("expires memory entries and keeps setIfNewer atomic in-process", async () => {
+    const store = createMemoryOAuthProxyStateStore();
+
+    await store.set("temporary", { value: "gone" }, 1);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(await store.get("temporary")).toBeUndefined();
+
+    await store.setIfNewer("versioned", { revision: 2, updatedAt: 20 });
+    expect(
+      await store.setIfNewer("versioned", { revision: 1, updatedAt: 30 })
+    ).toBe(false);
+    expect(await store.get("versioned")).toEqual({
+      revision: 2,
+      updatedAt: 20,
+    });
+
+    await Promise.all([
+      store.setIfNewer("concurrent", { revision: 1, updatedAt: 1 }),
+      store.setIfNewer("concurrent", { revision: 2, updatedAt: 2 }),
+    ]);
+    expect(await store.get("concurrent")).toEqual({
+      revision: 2,
+      updatedAt: 2,
+    });
+
+    await Promise.all([
+      store.setIfNewer("higher-first", { revision: 3, updatedAt: 3 }),
+      store.setIfNewer("higher-first", { revision: 2, updatedAt: 4 }),
+    ]);
+    expect(await store.get("higher-first")).toEqual({
+      revision: 3,
+      updatedAt: 3,
+    });
+    await store.close?.();
+  });
+
+  it("accepts exactly 32-byte base64 encryption keys", () => {
+    const encoded = Buffer.alloc(32, 7).toString("base64");
+    expect(decodeOAuthProxyEncryptionKey(encoded)).toHaveLength(32);
+    expect(() => decodeOAuthProxyEncryptionKey("AAAA")).toThrow(
+      "must decode to 32 bytes"
+    );
+  });
+});

--- a/libraries/typescript/packages/inspector/tests/unit/oauth-state-store.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/oauth-state-store.test.ts
@@ -39,6 +39,25 @@ describe("Inspector OAuth state stores", () => {
       revision: 3,
       updatedAt: 3,
     });
+
+    await store.set("deletion-race", { revision: 4, updatedAt: 4 });
+    expect(
+      await store.deleteIfVersion?.("deletion-race", {
+        revision: 3,
+        updatedAt: 5,
+      })
+    ).toBe(false);
+    expect(await store.get("deletion-race")).toEqual({
+      revision: 4,
+      updatedAt: 4,
+    });
+    expect(
+      await store.deleteIfVersion?.("deletion-race", {
+        revision: 4,
+        updatedAt: 4,
+      })
+    ).toBe(true);
+    expect(await store.get("deletion-race")).toBeUndefined();
     await store.close?.();
   });
 

--- a/libraries/typescript/packages/inspector/tests/unit/proxy-routes.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/proxy-routes.test.ts
@@ -1,0 +1,49 @@
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+import { registerInspectorProxyRoutes } from "../../src/server/proxy-routes.js";
+
+describe("Inspector health state-store probes", () => {
+  it("actively probes the state store instead of trusting ready state", async () => {
+    const probe = vi.fn(async () => undefined);
+    const ready = vi.fn(async () => {
+      throw new Error("ready must not be used when probe is available");
+    });
+    const app = new Hono();
+    registerInspectorProxyRoutes(app, {
+      mcp: false,
+      oauth: false,
+      oauthProxyStateStore: {
+        get: async () => undefined,
+        set: async () => undefined,
+        delete: async () => undefined,
+        probe,
+        ready,
+      },
+    });
+
+    const response = await app.request("/inspector/health");
+    expect(response.status).toBe(200);
+    expect(probe).toHaveBeenCalledOnce();
+    expect(ready).not.toHaveBeenCalled();
+  });
+
+  it("reports unavailable when an active state-store probe fails", async () => {
+    const app = new Hono();
+    registerInspectorProxyRoutes(app, {
+      mcp: false,
+      oauth: false,
+      oauthProxyStateStore: {
+        get: async () => undefined,
+        set: async () => undefined,
+        delete: async () => undefined,
+        probe: async () => {
+          throw new Error("probe failed");
+        },
+      },
+    });
+
+    const response = await app.request("/inspector/health");
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ status: "unavailable" });
+  });
+});

--- a/libraries/typescript/packages/inspector/tests/unit/rate-limit.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/rate-limit.test.ts
@@ -1,12 +1,18 @@
 import { Hono } from "hono";
 import RateLimiterMemory from "rate-limiter-flexible/lib/RateLimiterMemory.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mountMcpProxy } from "../../src/server/proxy/mcp-proxy.js";
 import {
   INSPECTOR_API_RATE_LIMIT,
   INSPECTOR_ASSET_RATE_LIMIT,
+  defaultInspectorGlobalRateLimiter,
   inspectorRateLimitResponse,
   inspectorServerRateLimitKey,
 } from "../../src/server/rate-limit.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("Inspector route rate limits", () => {
   it("uses separate budgets for assets and proxy/OAuth traffic", async () => {
@@ -74,6 +80,46 @@ describe("Inspector route rate limits", () => {
       )
     ).toBe("oauth:https://example.com/mcp");
     expect(inspectorServerRateLimitKey("mcp", "not a URL")).toBe("mcp:unknown");
+  });
+
+  it("bounds long target paths while keeping distinct buckets", () => {
+    const first = inspectorServerRateLimitKey(
+      "mcp",
+      `https://example.com/${"a".repeat(2_000)}`
+    );
+    const second = inspectorServerRateLimitKey(
+      "mcp",
+      `https://example.com/${"b".repeat(2_000)}`
+    );
+    expect(first.length).toBeLessThan(256);
+    expect(first).not.toBe(second);
+  });
+
+  it("shares the default process-global limiter across mounted instances", async () => {
+    const previousPoints = defaultInspectorGlobalRateLimiter.points;
+    defaultInspectorGlobalRateLimiter.points = 1;
+    await defaultInspectorGlobalRateLimiter.delete("inspector-api:global");
+    try {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn<typeof fetch>(async () => new Response("ok"))
+      );
+      const first = new Hono();
+      const second = new Hono();
+      mountMcpProxy(first, { path: "/proxy", enableLogging: false });
+      mountMcpProxy(second, { path: "/proxy", enableLogging: false });
+      const request = () =>
+        new Request("http://localhost/proxy", {
+          headers: { "X-Target-URL": "https://93.184.216.34/mcp" },
+        });
+      const responseFromFirst = await first.fetch(request());
+      const responseFromSecond = await second.fetch(request());
+      expect(responseFromFirst.status).toBe(200);
+      expect(responseFromSecond.status).toBe(429);
+    } finally {
+      defaultInspectorGlobalRateLimiter.points = previousPoints;
+      await defaultInspectorGlobalRateLimiter.delete("inspector-api:global");
+    }
   });
 
   it("uses the fallback Retry-After for non-finite limiter values", async () => {

--- a/libraries/typescript/packages/inspector/tests/unit/rate-limit.test.ts
+++ b/libraries/typescript/packages/inspector/tests/unit/rate-limit.test.ts
@@ -5,6 +5,7 @@ import {
   INSPECTOR_API_RATE_LIMIT,
   INSPECTOR_ASSET_RATE_LIMIT,
   inspectorRateLimitResponse,
+  inspectorServerRateLimitKey,
 } from "../../src/server/rate-limit.js";
 
 describe("Inspector route rate limits", () => {
@@ -63,6 +64,16 @@ describe("Inspector route rate limits", () => {
   it("keeps the security patch defaults stable", () => {
     expect(INSPECTOR_API_RATE_LIMIT).toBe(120);
     expect(INSPECTOR_ASSET_RATE_LIMIT).toBe(600);
+  });
+
+  it("canonicalizes target keys without query, fragment, or credentials", () => {
+    expect(
+      inspectorServerRateLimitKey(
+        "oauth",
+        "https://user:password@example.com/mcp/?token=secret#fragment"
+      )
+    ).toBe("oauth:https://example.com/mcp");
+    expect(inspectorServerRateLimitKey("mcp", "not a URL")).toBe("mcp:unknown");
   });
 
   it("uses the fallback Retry-After for non-finite limiter values", async () => {

--- a/libraries/typescript/packages/inspector/tsup.server.ts
+++ b/libraries/typescript/packages/inspector/tsup.server.ts
@@ -15,6 +15,12 @@ const rateLimiterMemoryShim = fileURLToPath(
 const rateLimiterMemoryAdapter = fileURLToPath(
   import.meta.resolve("rate-limiter-flexible/lib/RateLimiterMemory.js")
 );
+// Redis is bundled to keep the standalone Inspector self-contained. Its
+// CommonJS transitive dependencies use require("node:crypto") and friends;
+// provide the native ESM-safe require that those modules expect.
+const nodeRequireBanner = {
+  js: 'import { createRequire } from "node:module"; const require = createRequire(import.meta.url);',
+};
 
 function bundleOnlyMemoryRateLimiter(options: {
   alias?: Record<string, string>;
@@ -38,6 +44,7 @@ export default defineConfig([
     minify: true,
     dts: true,
     noExternal: bundledServerDependencies,
+    banner: nodeRequireBanner,
     esbuildOptions: bundleOnlyMemoryRateLimiter,
   },
   {
@@ -52,6 +59,7 @@ export default defineConfig([
     dts: false,
     clean: false,
     noExternal: bundledServerDependencies,
+    banner: nodeRequireBanner,
     esbuildOptions: bundleOnlyMemoryRateLimiter,
   },
 ]);

--- a/libraries/typescript/packages/inspector/tsup.server.ts
+++ b/libraries/typescript/packages/inspector/tsup.server.ts
@@ -6,6 +6,7 @@ const bundledServerDependencies = [
   "@hono/node-server",
   "@mcp-use/client",
   "open",
+  "redis",
   "rate-limiter-flexible",
 ];
 const rateLimiterMemoryShim = fileURLToPath(

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -427,9 +427,6 @@ importers:
       mcp-use:
         specifier: workspace:*
         version: link:../server
-      redis:
-        specifier: ^5.8.2
-        version: 5.12.1(@opentelemetry/api@1.9.1)
     devDependencies:
       '@base-ui/react':
         specifier: ^1.6.0
@@ -503,6 +500,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.6.4
         version: 4.6.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      redis:
+        specifier: ^5.8.2
+        version: 5.12.1(@opentelemetry/api@1.9.1)
       react-router:
         specifier: ^8.3.0
         version: 8.3.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -427,6 +427,9 @@ importers:
       mcp-use:
         specifier: workspace:*
         version: link:../server
+      redis:
+        specifier: ^5.8.2
+        version: 5.12.1(@opentelemetry/api@1.9.1)
     devDependencies:
       '@base-ui/react':
         specifier: ^1.6.0
@@ -4109,6 +4112,42 @@ packages:
   '@radix-ui/rect@1.1.3':
     resolution: {integrity: sha512-JtyZR+mqgBibTo8xea3B6ZRmzZiM/YeVBtUkas6zMuXjAlfIFIW2FgqeM9eLyvEaYX66vr6DJMK+4U6LV0KhNw==}
 
+  '@redis/bloom@5.12.1':
+    resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/client@5.12.1':
+    resolution: {integrity: sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@5.12.1':
+    resolution: {integrity: sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/search@5.12.1':
+    resolution: {integrity: sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
+  '@redis/time-series@5.12.1':
+    resolution: {integrity: sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==}
+    engines: {node: '>= 18.19.0'}
+    peerDependencies:
+      '@redis/client': ^5.12.1
+
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5657,6 +5696,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -7992,6 +8035,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  redis@5.12.1:
+    resolution: {integrity: sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==}
+    engines: {node: '>= 18.19.0'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -11445,6 +11492,28 @@ snapshots:
 
   '@radix-ui/rect@1.1.3': {}
 
+  '@redis/bloom@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/client@5.12.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@redis/json@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/search@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
+  '@redis/time-series@5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -12836,6 +12905,8 @@ snapshots:
   clsx@1.1.1: {}
 
   clsx@2.1.1: {}
+
+  cluster-key-slot@1.1.2: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -15419,6 +15490,17 @@ snapshots:
       picomatch: 4.0.4
 
   readdirp@4.1.2: {}
+
+  redis@5.12.1(@opentelemetry/api@1.9.1):
+    dependencies:
+      '@redis/bloom': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/client': 5.12.1(@opentelemetry/api@1.9.1)
+      '@redis/json': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/search': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+      '@redis/time-series': 5.12.1(@redis/client@5.12.1(@opentelemetry/api@1.9.1))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   reflect.getprototypeof@1.0.10:
     dependencies:


### PR DESCRIPTION
## Summary

Supersedes #2357 with a current-`main` implementation of the Inspector hosted OAuth/state foundation and the relay security boundary.

This keeps the existing self-hosted CLI behavior while making hosted deployment choices explicit:

- `disabled`, `memory`, and encrypted `redis` OAuth state-store modes.
- Redis startup `connect` + `PING` readiness, reconnect-safe lazy readiness, a dedicated CAS connection, serialized local WATCH transactions, cross-replica conflict handling, and bounded graceful shutdown.
- AES-256-GCM state envelopes with key IDs and primary/previous-key rotation support.
- Revision/`updatedAt` handling and atomic `setIfNewer` semantics so stale durable state cannot overwrite fresher local state.
- Confidential-client keys scoped by MCP server and authorization server/issuer; `client_secret_expires_at: 0` is represented as no expiry.
- Strict confidential-client configuration parsing that rejects malformed `authorizationServers` instead of widening scope.
- DCR parsing that never exposes `client_secret` on malformed, primitive, array, or otherwise browser-visible responses.
- Exact-origin CORS semantics: omitted origins retain the legacy wildcard only for compatibility, while an explicit empty list denies cross-origin requests. OAuth and MCP preflight allow `DPoP`.
- Safe canonical target keys with bounded hashing for long paths, shared default process-wide backstops, and a separate per-client/global pre-auth budget. The known process-wide Request-object keying issue is not retained.
- Injectable relay authentication for reusable mounts, with authentication performed before protected relay budgets are consumed and again for every redirect destination/effective method. Upstream `Authorization` remains a separate header and is forwarded only to the upstream request.
- `/inspector/health` actively probes the configured state store (including Redis `PING`) and returns 503 when it is unavailable; health timeouts are bounded and cleaned up.
- Expired confidential-client deletion is version/CAS-safe, and equal-version binding conflicts adopt durable state before subsequent saves.
- Current-main `logPrefix` and development API architecture are preserved.

## Hosted Cloud contract / rollout boundary

This SDK intentionally does not invent browser authentication. Exact CORS is not authentication, and a static relay bearer token would require exposing a shared secret to every browser. Hosted Cloud/edge must provide:

1. An `authenticate(c, target)` callback to the mounted relay routes (or `mountInspector`) that verifies a short-lived, user/session- and target-bound signed capability. The verifier should bind the capability to the target origin/path, HTTP method, expiry, and replay policy; false returns 401. The upstream `Authorization` header must remain independent. Redirect destinations are re-authenticated before their upstream fetch.
2. Explicit production `oauthProxyAllowedOrigins` and `mcpProxyAllowedOrigins` containing exact trusted origins. Do not omit them or use a wildcard in hosted production.
3. `INSPECTOR_OAUTH_STATE_STORE=redis`, `INSPECTOR_OAUTH_REDIS_URL` (or `REDIS_URL`), a base64-encoded 32-byte `INSPECTOR_OAUTH_ENCRYPTION_KEY`, and an environment-specific key prefix. Optional key ID and previous-key JSON support rotation without exposing key material.
4. Confidential-client resolver configuration with server URLs, optional authorization-server/issuer URLs, client ID, client secret, and auth method. These values stay server-side.
5. A distributed/edge rate limiter. The SDK limiter is deliberately process-local and only a backstop; it is not sufficient as the product-wide abuse-control boundary.

The callback is invoked as `(c, target)`, while existing one-argument
callbacks remain source-compatible. `target` is `{ origin, pathname, method }`
for a valid requested upstream target (query, fragment, and credentials are
omitted), or `undefined` for malformed/missing input. Hosted verifiers should
bind the short-lived capability to this target context without cloning or
parsing the OAuth relay body. Browsers send that capability in the distinct
`X-Inspector-Relay-Token` header; both relay preflights allow it, and both
relays strip it before upstream forwarding. Upstream `Authorization` remains
independent.

Cloud should gate readiness on `/inspector/health` and wait for Redis readiness. This PR does not claim that currently deployed public aliases are cut over: existing hosted services remain a separate image/configuration concern until Cloud supplies the auth, exact-origin, Redis, and distributed-limiter configuration.

The default-off consumer is [mcp-use-cloud PR #1651](https://github.com/mcp-use/mcp-use-cloud/pull/1651). Keep #1651 disabled until this package is released and deployed, and until its capability-auth, exact-origin, Redis/readiness, distributed-rate-limit, and live runtime gates all pass.

PR #2260 was not cherry-picked: it targets `canary` and is DIRTY. Its safe target-key behavior is represented here without importing its unrelated state.

## Verification

Run from `libraries/typescript`:

```text
pnpm --filter @mcp-use/inspector lint
pnpm --filter @mcp-use/inspector type-check
pnpm --filter @mcp-use/inspector build
pnpm --filter @mcp-use/inspector exec vitest run tests/unit
```

Results:

- lint, type-check, and build passed.
- Unit suite: 59 suites, 288 passed, 1 skipped (the opt-in Redis integration file without a Redis URL).
- With a disposable `redis:7-alpine`, `INSPECTOR_REDIS_TEST_URL=... pnpm --filter @mcp-use/inspector exec vitest run tests/unit/oauth-state-store-redis.test.ts` passed the live encrypted round-trip, wrong/rotated-key, cross-store CAS, delete, and close checks.
- A separate Redis restart smoke observed `initial-ready` followed by `reconnected-ready` from the same store process.
- Production CLI smoke with the disabled state mode served `/inspector/health` successfully and shut down cleanly on SIGINT.
- `git diff --check` passed.

## Residual risks

- No Cloud deployment/image cutover or public-alias runtime proof is included; hosted rollout remains blocked on the contract above.
- The Redis integration test is opt-in because CI environments may not provide Docker/Redis.
- Rotated keys are accepted for reads and new writes use the primary key; existing records are not eagerly re-encrypted until rewritten.
- Custom state stores that do not implement `setIfNewer` use a compatibility get/set fallback and are not cross-process atomic. Production hosted deployments should use the bundled Redis store or provide an atomic implementation.
- Loopback target policy defaults remain permissive for local development and restrictive for production configuration.
