### PR TITLE
fix(ci): post test reports when CI is called for a fork PR

### DIFF
--- a/.github/workflows/approve-fork-pr.yml
+++ b/.github/workflows/approve-fork-pr.yml
@@ -106,4 +106,5 @@ jobs:
       typescript: ${{ needs.promote.outputs.typescript == 'true' }}
       create_mcp_use_app: ${{ needs.promote.outputs.create_mcp_use_app == 'true' }}
       run_changeset_check: false
+      pr_number: ${{ inputs.pull_number }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ on:
         required: false
         type: boolean
         default: false
+      pr_number:
+        description: "PR number for the reporting jobs to comment on"
+        required: false
+        type: number
 
 jobs:
   detect-changes:
@@ -281,7 +285,7 @@ jobs:
 
   python-transport-tests-report:
     needs: python-transport-tests
-    if: always() && github.event_name == 'pull_request' && needs.python-transport-tests.result != 'skipped'
+    if: always() && (inputs.pr_number || github.event_name == 'pull_request') && needs.python-transport-tests.result != 'skipped'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -294,10 +298,13 @@ jobs:
           merge-multiple: false
       - name: Generate PR comment
         uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
+            const issueNumber = Number(process.env.PR_NUMBER) || context.issue.number;
 
             const transports = ['stdio', 'sse', 'streamable_http'];
             let tableRows = [];
@@ -360,7 +367,7 @@ jobs:
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
             });
 
             const botComment = comments.find(c => 
@@ -379,7 +386,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 body: comment,
               });
             }
@@ -446,7 +453,7 @@ jobs:
 
   python-primitive-tests-report:
     needs: python-primitive-tests
-    if: always() && github.event_name == 'pull_request' && needs.python-primitive-tests.result != 'skipped'
+    if: always() && (inputs.pr_number || github.event_name == 'pull_request') && needs.python-primitive-tests.result != 'skipped'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -459,10 +466,13 @@ jobs:
           merge-multiple: false
       - name: Generate PR comment
         uses: actions/github-script@v9
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
         with:
           script: |
             const fs = require('fs');
             const path = require('path');
+            const issueNumber = Number(process.env.PR_NUMBER) || context.issue.number;
 
             const primitives = ['sampling', 'tools', 'resources', 'prompts', 'elicitation', 'notifications', 'auth', 'roots'];
             let tableRows = [];
@@ -525,7 +535,7 @@ jobs:
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: issueNumber,
             });
 
             const botComment = comments.find(c => 
@@ -544,7 +554,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: issueNumber,
                 body: comment,
               });
             }


### PR DESCRIPTION
`approve-fork-pr` is dispatched manually and then calls `ci.yml` as a reusable workflow. A called workflow sees the caller's `github` context, so `github.event_name` there is `workflow_dispatch`, never `pull_request`. Both python report jobs gate on that value, so neither runs on this path. `context.issue.number` is undefined off the `pull_request` trigger too, so the comment would have had no target even if they did run.

This is the same caller-context problem #2418 fixed for the checkouts. Those tested for `workflow_call`; these two compare against `pull_request`, so that sweep did not reach them. The fix passes the dispatched PR number through as an input and uses it for both the job condition and the comment target, falling back to the existing context on the `pull_request` path exactly as before.

Worth saying plainly: `approve-fork-pr` has never run, 0 runs since #442 added it, so this is latent rather than live breakage and I cannot show you a skipped job. The evidence is structural.

Disclosure: AI-assisted. I checked that both files parse, that the new input reaches both jobs, and that the two conditions read as intended.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes test report jobs not running when CI is triggered from an approved fork PR. Previously, the report jobs checked `github.event_name == 'pull_request'`, but that event is never seen when `ci.yml` is called as a reusable workflow from `approve-fork-pr`. Now the PR number is passed as an input and used to gate the jobs and target the comment, falling back to the existing context on the normal pull request path.

<sup>Written for commit 7ebeec18099f7550af6c20a865132cc565865804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

