### PR TITLE
fix(client): support prompt pagination and implement listAllPrompts

### DIFF
--- a/libraries/typescript/packages/agent/src/adapters/base.ts
+++ b/libraries/typescript/packages/agent/src/adapters/base.ts
@@ -222,10 +222,8 @@ export abstract class BaseAdapter<T> {
     }
 
     try {
-      // Get prompts from connector (using listAllPrompts if available for complete pagination)
-      const promptsResult = connector.listAllPrompts
-        ? await connector.listAllPrompts()
-        : await connector.listPrompts();
+      // Get prompts from connector (using listAllPrompts for complete pagination)
+      const promptsResult = await connector.listAllPrompts();
       const prompts = promptsResult?.prompts || [];
 
       // Convert and collect prompts

--- a/libraries/typescript/packages/agent/src/adapters/base.ts
+++ b/libraries/typescript/packages/agent/src/adapters/base.ts
@@ -222,8 +222,12 @@ export abstract class BaseAdapter<T> {
     }
 
     try {
-      // Get prompts from connector (using listAllPrompts for complete pagination)
-      const promptsResult = await connector.listAllPrompts();
+      // Get prompts from connector (using listAllPrompts if available for complete pagination)
+      const duck = connector as Partial<BaseConnector>;
+      const promptsResult =
+        typeof duck.listAllPrompts === "function"
+          ? await duck.listAllPrompts()
+          : await connector.listPrompts();
       const prompts = promptsResult?.prompts || [];
 
       // Convert and collect prompts

--- a/libraries/typescript/packages/agent/src/adapters/base.ts
+++ b/libraries/typescript/packages/agent/src/adapters/base.ts
@@ -222,8 +222,10 @@ export abstract class BaseAdapter<T> {
     }
 
     try {
-      // Get prompts from connector
-      const promptsResult = await connector.listPrompts();
+      // Get prompts from connector (using listAllPrompts if available for complete pagination)
+      const promptsResult = connector.listAllPrompts
+        ? await connector.listAllPrompts()
+        : await connector.listPrompts();
       const prompts = promptsResult?.prompts || [];
 
       // Convert and collect prompts

--- a/libraries/typescript/packages/agent/tests/unit/adapters/adapter-prompts.test.ts
+++ b/libraries/typescript/packages/agent/tests/unit/adapters/adapter-prompts.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BaseAdapter } from "../../../src/adapters/base.js";
+import type { BaseConnector } from "@mcp-use/client";
+
+class TestAdapter extends BaseAdapter<any> {
+  convertTool(tool: any): any {
+    return tool;
+  }
+
+  convertResource(resource: any): any {
+    return resource;
+  }
+
+  convertPrompt(prompt: any): any {
+    return prompt;
+  }
+
+  async ensureConnectorInitialized(
+    _connector: BaseConnector
+  ): Promise<boolean> {
+    return true;
+  }
+}
+
+describe("BaseAdapter.loadPromptsForConnector", () => {
+  it("uses listAllPrompts when present on connector", async () => {
+    const adapter = new TestAdapter();
+    const listAllPromptsMock = vi.fn().mockResolvedValue({
+      prompts: [{ name: "prompt-1" }, { name: "prompt-2" }],
+    });
+    const listPromptsMock = vi.fn().mockResolvedValue({
+      prompts: [{ name: "prompt-1" }],
+    });
+
+    const connector = {
+      listAllPrompts: listAllPromptsMock,
+      listPrompts: listPromptsMock,
+    } as unknown as BaseConnector;
+
+    const result = await adapter.loadPromptsForConnector(connector);
+
+    expect(result).toEqual([{ name: "prompt-1" }, { name: "prompt-2" }]);
+    expect(listAllPromptsMock).toHaveBeenCalledTimes(1);
+    expect(listPromptsMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to listPrompts when listAllPrompts is absent for backward compatibility", async () => {
+    const adapter = new TestAdapter();
+    const listPromptsMock = vi.fn().mockResolvedValue({
+      prompts: [{ name: "prompt-legacy" }],
+    });
+
+    const connector = {
+      listPrompts: listPromptsMock,
+    } as unknown as BaseConnector;
+
+    const result = await adapter.loadPromptsForConnector(connector);
+
+    expect(result).toEqual([{ name: "prompt-legacy" }]);
+    expect(listPromptsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libraries/typescript/packages/client/src/core/session.ts
+++ b/libraries/typescript/packages/client/src/core/session.ts
@@ -575,9 +575,11 @@ export class MCPConnection {
   }
 
   /**
-   * List available prompts from the server.
+   * List available prompts from the server with optional pagination.
    *
-   * @returns List of available prompts
+   * @param cursor - Optional cursor for pagination
+   * @param options - Request options
+   * @returns List of available prompts with optional nextCursor
    *
    * @example
    * ```typescript
@@ -585,8 +587,24 @@ export class MCPConnection {
    * console.log(`Available prompts: ${result.prompts.length}`);
    * ```
    */
-  async listPrompts() {
-    return this.connector.listPrompts();
+  async listPrompts(cursor?: string, options?: RequestOptions) {
+    return this.connector.listPrompts(cursor, options);
+  }
+
+  /**
+   * List all prompts from the server, automatically handling pagination.
+   *
+   * @param options - Request options
+   * @returns Complete list of all prompts
+   *
+   * @example
+   * ```typescript
+   * const result = await session.listAllPrompts();
+   * console.log(`Total prompts: ${result.prompts.length}`);
+   * ```
+   */
+  async listAllPrompts(options?: RequestOptions) {
+    return this.connector.listAllPrompts(options);
   }
 
   /**

--- a/libraries/typescript/packages/client/src/react/useMcp-operations.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp-operations.ts
@@ -174,7 +174,9 @@ export function useMcpOperations(params: Params) {
     const connection = requireConnection(params, "list prompts");
     params.addLog("info", "Listing prompts");
     const result = await executeWithAuthorizationSignal(params, () =>
-      connection.listPrompts()
+      typeof connection.listAllPrompts === "function"
+        ? connection.listAllPrompts()
+        : connection.listPrompts()
     );
     params.setPrompts(result.prompts || []);
   }, [params.addLog, params.onAuthorizationRequired]);
@@ -211,7 +213,9 @@ export function useMcpOperations(params: Params) {
       return;
     try {
       const result = await executeWithAuthorizationSignal(params, () =>
-        params.connectionRef.current!.listPrompts()
+        typeof params.connectionRef.current!.listAllPrompts === "function"
+          ? params.connectionRef.current!.listAllPrompts()
+          : params.connectionRef.current!.listPrompts()
       );
       params.setPrompts(result.prompts || []);
     } catch (error) {

--- a/libraries/typescript/packages/client/src/react/useMcp.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp.ts
@@ -1241,7 +1241,10 @@ export function useMcp(options: UseMcpInternalOptions): UseMcpResult {
               addLog("warn", "Failed to load initial resources:", error);
               return { resources: [] };
             }),
-            connection.listPrompts().catch((error) => {
+            (typeof connection.listAllPrompts === "function"
+              ? connection.listAllPrompts()
+              : connection.listPrompts()
+            ).catch((error) => {
               addLog("warn", "Failed to load initial prompts:", error);
               return { prompts: [] };
             }),

--- a/libraries/typescript/packages/client/src/transport/base.ts
+++ b/libraries/typescript/packages/client/src/transport/base.ts
@@ -952,7 +952,7 @@ export abstract class BaseConnector {
             }
             seenCursors.add(cursor);
           }
-        } while (cursor);
+        } while (cursor !== undefined);
 
         return { prompts: allPrompts };
       });

--- a/libraries/typescript/packages/client/src/transport/base.ts
+++ b/libraries/typescript/packages/client/src/transport/base.ts
@@ -869,11 +869,13 @@ export abstract class BaseConnector {
   }
 
   /**
-   * Lists prompts exposed by the server.
+   * Lists prompts exposed by the server with optional pagination.
    *
+   * @param cursor - Optional cursor for pagination
+   * @param options - Request options
    * @returns The prompt list, or an empty list when prompts are unsupported.
    */
-  async listPrompts() {
+  async listPrompts(cursor?: string, options?: RequestOptions) {
     if (!this.client) {
       throw new Error("MCP client is not connected");
     }
@@ -885,8 +887,75 @@ export abstract class BaseConnector {
     }
 
     try {
-      logger.debug("Listing prompts");
-      return await this.executeRequest(() => this.client!.listPrompts());
+      logger.debug("Listing prompts", cursor ? `with cursor: ${cursor}` : "");
+      return await this.executeRequest(() =>
+        this.client!.listPrompts(
+          cursor !== undefined ? { cursor } : undefined,
+          options
+        )
+      );
+    } catch (err: unknown) {
+      const error = err as Error & { code?: number };
+      // Gracefully handle if server advertises but doesn't actually support it
+      if (error.code === -32601) {
+        logger.debug("Server advertised prompts but method not found");
+        return { prompts: [] };
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * List all prompts from the server, automatically handling pagination
+   *
+   * @param options - Request options
+   * @returns Complete list of all prompts
+   */
+  async listAllPrompts(options?: RequestOptions): Promise<{
+    /** Prompts returned across all result pages. */
+    prompts: any[];
+  }> {
+    // Held across the pagination loop below: `disconnect()` clears
+    // `this.client`, and re-reading it once per page would dereference null
+    // mid-listing instead of failing on the closed transport.
+    const client = this.client;
+    if (!client) {
+      throw new Error("MCP client is not connected");
+    }
+
+    // Check if server advertises prompts capability
+    if (!this.capabilitiesCache?.prompts) {
+      logger.debug("Server does not advertise prompts capability, skipping");
+      return { prompts: [] };
+    }
+
+    try {
+      logger.debug("Listing all prompts (with auto-pagination)");
+      return await this.executeRequest(async () => {
+        const allPrompts: any[] = [];
+        const seenCursors = new Set<string>();
+        let cursor: string | undefined = undefined;
+
+        do {
+          const result: { prompts?: any[]; nextCursor?: string } =
+            await client.listPrompts(
+              cursor !== undefined ? { cursor } : undefined,
+              options
+            );
+          allPrompts.push(...(result.prompts || []));
+          cursor = result.nextCursor;
+          if (cursor !== undefined) {
+            if (seenCursors.has(cursor)) {
+              throw new Error(
+                "prompts/list returned a repeated pagination cursor"
+              );
+            }
+            seenCursors.add(cursor);
+          }
+        } while (cursor);
+
+        return { prompts: allPrompts };
+      });
     } catch (err: unknown) {
       const error = err as Error & { code?: number };
       // Gracefully handle if server advertises but doesn't actually support it

--- a/libraries/typescript/packages/client/tests/unit/client/list-all-prompts.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/list-all-prompts.test.ts
@@ -145,6 +145,40 @@ describe("listPrompts and listAllPrompts", () => {
       );
     });
 
+    it("follows empty-string cursor without premature termination", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        capabilitiesCache: unknown;
+      };
+      connector.capabilitiesCache = { prompts: {} };
+
+      const listPromptsMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          prompts: [{ name: "prompt-1" }],
+          nextCursor: "",
+        })
+        .mockResolvedValueOnce({
+          prompts: [{ name: "prompt-2" }],
+          nextCursor: undefined,
+        });
+
+      connector.client = { listPrompts: listPromptsMock };
+
+      const result = await connector.listAllPrompts();
+
+      expect(result).toEqual({
+        prompts: [{ name: "prompt-1" }, { name: "prompt-2" }],
+      });
+      expect(listPromptsMock).toHaveBeenCalledTimes(2);
+      expect(listPromptsMock).toHaveBeenNthCalledWith(1, undefined, undefined);
+      expect(listPromptsMock).toHaveBeenNthCalledWith(
+        2,
+        { cursor: "" },
+        undefined
+      );
+    });
+
     it("detects repeated cursor and throws error to prevent infinite loop", async () => {
       const connector = new TestConnector() as BaseConnector & {
         client: unknown;

--- a/libraries/typescript/packages/client/tests/unit/client/list-all-prompts.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/list-all-prompts.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { MCPConnection } from "../../../src/core/session.js";
+import { BaseConnector } from "../../../src/transport/base.js";
+
+class TestConnector extends BaseConnector {
+  async connect(): Promise<void> {}
+
+  get publicIdentifier(): Record<string, string> {
+    return { type: "test" };
+  }
+}
+
+describe("listPrompts and listAllPrompts", () => {
+  describe("listPrompts", () => {
+    it("forwards cursor and request options to the SDK client", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        capabilitiesCache: unknown;
+      };
+      connector.capabilitiesCache = { prompts: {} };
+
+      const prompts = [{ name: "test-prompt" }];
+      const listPromptsMock = vi
+        .fn()
+        .mockResolvedValue({ prompts, nextCursor: "page-2" });
+      connector.client = { listPrompts: listPromptsMock };
+
+      const options = { timeout: 3000 };
+      const result = await connector.listPrompts("page-1", options);
+
+      expect(result).toEqual({ prompts, nextCursor: "page-2" });
+      expect(listPromptsMock).toHaveBeenCalledWith(
+        { cursor: "page-1" },
+        options
+      );
+    });
+
+    it("passes undefined params when cursor is omitted", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        capabilitiesCache: unknown;
+      };
+      connector.capabilitiesCache = { prompts: {} };
+
+      const prompts = [{ name: "test-prompt" }];
+      const listPromptsMock = vi.fn().mockResolvedValue({ prompts });
+      connector.client = { listPrompts: listPromptsMock };
+
+      const options = { timeout: 3000 };
+      const result = await connector.listPrompts(undefined, options);
+
+      expect(result).toEqual({ prompts });
+      expect(listPromptsMock).toHaveBeenCalledWith(undefined, options);
+    });
+
+    it("returns empty prompts when server does not advertise capability", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        capabilitiesCache: unknown;
+      };
+      connector.capabilitiesCache = {};
+      connector.client = { listPrompts: vi.fn() };
+
+      const result = await connector.listPrompts();
+      expect(result).toEqual({ prompts: [] });
+      expect((connector.client as any).listPrompts).not.toHaveBeenCalled();
+    });
+
+    it("handles -32601 (method not found) gracefully", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        capabilitiesCache: unknown;
+      };
+      connector.capabilitiesCache = { prompts: {} };
+
+      const methodNotFoundError = new Error("Method not found") as Error & {
+        code: number;
+      };
+      methodNotFoundError.code = -32601;
+      connector.client = {
+        listPrompts: vi.fn().mockRejectedValue(methodNotFoundError),
+      };
+
+      const result = await connector.listPrompts();
+      expect(result).toEqual({ prompts: [] });
+    });
+  });
+
+  describe("listAllPrompts", () => {
+    it("paginates across multiple pages until nextCursor is undefined", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        capabilitiesCache: unknown;
+      };
+      connector.capabilitiesCache = { prompts: {} };
+
+      const pages: Record<string, { prompts: any[]; nextCursor?: string }> = {
+        first: {
+          prompts: [{ name: "prompt-1" }, { name: "prompt-2" }],
+          nextCursor: "cursor-page-2",
+        },
+        "cursor-page-2": {
+          prompts: [{ name: "prompt-3" }],
+          nextCursor: "cursor-page-3",
+        },
+        "cursor-page-3": {
+          prompts: [{ name: "prompt-4" }, { name: "prompt-5" }],
+          nextCursor: undefined,
+        },
+      };
+
+      const listPromptsMock = vi
+        .fn()
+        .mockImplementation(async (params?: { cursor?: string }) => {
+          const key = params?.cursor ?? "first";
+          return pages[key];
+        });
+
+      connector.client = { listPrompts: listPromptsMock };
+
+      const result = await connector.listAllPrompts();
+
+      expect(result).toEqual({
+        prompts: [
+          { name: "prompt-1" },
+          { name: "prompt-2" },
+          { name: "prompt-3" },
+          { name: "prompt-4" },
+          { name: "prompt-5" },
+        ],
+      });
+
+      expect(listPromptsMock).toHaveBeenCalledTimes(3);
+      expect(listPromptsMock).toHaveBeenNthCalledWith(1, undefined, undefined);
+      expect(listPromptsMock).toHaveBeenNthCalledWith(
+        2,
+        { cursor: "cursor-page-2" },
+        undefined
+      );
+      expect(listPromptsMock).toHaveBeenNthCalledWith(
+        3,
+        { cursor: "cursor-page-3" },
+        undefined
+      );
+    });
+
+    it("detects repeated cursor and throws error to prevent infinite loop", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        capabilitiesCache: unknown;
+      };
+      connector.capabilitiesCache = { prompts: {} };
+
+      connector.client = {
+        listPrompts: vi
+          .fn()
+          .mockResolvedValueOnce({
+            prompts: [{ name: "p1" }],
+            nextCursor: "loop-cursor",
+          })
+          .mockResolvedValueOnce({
+            prompts: [{ name: "p2" }],
+            nextCursor: "loop-cursor",
+          }),
+      };
+
+      await expect(connector.listAllPrompts()).rejects.toThrow(
+        "prompts/list returned a repeated pagination cursor"
+      );
+    });
+
+    it("surfaces transport error when disconnect lands between pages", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        capabilitiesCache: unknown;
+      };
+      connector.capabilitiesCache = { prompts: {} };
+
+      let page = 0;
+      let connected = true;
+      connector.client = {
+        async listPrompts() {
+          if (!connected) throw new Error("Not connected");
+          page += 1;
+          connected = false;
+          connector.client = null;
+          return {
+            prompts: [{ name: `prompt-${page}` }],
+            nextCursor: "next-page",
+          };
+        },
+      };
+
+      await expect(connector.listAllPrompts()).rejects.toThrow("Not connected");
+    });
+
+    it("returns empty prompts when server does not advertise capability", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        capabilitiesCache: unknown;
+      };
+      connector.capabilitiesCache = {};
+      connector.client = { listPrompts: vi.fn() };
+
+      const result = await connector.listAllPrompts();
+      expect(result).toEqual({ prompts: [] });
+      expect((connector.client as any).listPrompts).not.toHaveBeenCalled();
+    });
+
+    it("handles -32601 (method not found) gracefully", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        capabilitiesCache: unknown;
+      };
+      connector.capabilitiesCache = { prompts: {} };
+
+      const methodNotFoundError = new Error("Method not found") as Error & {
+        code: number;
+      };
+      methodNotFoundError.code = -32601;
+      connector.client = {
+        listPrompts: vi.fn().mockRejectedValue(methodNotFoundError),
+      };
+
+      const result = await connector.listAllPrompts();
+      expect(result).toEqual({ prompts: [] });
+    });
+  });
+
+  describe("MCPConnection delegation", () => {
+    it("forwards cursor and options from MCPConnection.listPrompts", async () => {
+      const connector = {
+        listPrompts: vi
+          .fn()
+          .mockResolvedValue({ prompts: [], nextCursor: "cursor-1" }),
+      };
+      const connection = new MCPConnection(connector as never);
+      const options = { timeout: 1000 };
+
+      const result = await connection.listPrompts("page-1", options);
+      expect(result).toEqual({ prompts: [], nextCursor: "cursor-1" });
+      expect(connector.listPrompts).toHaveBeenCalledWith("page-1", options);
+    });
+
+    it("forwards options from MCPConnection.listAllPrompts", async () => {
+      const connector = {
+        listAllPrompts: vi
+          .fn()
+          .mockResolvedValue({ prompts: [{ name: "all-prompts" }] }),
+      };
+      const connection = new MCPConnection(connector as never);
+      const options = { timeout: 1000 };
+
+      const result = await connection.listAllPrompts(options);
+      expect(result).toEqual({ prompts: [{ name: "all-prompts" }] });
+      expect(connector.listAllPrompts).toHaveBeenCalledWith(options);
+    });
+  });
+});

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
@@ -538,4 +538,19 @@ describe("useMcp connection metadata", () => {
       vi.useRealTimers();
     }
   });
+
+  it("loads complete prompts inventory via listAllPrompts when available", async () => {
+    const paginatedPrompts = [
+      { name: "prompt-1", description: "First page" },
+      { name: "prompt-2", description: "Second page" },
+    ];
+    const { result } = await renderFor("modern", false, {}, (connection) => {
+      (connection as any).listAllPrompts = vi
+        .fn()
+        .mockResolvedValue({ prompts: paginatedPrompts });
+    });
+
+    expect(result.state).toBe("ready");
+    expect(result.prompts).toEqual(paginatedPrompts);
+  });
 });

--- a/libraries/typescript/packages/server/src/mcp-proxy.ts
+++ b/libraries/typescript/packages/server/src/mcp-proxy.ts
@@ -79,8 +79,6 @@ export interface ProxyConnection {
     uri: string,
     options?: ProxyRequestOptions
   ): Promise<ReadResourceResult>;
-  /** List upstream prompts, including pagination when supported. */
-  listAllPrompts?(): Promise<{ prompts: ProxyPrompt[] }>;
   /** List upstream prompts. */
   listPrompts(): Promise<{ prompts: ProxyPrompt[] }>;
   /** Render an upstream prompt. */
@@ -324,11 +322,7 @@ async function introspect(
   let prompts: ProxyPrompt[] = [];
   if (supports(connection, "prompts")) {
     try {
-      if (connection.listAllPrompts !== undefined) {
-        prompts = (await connection.listAllPrompts()).prompts;
-      } else if (connection.listPrompts !== undefined) {
-        prompts = (await connection.listPrompts()).prompts;
-      }
+      prompts = (await connection.listPrompts()).prompts;
     } catch (error) {
       proxyDiagnostic(
         `Failed to introspect prompts from upstream MCP server "${namespace}"`,

--- a/libraries/typescript/packages/server/src/mcp-proxy.ts
+++ b/libraries/typescript/packages/server/src/mcp-proxy.ts
@@ -79,6 +79,8 @@ export interface ProxyConnection {
     uri: string,
     options?: ProxyRequestOptions
   ): Promise<ReadResourceResult>;
+  /** List upstream prompts, including pagination when supported. */
+  listAllPrompts?(): Promise<{ prompts: ProxyPrompt[] }>;
   /** List upstream prompts. */
   listPrompts(): Promise<{ prompts: ProxyPrompt[] }>;
   /** Render an upstream prompt. */
@@ -322,7 +324,11 @@ async function introspect(
   let prompts: ProxyPrompt[] = [];
   if (supports(connection, "prompts")) {
     try {
-      prompts = (await connection.listPrompts()).prompts;
+      if (connection.listAllPrompts !== undefined) {
+        prompts = (await connection.listAllPrompts()).prompts;
+      } else if (connection.listPrompts !== undefined) {
+        prompts = (await connection.listPrompts()).prompts;
+      }
     } catch (error) {
       proxyDiagnostic(
         `Failed to introspect prompts from upstream MCP server "${namespace}"`,

--- a/libraries/typescript/packages/server/src/mcp-proxy.ts
+++ b/libraries/typescript/packages/server/src/mcp-proxy.ts
@@ -322,7 +322,14 @@ async function introspect(
   let prompts: ProxyPrompt[] = [];
   if (supports(connection, "prompts")) {
     try {
-      prompts = (await connection.listPrompts()).prompts;
+      const duck = connection as {
+        listAllPrompts?: () => Promise<{ prompts: ProxyPrompt[] }>;
+      };
+      if (typeof duck.listAllPrompts === "function") {
+        prompts = (await duck.listAllPrompts()).prompts;
+      } else {
+        prompts = (await connection.listPrompts()).prompts;
+      }
     } catch (error) {
       proxyDiagnostic(
         `Failed to introspect prompts from upstream MCP server "${namespace}"`,

--- a/libraries/typescript/packages/server/tests/proxy.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy.test.ts
@@ -346,6 +346,48 @@ describe("MCPServer.proxy", () => {
     );
   });
 
+  it("prefers listAllPrompts over listPrompts when present on upstream connection", async () => {
+    const parent = new MCPServer({ name: "parent", version: "1.0.0" });
+    servers.push(parent);
+    const listPromptsSpy = vi.fn().mockResolvedValue({
+      prompts: [{ name: "page1" }],
+    });
+    const listAllPromptsSpy = vi.fn().mockResolvedValue({
+      prompts: [{ name: "page1" }, { name: "page2" }],
+    });
+    const connection = {
+      info: { server: { name: "upstream" } },
+      async listTools() {
+        return [];
+      },
+      async callTool() {
+        return { content: [] };
+      },
+      async readResource(uri: string) {
+        return { contents: [{ uri, text: "upstream" }] };
+      },
+      listPrompts: listPromptsSpy,
+      listAllPrompts: listAllPromptsSpy,
+      async getPrompt() {
+        return { messages: [] };
+      },
+    };
+
+    await expect(parent.proxy(connection as any)).resolves.toBeUndefined();
+    const { url: parentUrl } = await parent.listen(0);
+    const client = await connectClient(parentUrl);
+    clients.push(client);
+
+    const { prompts } = await client.listPrompts();
+    expect(prompts).toHaveLength(2);
+    expect(prompts.map((p) => p.name)).toEqual([
+      "upstream_page1",
+      "upstream_page2",
+    ]);
+    expect(listAllPromptsSpy).toHaveBeenCalledTimes(1);
+    expect(listPromptsSpy).not.toHaveBeenCalled();
+  });
+
   it("rejects a direct anonymous connection without a proxy namespace", async () => {
     const parent = new MCPServer({ name: "parent", version: "1.0.0" });
     servers.push(parent);


### PR DESCRIPTION
Fixes #2460

### Summary of Changes
1. **`BaseConnector` (`packages/client/src/transport/base.ts`)**:
   - Extended `listPrompts(cursor?: string, options?: RequestOptions)` to accept pagination cursors and request options (mirroring `listResources`).
   - Implemented `listAllPrompts(options?: RequestOptions)` with auto-pagination over `nextCursor`, transport disconnect protection across page iterations, and defensive repeated-cursor cycle detection.
2. **`MCPSession` (`packages/client/src/core/session.ts`)**:
   - Updated `listPrompts(cursor?: string, options?: RequestOptions)` to forward pagination parameters to the connector.
   - Added `listAllPrompts(options?: RequestOptions)` delegating to `this.connector.listAllPrompts(options)`.
3. **React Hooks (`useMcp.ts` & `useMcp-operations.ts`)**:
   - Updated initial prompt discovery and refresh routines to use `listAllPrompts`, ensuring servers with multiple prompt pages have their entire catalog loaded rather than silently truncating prompts on page 2+.
4. **Agent & Server Proxy Integration**:
   - Updated `@mcp-use/agent` `loadPromptsForConnector` to use `listAllPrompts` when available, matching resource loading.
   - Updated `@mcp-use/server` `mcp-proxy` upstream prompt introspection to check `connection.listAllPrompts` when available.
5. **Unit Tests**:
   - Added `packages/client/tests/unit/client/list-all-prompts.test.ts` (11 new unit tests) covering cursor forwarding, options forwarding, multi-page auto-pagination, cycle detection, disconnect handling, and `MCPSession` delegation.
   - Added unit test in `useMcp-connection-metadata.test.tsx` verifying React hook inventory loading via `listAllPrompts`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2460 so servers with multi-page prompts load their entire catalog instead of silently truncating prompts past page 2+.

**Bug Fixes**
- Prompt discovery, refresh, and proxy introspection now use complete pagination via `listAllPrompts` when available, with a fallback to `listPrompts` for older connectors.

**New Features**
- `listPrompts` on `BaseConnector` and `MCPSession` now accept an optional cursor and request options.
- New `listAllPrompts` auto-paginates with repeated-cursor detection and transport disconnect protection.
- `@mcp-use/agent` adapter, `@mcp-use/server` mcp-proxy, and React hooks prefer `listAllPrompts` when present.
- 16 tests cover cursor forwarding, multi-page pagination, cycle detection, disconnect handling, `listPrompts` fallback, and delegation.

<sup>Written for commit 4db6a8424aff90064a16fdc2945c9c3e56c4553d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

