### PR TITLE
fix(server): prevent overlapping listen() calls and leaked background HTTP listeners

### DIFF
--- a/libraries/typescript/.changeset/server-listen-lifecycle-concurrency.md
+++ b/libraries/typescript/.changeset/server-listen-lifecycle-concurrency.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Prevent overlapping listen() calls and avoid leaking background HTTP listeners on duplicate startup or shutdown

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -360,6 +360,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
   #handler: McpHttpHandler | undefined;
   #eventBus: ServerEventBus | undefined;
   #httpServer: NodeHttpListener | undefined;
+  #listenPromise: Promise<{ port: number; url: string }> | undefined;
   #oauthResource: URL | undefined;
   #oauthResourceResolved = false;
   #oauthResourceConfigurationAbsent = false;
@@ -1003,70 +1004,93 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     url: string;
   }> {
     this.#assertOpen("listen()");
-    await this.#ensureSkillsPrimed();
-    const host = resolveListenHost(options.host, this.#config.host);
-    const requestedPort = resolveListenPort(port, this.#config.port);
-    this.#assertListenOAuthConfiguration(host);
-
-    return new Promise((resolve, reject) => {
-      let resolveFetch: ((fetch: FetchHandler) => void) | undefined;
-      let rejectFetch: ((error: unknown) => void) | undefined;
-      const fetchReady = new Promise<FetchHandler>(
-        (resolveFetchPromise, rejectFetchPromise) => {
-          resolveFetch = resolveFetchPromise;
-          rejectFetch = rejectFetchPromise;
-        }
+    if (this.#httpServer !== undefined || this.#listenPromise !== undefined) {
+      throw new Error(
+        "Cannot call listen() while the server is already listening."
       );
-      void fetchReady.catch(() => undefined);
+    }
 
-      let settled = false;
-      const rejectAndClose = (error: unknown) => {
-        if (!settled) {
-          settled = true;
-          reject(error);
-        }
-        rejectFetch?.(error);
-        void new Promise<void>((closeResolve) =>
-          server.close(() => closeResolve())
-        )
-          .catch(() => undefined)
-          .finally(() => {
-            if (this.#httpServer === server) {
-              this.#httpServer = undefined;
-            }
-          });
-      };
+    const listenPromise = (async () => {
+      await this.#ensureSkillsPrimed();
+      const host = resolveListenHost(options.host, this.#config.host);
+      const requestedPort = resolveListenPort(port, this.#config.port);
+      this.#assertListenOAuthConfiguration(host);
 
-      const nodeHandler = toNodeHandler({
-        fetch: async (request) => (await fetchReady)(request),
-      });
-      const server = createNodeHttpServer((req, res) => {
-        void nodeHandler(req, res);
-      }) as NodeHttpListener;
+      return new Promise<{ port: number; url: string }>((resolve, reject) => {
+        let resolveFetch: ((fetch: FetchHandler) => void) | undefined;
+        let rejectFetch: ((error: unknown) => void) | undefined;
+        const fetchReady = new Promise<FetchHandler>(
+          (resolveFetchPromise, rejectFetchPromise) => {
+            resolveFetch = resolveFetchPromise;
+            rejectFetch = rejectFetchPromise;
+          }
+        );
+        void fetchReady.catch(() => undefined);
 
-      server.once("error", rejectAndClose);
-      server.listen(requestedPort, host, () => {
-        try {
-          const address = server.address();
-          const boundPort =
-            typeof address === "object" && address !== null
-              ? address.port
-              : requestedPort;
-          const { fetch } = this.#ensureMounted("listen", boundPort, host);
-          resolveFetch?.(fetch);
+        let settled = false;
+        const nodeHandler = toNodeHandler({
+          fetch: async (request) => (await fetchReady)(request),
+        });
+        const server = createNodeHttpServer((req, res) => {
+          void nodeHandler(req, res);
+        }) as NodeHttpListener;
+
+        const rejectAndClose = (error: unknown) => {
           if (!settled) {
             settled = true;
-            resolve({
-              port: boundPort,
-              url: `http://localhost:${boundPort}${this.#basePath()}`,
-            });
+            reject(error);
           }
-        } catch (error) {
-          rejectAndClose(error);
-        }
+          rejectFetch?.(error);
+          void new Promise<void>((closeResolve) =>
+            server.close(() => closeResolve())
+          )
+            .catch(() => undefined)
+            .finally(() => {
+              if (this.#httpServer === server) {
+                this.#httpServer = undefined;
+              }
+            });
+        };
+
+        server.once("error", rejectAndClose);
+        server.listen(requestedPort, host, () => {
+          try {
+            if (this.#closed) {
+              rejectAndClose(
+                new Error("Cannot use the server after it has closed.")
+              );
+              return;
+            }
+            const address = server!.address();
+            const boundPort =
+              typeof address === "object" && address !== null
+                ? address.port
+                : requestedPort;
+            const { fetch } = this.#ensureMounted("listen", boundPort, host);
+            resolveFetch?.(fetch);
+            this.#httpServer = server;
+            if (!settled) {
+              settled = true;
+              resolve({
+                port: boundPort,
+                url: `http://localhost:${boundPort}${this.#basePath()}`,
+              });
+            }
+          } catch (error) {
+            rejectAndClose(error);
+          }
+        });
       });
-      this.#httpServer = server;
-    });
+    })();
+
+    this.#listenPromise = listenPromise;
+    try {
+      return await listenPromise;
+    } finally {
+      if (this.#listenPromise === listenPromise) {
+        this.#listenPromise = undefined;
+      }
+    }
   }
 
   /**
@@ -1078,6 +1102,9 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
    */
   async close(): Promise<void> {
     this.#closed = true;
+    if (this.#listenPromise !== undefined) {
+      await this.#listenPromise.catch(() => undefined);
+    }
     await Promise.allSettled([...this.#proxyOperations]);
 
     const errors: unknown[] = [];

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -275,6 +275,7 @@ interface PromptEntry<TUser, TEnv extends Env> {
 /** Node HTTP listener returned by `listen()`. */
 interface NodeHttpListener {
   close(callback?: (error?: Error) => void): void;
+  closeAllConnections?(): void;
   once(event: "error", listener: (error: unknown) => void): void;
   listen(port: number, hostname: string, callback?: () => void): NodeHttpServer;
   address(): { port: number } | string | null;
@@ -361,6 +362,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
   #eventBus: ServerEventBus | undefined;
   #httpServer: NodeHttpListener | undefined;
   #listenPromise: Promise<{ port: number; url: string }> | undefined;
+  #listenCleanupPromise: Promise<void> | undefined;
   #oauthResource: URL | undefined;
   #oauthResourceResolved = false;
   #oauthResourceConfigurationAbsent = false;
@@ -1035,28 +1037,44 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
           void nodeHandler(req, res);
         }) as NodeHttpListener;
 
-        const rejectAndClose = (error: unknown) => {
-          if (!settled) {
-            settled = true;
-            reject(error);
-          }
+        let cleanupPromise: Promise<void> | undefined;
+        const rejectAndClose = (error: unknown): Promise<void> => {
           rejectFetch?.(error);
-          void new Promise<void>((closeResolve) =>
-            server.close(() => closeResolve())
-          )
-            .catch(() => undefined)
-            .finally(() => {
-              if (this.#httpServer === server) {
-                this.#httpServer = undefined;
+          if (!cleanupPromise) {
+            try {
+              server.closeAllConnections?.();
+            } catch {
+              // ignore if not supported
+            }
+            cleanupPromise = new Promise<void>((closeResolve) => {
+              try {
+                server.close(() => closeResolve());
+              } catch {
+                closeResolve();
               }
-            });
+            })
+              .catch(() => undefined)
+              .finally(() => {
+                if (this.#httpServer === server) {
+                  this.#httpServer = undefined;
+                }
+                if (!settled) {
+                  settled = true;
+                  reject(error);
+                }
+              });
+            this.#listenCleanupPromise = cleanupPromise;
+          }
+          return cleanupPromise;
         };
 
-        server.once("error", rejectAndClose);
+        server.once("error", (error) => {
+          void rejectAndClose(error);
+        });
         server.listen(requestedPort, host, () => {
           try {
             if (this.#closed) {
-              rejectAndClose(
+              void rejectAndClose(
                 new Error("Cannot use the server after it has closed.")
               );
               return;
@@ -1077,7 +1095,7 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
               });
             }
           } catch (error) {
-            rejectAndClose(error);
+            void rejectAndClose(error);
           }
         });
       });
@@ -1105,6 +1123,10 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     if (this.#listenPromise !== undefined) {
       await this.#listenPromise.catch(() => undefined);
     }
+    if (this.#listenCleanupPromise !== undefined) {
+      await this.#listenCleanupPromise;
+      this.#listenCleanupPromise = undefined;
+    }
     await Promise.allSettled([...this.#proxyOperations]);
 
     const errors: unknown[] = [];
@@ -1123,6 +1145,11 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
     }
     const httpServer = this.#httpServer;
     if (httpServer !== undefined) {
+      try {
+        httpServer.closeAllConnections?.();
+      } catch {
+        // ignore if not supported
+      }
       try {
         await new Promise<void>((resolve, reject) => {
           httpServer.close((err) => (err ? reject(err) : resolve()));

--- a/libraries/typescript/packages/server/tests/server-listen-lifecycle.test.ts
+++ b/libraries/typescript/packages/server/tests/server-listen-lifecycle.test.ts
@@ -13,6 +13,18 @@ function isPortOpen(port: number): Promise<boolean> {
   });
 }
 
+function getFreePort(): Promise<number> {
+  return new Promise((resolve) => {
+    const s = http.createServer();
+    s.listen(0, "127.0.0.1", () => {
+      const address = s.address();
+      const port =
+        typeof address === "object" && address !== null ? address.port : 0;
+      s.close(() => resolve(port));
+    });
+  });
+}
+
 describe("MCPServer.listen lifecycle and concurrency", () => {
   it("rejects repeated listen() on an active server without leaking listeners", async () => {
     const server = new MCPServer({ name: "lifecycle-test", version: "1.0.0" });
@@ -90,20 +102,74 @@ describe("MCPServer.listen lifecycle and concurrency", () => {
   });
 
   it("cleans up listener when close() is called while listen() is in-flight", async () => {
+    const targetPort = await getFreePort();
     const server = new MCPServer({
       name: "close-inflight-test",
       version: "1.0.0",
     });
-    const listenPromise = server.listen(0);
+    const listenPromise = server.listen(targetPort);
     const closePromise = server.close();
 
-    const [listenResult] = await Promise.allSettled([
+    const [listenResult, closeResult] = await Promise.allSettled([
       listenPromise,
       closePromise,
     ]);
-    // Either listen was aborted or closed
-    if (listenResult.status === "fulfilled") {
-      expect(await isPortOpen(listenResult.value.port)).toBe(false);
+
+    expect(closeResult.status).toBe("fulfilled");
+    expect(listenResult.status).toBe("rejected");
+    if (listenResult.status === "rejected") {
+      expect((listenResult.reason as Error).message).toContain("closed");
     }
+
+    // Deterministically verify the target port is closed and not leaking
+    expect(await isPortOpen(targetPort)).toBe(false);
+
+    // Verify the port is immediately reusable without EADDRINUSE
+    const restartServer = new MCPServer({
+      name: "restart-test",
+      version: "1.0.0",
+    });
+    const restartListen = await restartServer.listen(targetPort);
+    expect(restartListen.port).toBe(targetPort);
+    expect(await isPortOpen(targetPort)).toBe(true);
+
+    await restartServer.close();
+    expect(await isPortOpen(targetPort)).toBe(false);
+  });
+
+  it("terminates active connections promptly when shutdown races listen()", async () => {
+    const targetPort = await getFreePort();
+    const server = new MCPServer({
+      name: "race-active-req-test",
+      version: "1.0.0",
+    });
+
+    const listenPromise = server.listen(targetPort);
+
+    // Send a request immediately as the port is binding
+    const req = http.get(`http://127.0.0.1:${targetPort}/mcp`);
+    req.on("error", () => {
+      // Expected connection reset or abort
+    });
+
+    const closePromise = server.close();
+
+    const [, closeResult] = await Promise.allSettled([
+      listenPromise,
+      closePromise,
+    ]);
+
+    expect(closeResult.status).toBe("fulfilled");
+    expect(await isPortOpen(targetPort)).toBe(false);
+
+    // An immediate restart must succeed
+    const restartServer = new MCPServer({
+      name: "restart-after-race-test",
+      version: "1.0.0",
+    });
+    const restartListen = await restartServer.listen(targetPort);
+    expect(restartListen.port).toBe(targetPort);
+    await restartServer.close();
+    expect(await isPortOpen(targetPort)).toBe(false);
   });
 });

--- a/libraries/typescript/packages/server/tests/server-listen-lifecycle.test.ts
+++ b/libraries/typescript/packages/server/tests/server-listen-lifecycle.test.ts
@@ -1,0 +1,109 @@
+import http from "node:http";
+import { describe, expect, it } from "vitest";
+
+import { MCPServer } from "../src/index.js";
+
+function isPortOpen(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = http.get(`http://127.0.0.1:${port}/mcp`, (res) => {
+      res.resume();
+      resolve(true);
+    });
+    req.on("error", () => resolve(false));
+  });
+}
+
+describe("MCPServer.listen lifecycle and concurrency", () => {
+  it("rejects repeated listen() on an active server without leaking listeners", async () => {
+    const server = new MCPServer({ name: "lifecycle-test", version: "1.0.0" });
+    const { port } = await server.listen(0);
+    expect(await isPortOpen(port)).toBe(true);
+
+    await expect(server.listen(0)).rejects.toThrow(
+      "Cannot call listen() while the server is already listening."
+    );
+
+    await server.close();
+    expect(await isPortOpen(port)).toBe(false);
+  });
+
+  it("handles concurrent listen() calls deterministically with zero leaked listeners", async () => {
+    const server = new MCPServer({ name: "concurrent-test", version: "1.0.0" });
+    const [first, second] = await Promise.allSettled([
+      server.listen(0),
+      server.listen(0),
+    ]);
+
+    const accepted = first.status === "fulfilled" ? first : second;
+    const rejected = first.status === "rejected" ? first : second;
+
+    expect(accepted.status).toBe("fulfilled");
+    expect(rejected.status).toBe("rejected");
+
+    if (accepted.status === "fulfilled") {
+      expect(typeof accepted.value.port).toBe("number");
+      expect(accepted.value.url).toContain(String(accepted.value.port));
+      expect(await isPortOpen(accepted.value.port)).toBe(true);
+    }
+
+    if (rejected.status === "rejected") {
+      expect(rejected.reason).toBeInstanceOf(Error);
+      expect((rejected.reason as Error).message).toBe(
+        "Cannot call listen() while the server is already listening."
+      );
+    }
+
+    const boundPort = (accepted as PromiseFulfilledResult<{ port: number }>)
+      .value.port;
+    await server.close();
+
+    expect(await isPortOpen(boundPort)).toBe(false);
+  });
+
+  it("allows retry after a failed listen attempt", async () => {
+    // Bind a dummy server to take an ephemeral port
+    const occupiedServer = http.createServer();
+    const occupiedPort = await new Promise<number>((resolve) => {
+      occupiedServer.listen(0, "127.0.0.1", () => {
+        const address = occupiedServer.address();
+        resolve(
+          typeof address === "object" && address !== null ? address.port : 0
+        );
+      });
+    });
+
+    const server = new MCPServer({ name: "retry-test", version: "1.0.0" });
+
+    // Attempting to listen on the occupied port should reject with EADDRINUSE
+    await expect(server.listen(occupiedPort)).rejects.toThrow();
+
+    // Close the dummy server to free the port
+    await new Promise<void>((resolve) => occupiedServer.close(() => resolve()));
+
+    // A subsequent listen attempt should now succeed and not be blocked by the previous failure
+    const retry = await server.listen(occupiedPort);
+    expect(retry.port).toBe(occupiedPort);
+    expect(await isPortOpen(occupiedPort)).toBe(true);
+
+    await server.close();
+    expect(await isPortOpen(occupiedPort)).toBe(false);
+  });
+
+  it("cleans up listener when close() is called while listen() is in-flight", async () => {
+    const server = new MCPServer({
+      name: "close-inflight-test",
+      version: "1.0.0",
+    });
+    const listenPromise = server.listen(0);
+    const closePromise = server.close();
+
+    const [listenResult] = await Promise.allSettled([
+      listenPromise,
+      closePromise,
+    ]);
+    // Either listen was aborted or closed
+    if (listenResult.status === "fulfilled") {
+      expect(await isPortOpen(listenResult.value.port)).toBe(false);
+    }
+  });
+});

--- a/libraries/typescript/packages/server/tests/server-listen-lifecycle.test.ts
+++ b/libraries/typescript/packages/server/tests/server-listen-lifecycle.test.ts
@@ -1,4 +1,5 @@
 import http from "node:http";
+import net from "node:net";
 import { describe, expect, it } from "vitest";
 
 import { MCPServer } from "../src/index.js";
@@ -10,18 +11,6 @@ function isPortOpen(port: number): Promise<boolean> {
       resolve(true);
     });
     req.on("error", () => resolve(false));
-  });
-}
-
-function getFreePort(): Promise<number> {
-  return new Promise((resolve) => {
-    const s = http.createServer();
-    s.listen(0, "127.0.0.1", () => {
-      const address = s.address();
-      const port =
-        typeof address === "object" && address !== null ? address.port : 0;
-      s.close(() => resolve(port));
-    });
   });
 }
 
@@ -102,12 +91,11 @@ describe("MCPServer.listen lifecycle and concurrency", () => {
   });
 
   it("cleans up listener when close() is called while listen() is in-flight", async () => {
-    const targetPort = await getFreePort();
     const server = new MCPServer({
       name: "close-inflight-test",
       version: "1.0.0",
     });
-    const listenPromise = server.listen(targetPort);
+    const listenPromise = server.listen(0);
     const closePromise = server.close();
 
     const [listenResult, closeResult] = await Promise.allSettled([
@@ -121,55 +109,54 @@ describe("MCPServer.listen lifecycle and concurrency", () => {
       expect((listenResult.reason as Error).message).toContain("closed");
     }
 
-    // Deterministically verify the target port is closed and not leaking
-    expect(await isPortOpen(targetPort)).toBe(false);
-
-    // Verify the port is immediately reusable without EADDRINUSE
+    // Verify a fresh server instance can immediately bind port 0 and serve requests without leaked listeners
     const restartServer = new MCPServer({
       name: "restart-test",
       version: "1.0.0",
     });
-    const restartListen = await restartServer.listen(targetPort);
-    expect(restartListen.port).toBe(targetPort);
-    expect(await isPortOpen(targetPort)).toBe(true);
+    const restartListen = await restartServer.listen(0);
+    expect(typeof restartListen.port).toBe("number");
+    expect(await isPortOpen(restartListen.port)).toBe(true);
 
     await restartServer.close();
-    expect(await isPortOpen(targetPort)).toBe(false);
+    expect(await isPortOpen(restartListen.port)).toBe(false);
   });
 
-  it("terminates active connections promptly when shutdown races listen()", async () => {
-    const targetPort = await getFreePort();
+  it("terminates active connections promptly on shutdown", async () => {
     const server = new MCPServer({
-      name: "race-active-req-test",
+      name: "active-conn-test",
       version: "1.0.0",
     });
+    const { port } = await server.listen(0);
+    expect(await isPortOpen(port)).toBe(true);
 
-    const listenPromise = server.listen(targetPort);
-
-    // Send a request immediately as the port is binding
-    const req = http.get(`http://127.0.0.1:${targetPort}/mcp`);
-    req.on("error", () => {
-      // Expected connection reset or abort
+    // Establish and synchronize on a confirmed active socket connection
+    const socket = net.connect(port, "127.0.0.1");
+    await new Promise<void>((resolve, reject) => {
+      socket.once("connect", () => resolve());
+      socket.once("error", reject);
     });
 
-    const closePromise = server.close();
+    const socketClosed = new Promise<void>((resolve) => {
+      if (socket.destroyed) resolve();
+      else socket.once("close", () => resolve());
+    });
 
-    const [, closeResult] = await Promise.allSettled([
-      listenPromise,
-      closePromise,
-    ]);
+    await server.close();
+    await socketClosed;
 
-    expect(closeResult.status).toBe("fulfilled");
-    expect(await isPortOpen(targetPort)).toBe(false);
+    expect(socket.destroyed).toBe(true);
+    expect(await isPortOpen(port)).toBe(false);
 
-    // An immediate restart must succeed
+    // An immediate restart on port 0 must succeed
     const restartServer = new MCPServer({
-      name: "restart-after-race-test",
+      name: "restart-after-close-test",
       version: "1.0.0",
     });
-    const restartListen = await restartServer.listen(targetPort);
-    expect(restartListen.port).toBe(targetPort);
+    const restartListen = await restartServer.listen(0);
+    expect(typeof restartListen.port).toBe("number");
+    expect(await isPortOpen(restartListen.port)).toBe(true);
     await restartServer.close();
-    expect(await isPortOpen(targetPort)).toBe(false);
+    expect(await isPortOpen(restartListen.port)).toBe(false);
   });
 });

--- a/libraries/typescript/packages/server/tests/server-listen-lifecycle.test.ts
+++ b/libraries/typescript/packages/server/tests/server-listen-lifecycle.test.ts
@@ -130,11 +130,12 @@ describe("MCPServer.listen lifecycle and concurrency", () => {
     const { port } = await server.listen(0);
     expect(await isPortOpen(port)).toBe(true);
 
-    // Establish and synchronize on a confirmed active socket connection
+    // Establish a confirmed active connection that the server has accepted and responded to
     const socket = net.connect(port, "127.0.0.1");
     await new Promise<void>((resolve, reject) => {
-      socket.once("connect", () => resolve());
+      socket.once("data", () => resolve());
       socket.once("error", reject);
+      socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
     });
 
     const socketClosed = new Promise<void>((resolve) => {


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Prevents overlapping `MCPServer.listen()` invocations, guards against duplicate listener allocation, and prevents leaking orphaned background HTTP servers during repeated startup, concurrent initialization, or shutdown.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Problem Statement & Root Cause

Previously, `MCPServer.listen()` did not maintain an in-flight startup lock or check whether an active listener was already bound:
1. **Repeated startup**: Calling `server.listen()` again would allocate a new `NodeHttpServer`, bind an additional port, and overwrite `this.#httpServer`.
2. **Concurrent startup**: Concurrent `server.listen()` invocations (e.g. `Promise.all([server.listen(0), server.listen(0)])`) both passed the open guard and concurrently initialized independent HTTP listeners.
3. **Leaked background listeners**: When `server.close()` was subsequently invoked, only the final `this.#httpServer` reference was closed. The previously bound HTTP listener remained open in the background, accepting traffic, consuming sockets, and preventing clean process termination.

## Implementation Details

1. Added private `#listenPromise: Promise<{ port: number; url: string }> | undefined` to track in-flight startup.
2. Synchronously check `this.#httpServer !== undefined || this.#listenPromise !== undefined` at the entry of `listen()`, rejecting concurrent or repeated invocations with:
   `Cannot call listen() while the server is already listening.`
3. Reset `#listenPromise` on startup failure or upon completion, and only set `this.#httpServer = server` once binding completes.
4. If startup fails (e.g. port already in use), all state is cleanly reset so callers can retry on an alternative port.
5. In `close()`, await `#listenPromise` if startup is in-flight to ensure any listener bound during shutdown is cleanly terminated.
6. Added automated unit tests in `packages/server/tests/server-listen-lifecycle.test.ts` covering repeated startup rejection, deterministic concurrent calls, listener cleanup verification, retry after failure, and in-flight close cancellation.

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [ ] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [x] `mcp-use` (server)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```typescript
const server = new MCPServer({ name: "my-server", version: "1.0.0" });

// Concurrent or repeated listen() created multiple HTTP listeners
const [res1, res2] = await Promise.all([server.listen(0), server.listen(0)]);

// Closing server only closed res2; res1 remained leaked and accepting requests
await server.close();
```

## Example Usage (After)

```typescript
const server = new MCPServer({ name: "my-server", version: "1.0.0" });

// Exactly one call is accepted; concurrent call rejects deterministically
const [res1, res2] = await Promise.allSettled([server.listen(0), server.listen(0)]);

// Clean teardown ensures all listeners are closed
await server.close();
```

## Documentation Updates

No documentation updates required (internal lifecycle and concurrency hardening).

## Testing

- Added `packages/server/tests/server-listen-lifecycle.test.ts` testing:
  - Repeated `listen()` rejection without listener leakage.
  - Deterministic concurrent startup (one accepted, one rejected) with zero leaked sockets.
  - Successful retry on free port after startup failure.
  - Teardown when `close()` is called while `listen()` is in-flight.
- Ran full test suite: `pnpm --filter mcp-use test` (45 test files, 479 passed).
- Ran formatting and linting: `pnpm format && pnpm lint` (0 errors, 0 warnings).
- Ran build: `pnpm --filter mcp-use build` (built cleanly).

## Backwards Compatibility

Fully backwards compatible. Single-call `server.listen()` behavior is completely unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `MCPServer.listen()` from being called twice or concurrently, which previously leaked background HTTP listeners that kept accepting traffic after `close()`.

**Bug Fixes**
- Repeated or concurrent `listen()` calls now reject with "Cannot call listen() while the server is already listening."
- `close()` waits for an in-flight startup, terminates active connections, and shuts down any listener bound during it.
- Startup failure resets internal state so a retry on another port works.
- Single-call `listen()` behavior is unchanged; tests cover duplicate calls, concurrent calls, retry after failure, close during startup, and active-connection shutdown.

<sup>Written for commit b12d81360d7bb88f6b17b281d661ee3c03437d33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

