### PR TITLE
fix(agent): honour the legacy auth_token in mcpServers

### DIFF
--- a/libraries/typescript/.changeset/agent-legacy-auth-token.md
+++ b/libraries/typescript/.changeset/agent-legacy-auth-token.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/agent": patch
+---
+
+Fix `auth_token` in `mcpServers` being ignored. `MCPServerConfig` advertises the legacy snake-case spelling for configurations shared with the Python SDK, but the config object was handed to `@mcp-use/client` unchanged and the client only reads `authToken`, so those servers connected with no `Authorization` header and no warning.

--- a/libraries/typescript/packages/agent/src/agents/mcp_agent.ts
+++ b/libraries/typescript/packages/agent/src/agents/mcp_agent.ts
@@ -32,6 +32,7 @@ import { normalizeRunOptions } from "./normalize_run_options.js";
 import type { RunOptions } from "./run_options.js";
 import { RemoteAgent } from "./remote.js";
 import type { BaseMessage, MCPServerConfig } from "./types.js";
+import { withResolvedAuthTokens } from "./types.js";
 
 export type {
   ProviderName,
@@ -242,7 +243,9 @@ export class MCPAgent {
 
     if (!this.client && this.mcpServersConfig && !this.hasLiveConnections()) {
       const { MCPClient } = await import("@mcp-use/client");
-      this.client = new MCPClient({ mcpServers: this.mcpServersConfig });
+      this.client = new MCPClient({
+        mcpServers: withResolvedAuthTokens(this.mcpServersConfig),
+      });
       this.clientOwnedByAgent = true;
     }
 

--- a/libraries/typescript/packages/agent/src/agents/mcp_agent_langchain.ts
+++ b/libraries/typescript/packages/agent/src/agents/mcp_agent_langchain.ts
@@ -34,6 +34,7 @@ import type {
   MCPAgentOptions,
   MCPServerConfig,
 } from "./types.js";
+import { withResolvedAuthTokens } from "./types.js";
 import { createLLMFromString, type LLMConfig } from "./utils/llm_provider.js";
 
 /** Tool invocation details yielded by the LangChain agent. */
@@ -355,7 +356,9 @@ export class MCPAgent {
         );
         // Dynamically import MCPClient (Node.js version)
         const { MCPClient } = await import("@mcp-use/client");
-        this.client = new MCPClient({ mcpServers: this.mcpServersConfig });
+        this.client = new MCPClient({
+          mcpServers: withResolvedAuthTokens(this.mcpServersConfig),
+        });
         logger.debug("✅ MCPClient created successfully");
       }
 

--- a/libraries/typescript/packages/agent/src/agents/types.ts
+++ b/libraries/typescript/packages/agent/src/agents/types.ts
@@ -40,6 +40,30 @@ export interface MCPServerConfig {
   authToken?: string;
 }
 
+/**
+ * Move a legacy `auth_token` onto the `authToken` the client actually reads.
+ *
+ * `MCPServerConfig` advertises both spellings so a configuration written for
+ * the Python SDK still loads, but `@mcp-use/client` only ever reads
+ * `authToken`. Without this the snake-case form is dropped and the connection
+ * goes out with no `Authorization` header and no warning.
+ *
+ * @param servers - Server configurations keyed by name.
+ * @returns The same map with the legacy token resolved.
+ */
+export function withResolvedAuthTokens(
+  servers: Record<string, MCPServerConfig>
+): Record<string, MCPServerConfig> {
+  return Object.fromEntries(
+    Object.entries(servers).map(([name, config]) => [
+      name,
+      config.authToken === undefined && config.auth_token !== undefined
+        ? { ...config, authToken: config.auth_token }
+        : config,
+    ])
+  );
+}
+
 /** Options shared by explicit and simplified LangChain agents. */
 export interface CommonAgentOptions {
   /** Maximum model calls per run. Defaults to `5`. */

--- a/libraries/typescript/packages/agent/tests/unit/agent/legacy-auth-token.test.ts
+++ b/libraries/typescript/packages/agent/tests/unit/agent/legacy-auth-token.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { withResolvedAuthTokens } from "../../../src/agents/types.js";
+
+/**
+ * `MCPServerConfig` advertises `auth_token` for configurations shared with the
+ * Python SDK, but `@mcp-use/client` only reads `authToken`, so the legacy
+ * spelling produced no `Authorization` header at all.
+ */
+describe("withResolvedAuthTokens", () => {
+  it("resolves the legacy token onto the field the client reads", () => {
+    expect(
+      withResolvedAuthTokens({
+        legacy: { url: "https://api.example.com/mcp", auth_token: "secret" },
+      })
+    ).toEqual({
+      legacy: {
+        url: "https://api.example.com/mcp",
+        auth_token: "secret",
+        authToken: "secret",
+      },
+    });
+  });
+
+  it("leaves an explicit authToken and unrelated servers alone", () => {
+    const servers = {
+      explicit: {
+        url: "https://api.example.com/mcp",
+        auth_token: "legacy",
+        authToken: "current",
+      },
+      stdio: { command: "npx", args: ["server"] },
+    };
+
+    expect(withResolvedAuthTokens(servers)).toEqual(servers);
+  });
+});


### PR DESCRIPTION
## Why

`MCPServerConfig` advertises two spellings of the token (`agent/src/agents/types.ts:37`):

```ts
/** Legacy snake-case authentication token. */
auth_token?: string;
/** Authentication token sent to a remote MCP server. */
authToken?: string;
```

Both agents pass that object to the client unchanged (`mcp_agent.ts:245`, `mcp_agent_langchain.ts:358`):

```ts
this.client = new MCPClient({ mcpServers: this.mcpServersConfig });
```

and `@mcp-use/client` only ever reads `authToken`. Building a connector from each spelling:

```
url + authToken    Authorization = "Bearer CAMEL"
url + auth_token   Authorization = null
```

So a server configured the snake-case way, which is how a configuration shared with the Python SDK is written, connects with **no `Authorization` header at all**, and nothing reports it. The request goes out unauthenticated and the failure surfaces later as a 401 from the server, or as unexplained empty results if the server treats anonymous callers as valid.

`auth_token` appears nowhere else in any package's source, so the agent is the only thing promising it.

## The change

Resolved where the promise is made. The agent owns this type, so the legacy spelling is mapped onto `authToken` as the configuration leaves for the client, rather than widening the client's public config surface for a field it never documented:

```ts
config.authToken === undefined && config.auth_token !== undefined
  ? { ...config, authToken: config.auth_token }
  : config
```

An explicit `authToken` always wins, stdio and other entries pass through untouched, and the original `auth_token` is left on the object so nothing that reads it later changes meaning.

Both construction sites use it, so the native and LangChain agents behave the same.

## Alternative I did not take

Teaching `@mcp-use/client` the alias would fix the direct-client and config-file paths too, but it means adding a legacy field to the client's public `ServerConfig` plus the three `createConnectorFromConfig` implementations and the `shouldAutoProvisionOAuth` guard that also branches on `authToken`. Since the client never advertised `auth_token`, that widens an API to satisfy a promise a different package made. Happy to do it that way instead if you would rather the compatibility live in the client.

## Tests

`tests/unit/agent/legacy-auth-token.test.ts` covers the legacy spelling being resolved, an explicit `authToken` taking precedence, and unrelated entries being untouched.

## Validation

From `libraries/typescript/packages/agent`: `vitest run` — all unit tests pass. The 8 failures in `tests/integration/agent` are pre-existing on `canary` without this diff and need live provider credentials.
`tsc --noEmit`, `eslint`, `prettier --check` — clean.
Monorepo preflight — 0 failing packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP servers configured with the legacy `auth_token` spelling connecting with no `Authorization` header.

- `@mcp-use/client` only reads `authToken`, so the snake-case token was silently dropped.
- The agent now maps `auth_token` onto `authToken` for both native and LangChain agents before passing config to the client.
- An explicit `authToken` always wins; stdio and other entries pass through unchanged.

<sup>Written for commit 39af64b254ccd0a423e1aa8619767678c1b5815d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

