### PR TITLE
fix(agent): forward RunOptions.messages in LangChain agent

### DIFF
--- a/libraries/typescript/.changeset/fix-langchain-run-options-messages.md
+++ b/libraries/typescript/.changeset/fix-langchain-run-options-messages.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/agent": patch
+---
+
+Forward RunOptions.messages in LangChain agent (fixes #2462).
+
+The LangChain agent silently dropped RunOptions.messages because normalizeRunOptions did not propagate the field. The messages are now converted from provider-neutral format to LangChain BaseMessage instances and inserted between externalHistory and the current prompt in both stream() and streamEvents().

--- a/libraries/typescript/packages/agent/src/agents/mcp_agent.ts
+++ b/libraries/typescript/packages/agent/src/agents/mcp_agent.ts
@@ -478,6 +478,12 @@ export class MCPAgent {
       );
     }
     if (this.isRemote && this.remoteAgent) {
+      if (options.messages?.length) {
+        throw new Error(
+          "RunOptions.messages is not supported in remote mode. " +
+            "The remote agent protocol does not carry a pre-seeded message list."
+        );
+      }
       return this.remoteAgent.run(
         options.prompt ?? "",
         options.maxSteps,
@@ -538,6 +544,12 @@ export class MCPAgent {
       signal
     );
     if (this.isRemote && this.remoteAgent) {
+      if (options.messages?.length) {
+        throw new Error(
+          "RunOptions.messages is not supported in remote mode. " +
+            "The remote agent protocol does not carry a pre-seeded message list."
+        );
+      }
       const result = await this.remoteAgent.run(
         options.prompt ?? "",
         options.maxSteps,

--- a/libraries/typescript/packages/agent/src/agents/mcp_agent_langchain.ts
+++ b/libraries/typescript/packages/agent/src/agents/mcp_agent_langchain.ts
@@ -1330,6 +1330,12 @@ export class MCPAgent {
 
     // Delegate to remote agent if in remote mode
     if (this.isRemote && this.remoteAgent) {
+      if (extraMessages?.length) {
+        throw new Error(
+          "RunOptions.messages is not supported in remote mode. " +
+            "The remote agent protocol does not carry a pre-seeded message list."
+        );
+      }
       const result = await this.remoteAgent.run(
         query,
         steps,
@@ -1887,6 +1893,19 @@ export class MCPAgent {
       outputSchema: schema,
       signal: abortSignal,
     } = normalized;
+
+    // Delegate to remote agent if in remote mode (streamEvents is not supported remotely)
+    if (this.isRemote && this.remoteAgent) {
+      if (extraMessages?.length) {
+        throw new Error(
+          "RunOptions.messages is not supported in remote mode. " +
+            "The remote agent protocol does not carry a pre-seeded message list."
+        );
+      }
+      throw new Error(
+        "streamEvents() is not supported in remote mode. Use stream() or run() instead."
+      );
+    }
 
     let initializedHere = false;
     const startTime = Date.now();

--- a/libraries/typescript/packages/agent/src/agents/mcp_agent_langchain.ts
+++ b/libraries/typescript/packages/agent/src/agents/mcp_agent_langchain.ts
@@ -140,9 +140,15 @@ function convertProviderMessagesToLangChain(
       return new AIMessageCls(content);
     }
     if (m.role === "tool") {
+      if (!m.toolCallId) {
+        throw new Error(
+          "RunOptions.messages: tool message is missing toolCallId. " +
+            "Every tool message must reference the id of the assistant tool call it responds to."
+        );
+      }
       return new ToolMessageCls({
         content,
-        tool_call_id: m.toolCallId ?? "",
+        tool_call_id: m.toolCallId,
       });
     }
     return new HumanMessageCls(content);
@@ -1250,6 +1256,12 @@ export class MCPAgent {
 
     // Delegate to remote agent if in remote mode
     if (this.isRemote && this.remoteAgent) {
+      if (extraMessages?.length) {
+        throw new Error(
+          "RunOptions.messages is not supported in remote mode. " +
+            "The remote agent protocol does not carry a pre-seeded message list."
+        );
+      }
       return this.remoteAgent.run(query, steps, manage, history, schema);
     }
 

--- a/libraries/typescript/packages/agent/src/agents/mcp_agent_langchain.ts
+++ b/libraries/typescript/packages/agent/src/agents/mcp_agent_langchain.ts
@@ -55,6 +55,7 @@ export interface AgentStep {
 }
 
 import type { RunOptions } from "./run_options.js";
+import type { ProviderMessage } from "../llm/types.js";
 
 /**
  * Helper function to normalize run options from either old-style positional arguments
@@ -72,6 +73,7 @@ function normalizeRunOptions<T>(
   maxSteps?: number;
   manageConnector?: boolean;
   externalHistory?: BaseMessage[];
+  messages?: ProviderMessage[];
   outputSchema?: ZodSchema<T>;
   signal?: AbortSignal;
 } {
@@ -83,6 +85,7 @@ function normalizeRunOptions<T>(
       maxSteps: options.maxSteps,
       manageConnector: options.manageConnector,
       externalHistory: options.externalHistory,
+      messages: options.messages,
       outputSchema: options.schema,
       signal: options.signal,
     };
@@ -97,6 +100,53 @@ function normalizeRunOptions<T>(
     outputSchema,
     signal,
   };
+}
+
+/**
+ * Convert provider-neutral ProviderMessage[] to LangChain BaseMessage[].
+ *
+ * Supports user, assistant (with optional tool calls), tool, and system roles.
+ */
+function convertProviderMessagesToLangChain(
+  messages: ProviderMessage[],
+  HumanMessageCls: typeof HumanMessage,
+  AIMessageCls: typeof AIMessage,
+  SystemMessageCls: typeof SystemMessage,
+  ToolMessageCls: typeof ToolMessage
+): BaseMessage[] {
+  return messages.map((m) => {
+    const content =
+      typeof m.content === "string"
+        ? m.content
+        : m.content.map((p) => (p.type === "text" ? p.text : "")).join("");
+
+    if (m.role === "user") {
+      return new HumanMessageCls(content);
+    }
+    if (m.role === "system") {
+      return new SystemMessageCls(content);
+    }
+    if (m.role === "assistant") {
+      if (m.toolCalls?.length) {
+        return new AIMessageCls({
+          content,
+          tool_calls: m.toolCalls.map((tc) => ({
+            id: tc.id,
+            name: tc.name,
+            args: tc.args,
+          })),
+        });
+      }
+      return new AIMessageCls(content);
+    }
+    if (m.role === "tool") {
+      return new ToolMessageCls({
+        content,
+        tool_call_id: m.toolCallId ?? "",
+      });
+    }
+    return new HumanMessageCls(content);
+  });
 }
 
 /** Runs a LangChain tool-calling agent against MCP servers. */
@@ -1186,6 +1236,7 @@ export class MCPAgent {
       maxSteps: steps,
       manageConnector: manage,
       externalHistory: history,
+      messages: extraMessages,
       outputSchema: schema,
       signal: abortSignal,
     } = normalizeRunOptions(
@@ -1202,14 +1253,17 @@ export class MCPAgent {
       return this.remoteAgent.run(query, steps, manage, history, schema);
     }
 
-    const generator = this.stream<T>(
-      query,
-      steps,
-      manage,
-      history,
+    // Pass messages via the options-object overload to preserve the field that
+    // the positional-argument signature cannot carry.
+    const generator = this.stream<T>({
+      prompt: query,
+      maxSteps: steps,
+      manageConnector: manage,
+      externalHistory: history,
+      messages: extraMessages,
       schema,
-      abortSignal
-    );
+      signal: abortSignal,
+    });
     return this._consumeAndReturn(generator);
   }
 
@@ -1250,6 +1304,7 @@ export class MCPAgent {
       maxSteps: steps,
       manageConnector: manage,
       externalHistory: history,
+      messages: extraMessages,
       outputSchema: schema,
       signal: abortSignal,
     } = normalizeRunOptions(
@@ -1342,8 +1397,23 @@ export class MCPAgent {
       // With dynamic tool reload: if tools change mid-execution, we interrupt and restart
       const maxRestarts = 3; // Prevent infinite restart loops
       let restartCount = 0;
+
+      // Convert RunOptions.messages (provider-neutral) to LangChain messages and
+      // insert them after history but before the current prompt, matching the
+      // ordering documented in RunOptions.externalHistory.
+      const convertedMessages = extraMessages?.length
+        ? convertProviderMessagesToLangChain(
+            extraMessages,
+            HumanMessage,
+            AIMessage,
+            SystemMessage,
+            ToolMessage
+          )
+        : [];
+
       const accumulatedMessages: BaseMessage[] = [
         ...langchainHistory,
+        ...convertedMessages,
         new HumanMessage(query),
       ];
 
@@ -1801,6 +1871,7 @@ export class MCPAgent {
       maxSteps: steps,
       manageConnector: manage,
       externalHistory: history,
+      messages: extraMessages,
       outputSchema: schema,
       signal: abortSignal,
     } = normalized;
@@ -1866,9 +1937,22 @@ export class MCPAgent {
         }
       }
 
+      // Convert RunOptions.messages (provider-neutral) to LangChain messages and
+      // insert them after history but before the current prompt.
+      const convertedMessages = extraMessages?.length
+        ? convertProviderMessagesToLangChain(
+            extraMessages,
+            HumanMessage,
+            AIMessage,
+            SystemMessage,
+            ToolMessage
+          )
+        : [];
+
       // Prepare inputs
       const inputs: BaseMessage[] = [
         ...langchainHistory,
+        ...convertedMessages,
         new HumanMessage(query),
       ];
 

--- a/libraries/typescript/packages/agent/src/agents/mcp_agent_langchain.ts
+++ b/libraries/typescript/packages/agent/src/agents/mcp_agent_langchain.ts
@@ -1896,12 +1896,6 @@ export class MCPAgent {
 
     // Delegate to remote agent if in remote mode (streamEvents is not supported remotely)
     if (this.isRemote && this.remoteAgent) {
-      if (extraMessages?.length) {
-        throw new Error(
-          "RunOptions.messages is not supported in remote mode. " +
-            "The remote agent protocol does not carry a pre-seeded message list."
-        );
-      }
       throw new Error(
         "streamEvents() is not supported in remote mode. Use stream() or run() instead."
       );

--- a/libraries/typescript/packages/agent/src/agents/run_options.ts
+++ b/libraries/typescript/packages/agent/src/agents/run_options.ts
@@ -21,7 +21,13 @@ export interface RunOptions<T = string> {
    * stored memory.
    */
   externalHistory?: BaseMessage[];
-  /** Provider-neutral messages appended before `prompt`. */
+  /**
+   * Provider-neutral messages appended before `prompt`.
+   *
+   * Not supported when the agent was constructed with `agentId` (remote mode):
+   * the remote agent protocol does not carry a pre-seeded message list and will
+   * throw at runtime if this field is non-empty.
+   */
   messages?: ProviderMessage[];
   /**
    * Zod schema for a typed result.

--- a/libraries/typescript/packages/agent/src/agents/run_options.ts
+++ b/libraries/typescript/packages/agent/src/agents/run_options.ts
@@ -24,9 +24,9 @@ export interface RunOptions<T = string> {
   /**
    * Provider-neutral messages appended before `prompt`.
    *
-   * Not supported when the agent was constructed with `agentId` (remote mode):
-   * the remote agent protocol does not carry a pre-seeded message list and will
-   * throw at runtime if this field is non-empty.
+   * Not supported when the agent was constructed with `agentId` (remote mode).
+   * Both the native agent and the LangChain agent throw at runtime if this
+   * field is non-empty and the agent is in remote mode.
    */
   messages?: ProviderMessage[];
   /**

--- a/libraries/typescript/packages/agent/tests/unit/run_options_messages.test.ts
+++ b/libraries/typescript/packages/agent/tests/unit/run_options_messages.test.ts
@@ -213,7 +213,7 @@ describe("RunOptions.messages forwarding", () => {
     await agent.initialize();
 
     const result = await agent.run({ prompt: "hello" });
-    expect(result).toBeTruthy();
+    expect(result).toBe("Test response");
   });
 
   it("streamEvents(): forwards RunOptions.messages before the prompt", async () => {

--- a/libraries/typescript/packages/agent/tests/unit/run_options_messages.test.ts
+++ b/libraries/typescript/packages/agent/tests/unit/run_options_messages.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests that RunOptions.messages is forwarded by the LangChain agent.
+ *
+ * Regression test for issue #2462: RunOptions.messages was silently dropped
+ * by the LangChain agent because normalizeRunOptions did not propagate the
+ * field and stream()/streamEvents() did not consume it.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Capture the messages array passed to agentExecutor.stream() so tests can
+// inspect whether RunOptions.messages was forwarded correctly.
+const capturedStreamInputs: any[] = [];
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn().mockReturnValue("test-user-id"),
+}));
+
+vi.mock("node:os", () => ({
+  homedir: vi.fn().mockReturnValue("/mock/home"),
+}));
+
+vi.mock("langchain", () => ({
+  createAgent: vi.fn(() => ({
+    stream: vi.fn().mockImplementation(async function* (inputs: any) {
+      capturedStreamInputs.push(inputs);
+      yield {
+        agent: {
+          messages: [
+            {
+              type: "ai",
+              content: "Test response",
+              tool_calls: [],
+            },
+          ],
+        },
+      };
+    }),
+    streamEvents: vi.fn().mockImplementation(async function* (inputs: any) {
+      capturedStreamInputs.push(inputs);
+      yield {
+        event: "on_chat_model_stream",
+        data: { chunk: { content: "Test" } },
+      };
+      yield {
+        event: "on_chain_end",
+        data: { output: "Test response" },
+      };
+    }),
+  })),
+  modelCallLimitMiddleware: vi.fn(() => ({})),
+  HumanMessage: class {
+    content: string;
+    type = "human";
+    constructor(content: string | { content: string }) {
+      this.content = typeof content === "string" ? content : content.content;
+    }
+    getType() {
+      return "human";
+    }
+  },
+  AIMessage: class {
+    content: string;
+    tool_calls: any[];
+    type = "ai";
+    constructor(content: string | { content: string; tool_calls?: any[] }) {
+      if (typeof content === "string") {
+        this.content = content;
+        this.tool_calls = [];
+      } else {
+        this.content = content.content;
+        this.tool_calls = content.tool_calls || [];
+      }
+    }
+    getType() {
+      return "ai";
+    }
+  },
+  SystemMessage: class {
+    content: string;
+    type = "system";
+    constructor(content: string) {
+      this.content = content;
+    }
+    getType() {
+      return "system";
+    }
+  },
+  ToolMessage: class {
+    content: string;
+    tool_call_id: string;
+    type = "tool";
+    constructor(data: { content: string; tool_call_id: string }) {
+      this.content = data.content;
+      this.tool_call_id = data.tool_call_id;
+    }
+    getType() {
+      return "tool";
+    }
+  },
+}));
+
+vi.mock("../../src/adapters/langchain_adapter.js", () => ({
+  LangChainAdapter: class {
+    createToolsFromConnectors = vi.fn().mockResolvedValue([]);
+    createResourcesFromConnectors = vi.fn().mockResolvedValue([]);
+    createPromptsFromConnectors = vi.fn().mockResolvedValue([]);
+  },
+}));
+
+vi.mock("@mcp-use/client", async (importOriginal) => {
+  return {
+    ...(await importOriginal<Record<string, unknown>>()),
+    MCPClient: class {
+      getAllActiveSessions = vi.fn().mockReturnValue({});
+      createAllSessions = vi.fn().mockResolvedValue({});
+      closeAllSessions = vi.fn().mockResolvedValue(undefined);
+      close = vi.fn().mockResolvedValue(undefined);
+      getServerNames = vi.fn().mockReturnValue([]);
+    },
+    Telemetry: {
+      getInstance: () => ({
+        trackAgentExecution: vi.fn(),
+      }),
+    },
+  };
+});
+
+vi.mock("../../src/observability/index.js", () => ({
+  ObservabilityManager: class {
+    getCallbacks = vi.fn().mockResolvedValue([]);
+    getHandlerNames = vi.fn().mockResolvedValue([]);
+    flush = vi.fn().mockResolvedValue(undefined);
+    shutdown = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+class MockConnector {
+  publicIdentifier = "mock-connector";
+  isClientConnected = true;
+  connect = vi.fn().mockResolvedValue(undefined);
+  disconnect = vi.fn().mockResolvedValue(undefined);
+  listTools = vi.fn().mockResolvedValue([]);
+}
+
+describe("RunOptions.messages forwarding", () => {
+  let mockLlm: any;
+
+  beforeEach(() => {
+    capturedStreamInputs.length = 0;
+    vi.clearAllMocks();
+
+    mockLlm = {
+      invoke: vi.fn().mockResolvedValue({ content: "Test response" }),
+      stream: vi.fn().mockImplementation(async function* () {
+        yield { content: "Test" };
+      }),
+      _llm_type: "openai",
+      modelName: "gpt-4",
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stream(): forwards RunOptions.messages before the prompt", async () => {
+    const { MCPAgent } =
+      await import("../../src/agents/mcp_agent_langchain.js");
+
+    const connector = new MockConnector();
+    const agent = new MCPAgent({
+      llm: mockLlm,
+      connectors: [connector as any],
+      memoryEnabled: false,
+    });
+
+    await agent.initialize();
+
+    await agent.run({
+      prompt: "what is the weather",
+      messages: [{ role: "user", content: "CANARY-PROVIDER-MESSAGE" }],
+    });
+
+    expect(capturedStreamInputs.length).toBeGreaterThan(0);
+    const { messages } = capturedStreamInputs[0];
+    expect(messages).toBeDefined();
+
+    // The CANARY message should appear before the prompt HumanMessage.
+    const contents = messages.map((m: any) => m.content);
+    const canaryIndex = contents.indexOf("CANARY-PROVIDER-MESSAGE");
+    const promptIndex = contents.indexOf("what is the weather");
+
+    expect(canaryIndex).toBeGreaterThanOrEqual(0);
+    expect(promptIndex).toBeGreaterThanOrEqual(0);
+    expect(canaryIndex).toBeLessThan(promptIndex);
+  });
+
+  it("stream(): omitting messages does not break execution", async () => {
+    const { MCPAgent } =
+      await import("../../src/agents/mcp_agent_langchain.js");
+
+    const connector = new MockConnector();
+    const agent = new MCPAgent({
+      llm: mockLlm,
+      connectors: [connector as any],
+      memoryEnabled: false,
+    });
+
+    await agent.initialize();
+
+    const result = await agent.run({ prompt: "hello" });
+    expect(result).toBeTruthy();
+  });
+
+  it("streamEvents(): forwards RunOptions.messages before the prompt", async () => {
+    const { MCPAgent } =
+      await import("../../src/agents/mcp_agent_langchain.js");
+
+    const connector = new MockConnector();
+    const agent = new MCPAgent({
+      llm: mockLlm,
+      connectors: [connector as any],
+      memoryEnabled: false,
+    });
+
+    await agent.initialize();
+
+    for await (const _ of agent.streamEvents({
+      prompt: "what is the weather",
+      messages: [{ role: "user", content: "CANARY-PROVIDER-MESSAGE" }],
+    })) {
+      // consume events
+    }
+
+    expect(capturedStreamInputs.length).toBeGreaterThan(0);
+    const { messages } = capturedStreamInputs[0];
+    expect(messages).toBeDefined();
+
+    const contents = messages.map((m: any) => m.content);
+    const canaryIndex = contents.indexOf("CANARY-PROVIDER-MESSAGE");
+    const promptIndex = contents.indexOf("what is the weather");
+
+    expect(canaryIndex).toBeGreaterThanOrEqual(0);
+    expect(promptIndex).toBeGreaterThanOrEqual(0);
+    expect(canaryIndex).toBeLessThan(promptIndex);
+  });
+});


### PR DESCRIPTION
## Summary

- `normalizeRunOptions` in `mcp_agent_langchain.ts` omitted the `messages` field from its return value, so `RunOptions.messages` was silently dropped for all three entry points (`run`, `stream`, `streamEvents`)
- Add `messages` propagation through `normalizeRunOptions` and both streaming methods
- Add `convertProviderMessagesToLangChain` helper to convert provider-neutral `ProviderMessage[]` to LangChain `BaseMessage[]` (handles user, assistant with optional tool calls, tool, and system roles)
- Delegate from `run()` to `stream()` via the options-object overload so the `messages` field is not lost when bridging the positional-argument call
- Converted messages are inserted between `externalHistory` and the current prompt, matching the ordering documented in `RunOptions.externalHistory`

## Test plan

- [x] New unit test: `stream()` forwards a provider-neutral canary message before the prompt when `RunOptions.messages` is set
- [x] New unit test: `stream()` without `messages` continues to work correctly
- [x] New unit test: `streamEvents()` forwards a provider-neutral canary message before the prompt when `RunOptions.messages` is set
- [x] All 143 existing unit tests pass (`pnpm test:unit`)

Fixes #2462

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes issue #2462 where the LangChain agent silently dropped `RunOptions.messages`. The messages are now converted from provider-neutral to LangChain `BaseMessage[]` and inserted between `externalHistory` and the current prompt in both `run()` and streaming paths. Both the LangChain and native agents now throw when `messages` is set in remote mode.

**Bug Fixes**
- `normalizeRunOptions` now propagates the `messages` field, and `run()` delegates to `stream()` through the options-object overload.
- Added `convertProviderMessagesToLangChain` for user, assistant (with tool calls), tool, and system roles; tool messages missing `toolCallId` throw an explicit error.
- `RunOptions.messages` in remote mode throws in `run()` and `stream()` for both agents, `streamEvents()` now always throws in remote mode, and the field's JSDoc documents the limitation.

<sup>Written for commit a4783279e1e0a203f40e8131bf8f091cd0c817aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

