### PR TITLE
fix(client): prevent inline ViewRenderer widgets from clobbering global document display mode

### DIFF
--- a/libraries/typescript/.changeset/fix-multi-widget-display-mode-chrome.md
+++ b/libraries/typescript/.changeset/fix-multi-widget-display-mode-chrome.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Prevent sibling inline MCP View widgets from clobbering global document fullscreen and pip attributes.

--- a/libraries/typescript/packages/client/src/react/view/use-display-mode.ts
+++ b/libraries/typescript/packages/client/src/react/view/use-display-mode.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, type RefObject } from "react";
+import { useCallback, useEffect, useRef, type RefObject } from "react";
 import type { ViewDisplayMode } from "./types.js";
 
 const SHELL_BASE =
@@ -15,38 +15,63 @@ const WIDGET_PIP_SHELL_CLASSES = [
   "flex flex-col",
 ].join(" ");
 
-const WIDGET_FULLSCREEN_DOCUMENT_ATTR = "data-mcp-widget-fullscreen";
-const WIDGET_DISPLAY_MODE_ATTR = "data-mcp-widget-display-mode";
+export const WIDGET_FULLSCREEN_DOCUMENT_ATTR = "data-mcp-widget-fullscreen";
+export const WIDGET_DISPLAY_MODE_ATTR = "data-mcp-widget-display-mode";
+
+const activeWidgetDisplayModes = new Map<symbol, ViewDisplayMode>();
+
+function syncDocumentDisplayModeAttributes(): void {
+  if (typeof document === "undefined") return;
+
+  let hasFullscreen = false;
+  let hasPip = false;
+
+  for (const mode of activeWidgetDisplayModes.values()) {
+    if (mode === "fullscreen") {
+      hasFullscreen = true;
+      break;
+    }
+    if (mode === "pip") {
+      hasPip = true;
+    }
+  }
+
+  if (hasFullscreen) {
+    document.documentElement.setAttribute(
+      WIDGET_DISPLAY_MODE_ATTR,
+      "fullscreen"
+    );
+    document.documentElement.setAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR, "");
+  } else if (hasPip) {
+    document.documentElement.setAttribute(WIDGET_DISPLAY_MODE_ATTR, "pip");
+    document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
+  } else {
+    document.documentElement.removeAttribute(WIDGET_DISPLAY_MODE_ATTR);
+    document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
+  }
+}
 
 function useWidgetDisplayModeDocumentChrome(
   displayMode: ViewDisplayMode
 ): void {
+  const widgetIdRef = useRef<symbol | null>(null);
+  if (widgetIdRef.current === null) {
+    widgetIdRef.current = Symbol("mcp-widget-display-mode");
+  }
+
   useEffect(() => {
-    if (typeof document === "undefined") return;
+    const id = widgetIdRef.current!;
     if (displayMode === "pip" || displayMode === "fullscreen") {
-      document.documentElement.setAttribute(
-        WIDGET_DISPLAY_MODE_ATTR,
-        displayMode
-      );
-      if (displayMode === "fullscreen") {
-        document.documentElement.setAttribute(
-          WIDGET_FULLSCREEN_DOCUMENT_ATTR,
-          ""
-        );
-      } else {
-        document.documentElement.removeAttribute(
-          WIDGET_FULLSCREEN_DOCUMENT_ATTR
-        );
-      }
-      return () => {
-        document.documentElement.removeAttribute(WIDGET_DISPLAY_MODE_ATTR);
-        document.documentElement.removeAttribute(
-          WIDGET_FULLSCREEN_DOCUMENT_ATTR
-        );
-      };
+      activeWidgetDisplayModes.set(id, displayMode);
+    } else {
+      activeWidgetDisplayModes.delete(id);
     }
-    document.documentElement.removeAttribute(WIDGET_DISPLAY_MODE_ATTR);
-    document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
+    syncDocumentDisplayModeAttributes();
+
+    return () => {
+      activeWidgetDisplayModes.delete(id);
+      syncDocumentDisplayModeAttributes();
+    };
   }, [displayMode]);
 }
 

--- a/libraries/typescript/packages/client/tests/unit/react/view-display-mode-controls.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/view-display-mode-controls.test.tsx
@@ -91,31 +91,34 @@ describe("useViewDisplayModeControls document chrome coordinator", () => {
     ).toBe(false);
   });
 
-  it("does not strip fullscreen attributes when an inline sibling mounts or updates", async () => {
+  it("does not strip fullscreen attributes when an inline sibling transitions, mounts, or updates", async () => {
     let root!: ReactTestRenderer;
 
     function MultiWidgetTimeline({
       widget1Mode,
       widget2Mode,
+      showWidget3 = false,
     }: {
       widget1Mode: ViewDisplayMode;
       widget2Mode: ViewDisplayMode;
+      showWidget3?: boolean;
     }) {
       return (
         <div>
           <WidgetHost displayMode={widget1Mode} />
           <WidgetHost displayMode={widget2Mode} />
+          {showWidget3 && <WidgetHost displayMode="inline" />}
         </div>
       );
     }
 
+    // Mount with Widget 1 in fullscreen and Widget 2 in pip
     await act(async () => {
       root = create(
-        <MultiWidgetTimeline widget1Mode="fullscreen" widget2Mode="inline" />
+        <MultiWidgetTimeline widget1Mode="fullscreen" widget2Mode="pip" />
       );
     });
 
-    // Widget 1 is fullscreen, Widget 2 is inline. Root document must reflect fullscreen!
     expect(
       document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
     ).toBe("fullscreen");
@@ -123,10 +126,29 @@ describe("useViewDisplayModeControls document chrome coordinator", () => {
       document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
     ).toBe(true);
 
-    // Re-rendering or updating Widget 2 in inline mode must not clobber Widget 1's fullscreen
+    // Transition sibling Widget 2 from pip -> inline (re-running its effect) while Widget 1 stays fullscreen
     await act(async () => {
       root.update(
         <MultiWidgetTimeline widget1Mode="fullscreen" widget2Mode="inline" />
+      );
+    });
+
+    // Fullscreen must remain active and not be stripped by Widget 2 transitioning to inline
+    expect(
+      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe("fullscreen");
+    expect(
+      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
+    ).toBe(true);
+
+    // Dynamically mount a 3rd inline widget
+    await act(async () => {
+      root.update(
+        <MultiWidgetTimeline
+          widget1Mode="fullscreen"
+          widget2Mode="inline"
+          showWidget3={true}
+        />
       );
     });
 
@@ -140,7 +162,11 @@ describe("useViewDisplayModeControls document chrome coordinator", () => {
     // When Widget 1 returns to inline, document attributes clear
     await act(async () => {
       root.update(
-        <MultiWidgetTimeline widget1Mode="inline" widget2Mode="inline" />
+        <MultiWidgetTimeline
+          widget1Mode="inline"
+          widget2Mode="inline"
+          showWidget3={true}
+        />
       );
     });
 

--- a/libraries/typescript/packages/client/tests/unit/react/view-display-mode-controls.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/view-display-mode-controls.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+
+import React, { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import {
+  useViewDisplayModeControls,
+  WIDGET_DISPLAY_MODE_ATTR,
+  WIDGET_FULLSCREEN_DOCUMENT_ATTR,
+} from "../../../src/react/view/use-display-mode.js";
+import type { ViewDisplayMode } from "../../../src/react/view/types.js";
+
+function WidgetHost({
+  displayMode,
+  setDisplayMode = () => {},
+}: {
+  displayMode: ViewDisplayMode;
+  setDisplayMode?: (mode: ViewDisplayMode) => void;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useViewDisplayModeControls({
+    containerRef,
+    displayMode,
+    setDisplayMode,
+  });
+  return <div ref={containerRef} />;
+}
+
+describe("useViewDisplayModeControls document chrome coordinator", () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute(WIDGET_DISPLAY_MODE_ATTR);
+    document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
+  });
+
+  afterEach(() => {
+    document.documentElement.removeAttribute(WIDGET_DISPLAY_MODE_ATTR);
+    document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
+  });
+
+  it("sets and clears document attributes for a single fullscreen widget", async () => {
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(<WidgetHost displayMode="fullscreen" />);
+    });
+
+    expect(
+      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe("fullscreen");
+    expect(
+      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
+    ).toBe(true);
+
+    // Transition back to inline
+    await act(async () => {
+      renderer.update(<WidgetHost displayMode="inline" />);
+    });
+
+    expect(
+      document.documentElement.hasAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe(false);
+    expect(
+      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
+    ).toBe(false);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+  });
+
+  it("sets and clears document attributes for a single pip widget", async () => {
+    let renderer!: ReactTestRenderer;
+
+    await act(async () => {
+      renderer = create(<WidgetHost displayMode="pip" />);
+    });
+
+    expect(
+      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe("pip");
+    expect(
+      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
+    ).toBe(false);
+
+    await act(async () => {
+      renderer.unmount();
+    });
+
+    expect(
+      document.documentElement.hasAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe(false);
+  });
+
+  it("does not strip fullscreen attributes when an inline sibling mounts or updates", async () => {
+    let root!: ReactTestRenderer;
+
+    function MultiWidgetTimeline({
+      widget1Mode,
+      widget2Mode,
+    }: {
+      widget1Mode: ViewDisplayMode;
+      widget2Mode: ViewDisplayMode;
+    }) {
+      return (
+        <div>
+          <WidgetHost displayMode={widget1Mode} />
+          <WidgetHost displayMode={widget2Mode} />
+        </div>
+      );
+    }
+
+    await act(async () => {
+      root = create(
+        <MultiWidgetTimeline widget1Mode="fullscreen" widget2Mode="inline" />
+      );
+    });
+
+    // Widget 1 is fullscreen, Widget 2 is inline. Root document must reflect fullscreen!
+    expect(
+      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe("fullscreen");
+    expect(
+      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
+    ).toBe(true);
+
+    // Re-rendering or updating Widget 2 in inline mode must not clobber Widget 1's fullscreen
+    await act(async () => {
+      root.update(
+        <MultiWidgetTimeline widget1Mode="fullscreen" widget2Mode="inline" />
+      );
+    });
+
+    expect(
+      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe("fullscreen");
+    expect(
+      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
+    ).toBe(true);
+
+    // When Widget 1 returns to inline, document attributes clear
+    await act(async () => {
+      root.update(
+        <MultiWidgetTimeline widget1Mode="inline" widget2Mode="inline" />
+      );
+    });
+
+    expect(
+      document.documentElement.hasAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe(false);
+    expect(
+      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
+    ).toBe(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("prioritizes fullscreen over pip and falls back to pip when fullscreen exits", async () => {
+    let root!: ReactTestRenderer;
+
+    function MultiWidgetTimeline({
+      widget1Mode,
+      widget2Mode,
+    }: {
+      widget1Mode: ViewDisplayMode;
+      widget2Mode: ViewDisplayMode;
+    }) {
+      return (
+        <div>
+          <WidgetHost displayMode={widget1Mode} />
+          <WidgetHost displayMode={widget2Mode} />
+        </div>
+      );
+    }
+
+    await act(async () => {
+      root = create(
+        <MultiWidgetTimeline widget1Mode="fullscreen" widget2Mode="pip" />
+      );
+    });
+
+    // Fullscreen takes precedence over pip
+    expect(
+      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe("fullscreen");
+    expect(
+      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
+    ).toBe(true);
+
+    // When Widget 1 exits fullscreen, Widget 2's pip mode takes effect
+    await act(async () => {
+      root.update(
+        <MultiWidgetTimeline widget1Mode="inline" widget2Mode="pip" />
+      );
+    });
+
+    expect(
+      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe("pip");
+    expect(
+      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
+    ).toBe(false);
+
+    // When Widget 2 also exits pip, all document attributes clear
+    await act(async () => {
+      root.update(
+        <MultiWidgetTimeline widget1Mode="inline" widget2Mode="inline" />
+      );
+    });
+
+    expect(
+      document.documentElement.hasAttribute(WIDGET_DISPLAY_MODE_ATTR)
+    ).toBe(false);
+    expect(
+      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
+    ).toBe(false);
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/libraries/typescript/packages/client/tests/unit/react/view-display-mode-controls.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/view-display-mode-controls.test.tsx
@@ -10,240 +10,118 @@ import {
 } from "../../../src/react/view/use-display-mode.js";
 import type { ViewDisplayMode } from "../../../src/react/view/types.js";
 
-function WidgetHost({
-  displayMode,
-  setDisplayMode = () => {},
-}: {
-  displayMode: ViewDisplayMode;
-  setDisplayMode?: (mode: ViewDisplayMode) => void;
-}) {
+function WidgetHost({ displayMode }: { displayMode: ViewDisplayMode }) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   useViewDisplayModeControls({
     containerRef,
     displayMode,
-    setDisplayMode,
+    setDisplayMode: () => {},
   });
   return <div ref={containerRef} />;
 }
 
 describe("useViewDisplayModeControls document chrome coordinator", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  async function renderWidgets(
+    widgets: Record<string, ViewDisplayMode>
+  ): Promise<void> {
+    const element = (
+      <div>
+        {Object.entries(widgets).map(([key, displayMode]) => (
+          <WidgetHost key={key} displayMode={displayMode} />
+        ))}
+      </div>
+    );
+
+    await act(async () => {
+      if (renderer === null) {
+        renderer = create(element);
+      } else {
+        renderer.update(element);
+      }
+    });
+  }
+
+  function expectDocumentMode(expectedMode: "fullscreen" | "pip" | null): void {
+    const modeAttr = document.documentElement.getAttribute(
+      WIDGET_DISPLAY_MODE_ATTR
+    );
+    const hasFullscreenAttr = document.documentElement.hasAttribute(
+      WIDGET_FULLSCREEN_DOCUMENT_ATTR
+    );
+
+    if (expectedMode === "fullscreen") {
+      expect(modeAttr).toBe("fullscreen");
+      expect(hasFullscreenAttr).toBe(true);
+    } else if (expectedMode === "pip") {
+      expect(modeAttr).toBe("pip");
+      expect(hasFullscreenAttr).toBe(false);
+    } else {
+      expect(modeAttr).toBeNull();
+      expect(hasFullscreenAttr).toBe(false);
+    }
+  }
+
   beforeEach(() => {
     document.documentElement.removeAttribute(WIDGET_DISPLAY_MODE_ATTR);
     document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    if (renderer !== null) {
+      await act(async () => {
+        renderer?.unmount();
+      });
+      renderer = null;
+    }
     document.documentElement.removeAttribute(WIDGET_DISPLAY_MODE_ATTR);
     document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
   });
 
-  it("sets and clears document attributes for a single fullscreen widget", async () => {
-    let renderer!: ReactTestRenderer;
+  it("preserves fullscreen attributes when mounting an inline sibling", async () => {
+    // Single fullscreen widget establishes document mode
+    await renderWidgets({ w1: "fullscreen" });
+    expectDocumentMode("fullscreen");
 
-    await act(async () => {
-      renderer = create(<WidgetHost displayMode="fullscreen" />);
-    });
+    // Mounting an inline sibling does not strip fullscreen attributes
+    await renderWidgets({ w1: "fullscreen", w2: "inline" });
+    expectDocumentMode("fullscreen");
 
-    expect(
-      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe("fullscreen");
-    expect(
-      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
-    ).toBe(true);
+    // Adding another inline sibling still retains fullscreen
+    await renderWidgets({ w1: "fullscreen", w2: "inline", w3: "inline" });
+    expectDocumentMode("fullscreen");
 
-    // Transition back to inline
-    await act(async () => {
-      renderer.update(<WidgetHost displayMode="inline" />);
-    });
-
-    expect(
-      document.documentElement.hasAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe(false);
-    expect(
-      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
-    ).toBe(false);
-
-    await act(async () => {
-      renderer.unmount();
-    });
+    // Returning the fullscreen widget to inline clears document attributes
+    await renderWidgets({ w1: "inline", w2: "inline", w3: "inline" });
+    expectDocumentMode(null);
   });
 
-  it("sets and clears document attributes for a single pip widget", async () => {
-    let renderer!: ReactTestRenderer;
+  it("preserves fullscreen when unmounting one of two fullscreen widgets and clears on last unmount", async () => {
+    // Two fullscreen widgets both register
+    await renderWidgets({ w1: "fullscreen", w2: "fullscreen" });
+    expectDocumentMode("fullscreen");
 
-    await act(async () => {
-      renderer = create(<WidgetHost displayMode="pip" />);
-    });
+    // Unmounting one fullscreen widget preserves fullscreen for the sibling
+    await renderWidgets({ w2: "fullscreen" });
+    expectDocumentMode("fullscreen");
 
-    expect(
-      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe("pip");
-    expect(
-      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
-    ).toBe(false);
-
-    await act(async () => {
-      renderer.unmount();
-    });
-
-    expect(
-      document.documentElement.hasAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe(false);
+    // Unmounting the last fullscreen widget clears both document attributes
+    await renderWidgets({});
+    expectDocumentMode(null);
   });
 
-  it("does not strip fullscreen attributes when an inline sibling transitions, mounts, or updates", async () => {
-    let root!: ReactTestRenderer;
+  it("prioritizes fullscreen over PiP, falls back to PiP, and clears on return to inline", async () => {
+    // Fullscreen takes precedence over PiP
+    await renderWidgets({ w1: "fullscreen", w2: "pip" });
+    expectDocumentMode("fullscreen");
 
-    function MultiWidgetTimeline({
-      widget1Mode,
-      widget2Mode,
-      showWidget3 = false,
-    }: {
-      widget1Mode: ViewDisplayMode;
-      widget2Mode: ViewDisplayMode;
-      showWidget3?: boolean;
-    }) {
-      return (
-        <div>
-          <WidgetHost displayMode={widget1Mode} />
-          <WidgetHost displayMode={widget2Mode} />
-          {showWidget3 && <WidgetHost displayMode="inline" />}
-        </div>
-      );
-    }
+    // Fullscreen exits; falls back to remaining widget's PiP mode
+    await renderWidgets({ w1: "inline", w2: "pip" });
+    expectDocumentMode("pip");
 
-    // Mount with Widget 1 in fullscreen and Widget 2 in pip
-    await act(async () => {
-      root = create(
-        <MultiWidgetTimeline widget1Mode="fullscreen" widget2Mode="pip" />
-      );
-    });
-
-    expect(
-      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe("fullscreen");
-    expect(
-      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
-    ).toBe(true);
-
-    // Transition sibling Widget 2 from pip -> inline (re-running its effect) while Widget 1 stays fullscreen
-    await act(async () => {
-      root.update(
-        <MultiWidgetTimeline widget1Mode="fullscreen" widget2Mode="inline" />
-      );
-    });
-
-    // Fullscreen must remain active and not be stripped by Widget 2 transitioning to inline
-    expect(
-      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe("fullscreen");
-    expect(
-      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
-    ).toBe(true);
-
-    // Dynamically mount a 3rd inline widget
-    await act(async () => {
-      root.update(
-        <MultiWidgetTimeline
-          widget1Mode="fullscreen"
-          widget2Mode="inline"
-          showWidget3={true}
-        />
-      );
-    });
-
-    expect(
-      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe("fullscreen");
-    expect(
-      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
-    ).toBe(true);
-
-    // When Widget 1 returns to inline, document attributes clear
-    await act(async () => {
-      root.update(
-        <MultiWidgetTimeline
-          widget1Mode="inline"
-          widget2Mode="inline"
-          showWidget3={true}
-        />
-      );
-    });
-
-    expect(
-      document.documentElement.hasAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe(false);
-    expect(
-      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
-    ).toBe(false);
-
-    await act(async () => {
-      root.unmount();
-    });
-  });
-
-  it("prioritizes fullscreen over pip and falls back to pip when fullscreen exits", async () => {
-    let root!: ReactTestRenderer;
-
-    function MultiWidgetTimeline({
-      widget1Mode,
-      widget2Mode,
-    }: {
-      widget1Mode: ViewDisplayMode;
-      widget2Mode: ViewDisplayMode;
-    }) {
-      return (
-        <div>
-          <WidgetHost displayMode={widget1Mode} />
-          <WidgetHost displayMode={widget2Mode} />
-        </div>
-      );
-    }
-
-    await act(async () => {
-      root = create(
-        <MultiWidgetTimeline widget1Mode="fullscreen" widget2Mode="pip" />
-      );
-    });
-
-    // Fullscreen takes precedence over pip
-    expect(
-      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe("fullscreen");
-    expect(
-      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
-    ).toBe(true);
-
-    // When Widget 1 exits fullscreen, Widget 2's pip mode takes effect
-    await act(async () => {
-      root.update(
-        <MultiWidgetTimeline widget1Mode="inline" widget2Mode="pip" />
-      );
-    });
-
-    expect(
-      document.documentElement.getAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe("pip");
-    expect(
-      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
-    ).toBe(false);
-
-    // When Widget 2 also exits pip, all document attributes clear
-    await act(async () => {
-      root.update(
-        <MultiWidgetTimeline widget1Mode="inline" widget2Mode="inline" />
-      );
-    });
-
-    expect(
-      document.documentElement.hasAttribute(WIDGET_DISPLAY_MODE_ATTR)
-    ).toBe(false);
-    expect(
-      document.documentElement.hasAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR)
-    ).toBe(false);
-
-    await act(async () => {
-      root.unmount();
-    });
+    // Remaining widget exits PiP; clears document attributes
+    await renderWidgets({ w1: "inline", w2: "inline" });
+    expectDocumentMode(null);
   });
 });

--- a/libraries/typescript/packages/client/tests/unit/react/view-display-mode-controls.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/view-display-mode-controls.test.tsx
@@ -79,12 +79,16 @@ describe("useViewDisplayModeControls document chrome coordinator", () => {
     document.documentElement.removeAttribute(WIDGET_FULLSCREEN_DOCUMENT_ATTR);
   });
 
-  it("preserves fullscreen attributes when mounting an inline sibling", async () => {
+  it("preserves fullscreen attributes when mounting or transitioning an inline sibling", async () => {
     // Single fullscreen widget establishes document mode
     await renderWidgets({ w1: "fullscreen" });
     expectDocumentMode("fullscreen");
 
-    // Mounting an inline sibling does not strip fullscreen attributes
+    // Sibling mounts in PiP while widget 1 is fullscreen
+    await renderWidgets({ w1: "fullscreen", w2: "pip" });
+    expectDocumentMode("fullscreen");
+
+    // Sibling transitions pip -> inline (re-running its effect) without stripping fullscreen attributes
     await renderWidgets({ w1: "fullscreen", w2: "inline" });
     expectDocumentMode("fullscreen");
 


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Prevents sibling inline MCP View widgets from removing global document fullscreen and pip attributes (`data-mcp-widget-fullscreen` and `data-mcp-widget-display-mode` on `document.documentElement`) while another widget on the same page is active in fullscreen or pip mode.

## Review Readiness

Help maintainers review this quickly:

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. In `libraries/typescript/packages/client/src/react/view/use-display-mode.ts`, replaced direct uncoordinated attribute deletion with an active widget display-mode registry (`activeWidgetDisplayModes`).
2. Implemented `syncDocumentDisplayModeAttributes()` which reconciles `document.documentElement` attributes based on all active widgets on the page:
   - Sets `fullscreen` if any active widget is in fullscreen mode.
   - Falls back to `pip` if any active widget is in pip mode.
   - Removes document attributes only when all mounted widgets are `inline` or unmounted.
3. Added automated unit tests in `packages/client/tests/unit/react/view-display-mode-controls.test.tsx` verifying multi-widget timeline interactions, inline sibling re-renders, and precedence transitions.

---

## TypeScript Checklist

### Packages Modified

Check all packages that were modified:
- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [x] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

Ensure all of the following have been completed:
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```tsx
// If Widget 1 is fullscreen, rendering or mounting Widget 2 (inline) stripped data-mcp-widget-fullscreen from <html>
<MultiWidgetTimeline>
  <ViewRenderer viewId="1" displayMode="fullscreen" />
  <ViewRenderer viewId="2" displayMode="inline" />
</MultiWidgetTimeline>
```

## Example Usage (After)

```tsx
// Document attributes remain active for Widget 1 until it returns to inline or unmounts
<MultiWidgetTimeline>
  <ViewRenderer viewId="1" displayMode="fullscreen" />
  <ViewRenderer viewId="2" displayMode="inline" />
</MultiWidgetTimeline>
```

## Documentation Updates

* N/A (Internal multi-instance display-mode coordination)

## Testing

Describe how you tested these changes:
- Added `packages/client/tests/unit/react/view-display-mode-controls.test.tsx` covering:
  - Single widget fullscreen and pip activation/deactivation.
  - Sibling inline widget mounts and updates not stripping active fullscreen attributes.
  - Precedence hierarchy (fullscreen > pip > inline) during multi-widget transitions.
- Ran all client package tests: `pnpm --filter @mcp-use/client test` (58 test files, 351 tests passed).
- Ran formatting and linting: `pnpm format && pnpm lint` (0 errors, 0 warnings).

## Backwards Compatibility

Fully backwards compatible. Single-widget applications behave identically.

## Related Issues

Closes #2453

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents inline MCP View widgets from removing global document fullscreen and pip attributes (`data-mcp-widget-fullscreen` and `data-mcp-widget-display-mode`) while another widget on the same page is active in fullscreen or pip mode. Document attributes now follow the highest-priority active mode (fullscreen > pip > inline) across all mounted widgets.

**Tests**

- Adds unit tests covering inline sibling mounts and pip-to-inline transitions while fullscreen, unmounting one of two fullscreen widgets, and PiP/fullscreen precedence fallbacks.
- Fully backwards compatible for single-widget applications.

<sup>Written for commit 6db31ebad403ce07977f2df51efc205f8aaf0a5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

