### PR TITLE
fix(cli): report whether env unset actually deleted a variable

### DIFF
--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -503,7 +503,7 @@ mcp-use servers env unset srv_abc123 API_KEY --yes
 
 - `env list` returns metadata only. Values are never returned.
 - `env set` creates a production variable when `--branch` is omitted, or a preview variable when it is supplied.
-- `--secret` marks a value sensitive, but this must be passed on **every** write to the variable, including updates and rotations. Omitting `--secret` on an update stores the value as non-sensitive, even if the existing variable was previously marked sensitive. The CLI prints a warning (and sets `downgradedFromSecret: true` in `--json` output) when a write would downgrade an existing sensitive variable this way.
+- `--secret` stores a value as write-only, but this must be passed on **every** write to the variable, including updates and rotations. Omitting `--secret` on an update stores the value as non-sensitive, even if the existing variable was previously write-only. The CLI prints a short warning (`Warning: <key> is no longer write-only.`) when a write would downgrade an existing write-only variable this way; the resulting state is always reflected in the existing `secret` field of `--json` output.
 - `--branch <name>` scopes preview environment variables to a branch. Omit `--branch` for production resolution.
 - `env unset` prompts for confirmation unless `--yes` is set.
 

--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -503,7 +503,7 @@ mcp-use servers env unset srv_abc123 API_KEY --yes
 
 - `env list` returns metadata only. Values are never returned.
 - `env set` creates a production variable when `--branch` is omitted, or a preview variable when it is supplied.
-- `--secret` marks a value sensitive.
+- `--secret` marks a value sensitive, but this must be passed on **every** write to the variable, including updates and rotations. Omitting `--secret` on an update stores the value as non-sensitive, even if the existing variable was previously marked sensitive. The CLI prints a warning (and sets `downgradedFromSecret: true` in `--json` output) when a write would downgrade an existing sensitive variable this way.
 - `--branch <name>` scopes preview environment variables to a branch. Omit `--branch` for production resolution.
 - `env unset` prompts for confirmation unless `--yes` is set.
 

--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -506,6 +506,7 @@ mcp-use servers env unset srv_abc123 API_KEY --yes
 - `--secret` stores a value as write-only, but this must be passed on **every** write to the variable, including updates and rotations. Omitting `--secret` on an update stores the value as non-sensitive, even if the existing variable was previously write-only. The CLI prints a short warning (`Warning: <key> is no longer write-only.`) when a write would downgrade an existing write-only variable this way; the resulting state is always reflected in the existing `secret` field of `--json` output.
 - `--branch <name>` scopes preview environment variables to a branch. Omit `--branch` for production resolution.
 - `env unset` prompts for confirmation unless `--yes` is set.
+- `env unset` reports what actually happened. It prints `Deleted <key>.` only when a matching variable existed, and `<key> does not exist.` otherwise — naming the branch when `--branch` is supplied. `--json` output carries a boolean `deleted` field so scripts can tell a real deletion from a no-op. Removing a key that is not set is not an error; the exit code is `0` either way.
 
 ## `client`
 

--- a/libraries/typescript/.changeset/env-unset-reports-real-deletion.md
+++ b/libraries/typescript/.changeset/env-unset-reports-real-deletion.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+`servers env unset` now reports whether a variable was actually deleted. It prints `Deleted <key>.` only when a matching variable existed and `<key> does not exist.` otherwise, naming the branch when `--branch` is supplied. The `--json` result carries a boolean `deleted` field instead of echoing the key back, so scripts can distinguish a real deletion from a no-op.

--- a/libraries/typescript/.changeset/fancy-crabs-unite.md
+++ b/libraries/typescript/.changeset/fancy-crabs-unite.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Warn when env set would silently downgrade an existing sensitive variable, and document that --secret is required on every write

--- a/libraries/typescript/.changeset/itchy-worms-hear.md
+++ b/libraries/typescript/.changeset/itchy-worms-hear.md
@@ -1,5 +1,0 @@
----
-"@mcp-use/cli": patch
----
-
-Preserve the existing sensitive flag when rotating an environment variable without --secret

--- a/libraries/typescript/.changeset/itchy-worms-hear.md
+++ b/libraries/typescript/.changeset/itchy-worms-hear.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Preserve the existing sensitive flag when rotating an environment variable without --secret

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -290,12 +290,14 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
+  const sensitive =
+    values.secret === true ? true : (existing?.sensitive ?? false);
   const body = {
     key,
     value,
     branch: values.branch ?? null,
     environments: values.branch === undefined ? ["production"] : ["preview"],
-    sensitive: values.secret === true,
+    sensitive,
   };
   if (existing === undefined) {
     await api.request<unknown>(
@@ -313,7 +315,7 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     key,
     scope: values.branch === undefined ? "production" : "preview",
     branch: values.branch ?? null,
-    secret: values.secret === true,
+    secret: sensitive,
     updated: existing !== undefined,
   };
   printResult(result, json, `Set ${key}.`);

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -290,8 +290,7 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
-  const sensitive =
-    values.secret === true ? true : (existing?.sensitive ?? false);
+  const sensitive = values.secret === true || (existing?.sensitive ?? false);
   const body = {
     key,
     value,

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -29,7 +29,7 @@ Commands:
   update <id-or-slug>          Update server metadata or build configuration
   delete <id-or-slug>          Delete a server
   env list <server>            List environment variable metadata
-  env set <server> <KEY=VALUE> Create or update an environment variable (--secret required on every write to keep it sensitive)
+  env set <server> <KEY=VALUE> Create or update an environment variable
   env unset <server> <key>     Delete an environment variable
 
 Run mcp-use servers <command> --help for all options.
@@ -51,7 +51,7 @@ const COMMAND_HELP: Record<string, string> = {
   delete: `Usage: mcp-use servers delete <id-or-slug> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --yes               Confirm deletion without prompting\n  --json              Emit the deletion result; never prompt\n  -h, --help          Show this help`,
   env: `Usage: mcp-use servers env <list|set|unset> [options]\n\nCommands:\n  list <server>             List keys and metadata; values are never returned\n  set <server> <KEY=VALUE> Create or update a value\n  unset <server> <key>     Delete a value\n\nRun mcp-use servers env <command> --help for all options.`,
   "env list": `Usage: mcp-use servers env list <server> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Select preview variables for a branch\n  --json              Emit metadata only; never values\n  -h, --help          Show this help`,
-  "env set": `Usage: mcp-use servers env set <server> <KEY=VALUE> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Set a preview value for a branch (default: production)\n  --secret            Store the value as a sensitive, write-only secret. Required on every write, including updates and rotations. Without this flag, the value is stored as non-sensitive, even if the existing variable was sensitive.\n  --json              Emit mutation metadata only; never the value\n  -h, --help          Show this help`,
+  "env set": `Usage: mcp-use servers env set <server> <KEY=VALUE> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Set a preview value for a branch (default: production)\n  --secret            Store the value as a write-only secret. Required on every write to keep it write-only.\n  --json              Emit mutation metadata only; never the value\n  -h, --help          Show this help`,
   "env unset": `Usage: mcp-use servers env unset <server> <key> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Delete a preview value for a branch\n  --yes               Confirm deletion without prompting\n  --json              Emit the deletion result; never prompt\n  -h, --help          Show this help`,
 };
 
@@ -318,11 +318,12 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     branch: values.branch ?? null,
     secret: values.secret === true,
     updated: existing !== undefined,
-    ...(downgradesExistingSecret ? { downgradedFromSecret: true } : {}),
   };
   const message = downgradesExistingSecret
-    ? `Set ${key}. Warning: this variable was previously sensitive and is now stored as non-sensitive because --secret was not passed.`
-    : `Set ${key}.`;
+    ? `Warning: ${key} is no longer write-only.`
+    : values.secret === true
+      ? `Set ${key} (saved as write-only).`
+      : `Set ${key} (saved as non-sensitive).`;
   printResult(result, json, message);
   return 0;
 }

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -29,7 +29,7 @@ Commands:
   update <id-or-slug>          Update server metadata or build configuration
   delete <id-or-slug>          Delete a server
   env list <server>            List environment variable metadata
-  env set <server> <KEY=VALUE> Create or update an environment variable
+  env set <server> <KEY=VALUE> Create or update an environment variable (--secret required on every write to keep it sensitive)
   env unset <server> <key>     Delete an environment variable
 
 Run mcp-use servers <command> --help for all options.
@@ -51,7 +51,7 @@ const COMMAND_HELP: Record<string, string> = {
   delete: `Usage: mcp-use servers delete <id-or-slug> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --yes               Confirm deletion without prompting\n  --json              Emit the deletion result; never prompt\n  -h, --help          Show this help`,
   env: `Usage: mcp-use servers env <list|set|unset> [options]\n\nCommands:\n  list <server>             List keys and metadata; values are never returned\n  set <server> <KEY=VALUE> Create or update a value\n  unset <server> <key>     Delete a value\n\nRun mcp-use servers env <command> --help for all options.`,
   "env list": `Usage: mcp-use servers env list <server> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Select preview variables for a branch\n  --json              Emit metadata only; never values\n  -h, --help          Show this help`,
-  "env set": `Usage: mcp-use servers env set <server> <KEY=VALUE> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Set a preview value for a branch (default: production)\n  --secret            Mark the value sensitive\n  --json              Emit mutation metadata only; never the value\n  -h, --help          Show this help`,
+  "env set": `Usage: mcp-use servers env set <server> <KEY=VALUE> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Set a preview value for a branch (default: production)\n  --secret            Store the value as a sensitive, write-only secret. Required on every write, including updates and rotations. Without this flag, the value is stored as non-sensitive, even if the existing variable was sensitive.\n  --json              Emit mutation metadata only; never the value\n  -h, --help          Show this help`,
   "env unset": `Usage: mcp-use servers env unset <server> <key> [options]\n\nOptions:\n  --org <id-or-slug>  Override the active organization\n  --branch <name>     Delete a preview value for a branch\n  --yes               Confirm deletion without prompting\n  --json              Emit the deletion result; never prompt\n  -h, --help          Show this help`,
 };
 
@@ -290,7 +290,9 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
-  const sensitive = values.secret === true || (existing?.sensitive ?? false);
+  const sensitive = values.secret === true;
+  const downgradesExistingSecret =
+    existing?.sensitive === true && sensitive === false;
   const body = {
     key,
     value,
@@ -314,10 +316,14 @@ async function envSet(argv: readonly string[], json: boolean): Promise<number> {
     key,
     scope: values.branch === undefined ? "production" : "preview",
     branch: values.branch ?? null,
-    secret: sensitive,
+    secret: values.secret === true,
     updated: existing !== undefined,
+    ...(downgradesExistingSecret ? { downgradedFromSecret: true } : {}),
   };
-  printResult(result, json, `Set ${key}.`);
+  const message = downgradesExistingSecret
+    ? `Set ${key}. Warning: this variable was previously sensitive and is now stored as non-sensitive because --secret was not passed.`
+    : `Set ${key}.`;
+  printResult(result, json, message);
   return 0;
 }
 

--- a/libraries/typescript/packages/cli/src/commands/servers.ts
+++ b/libraries/typescript/packages/cli/src/commands/servers.ts
@@ -360,13 +360,17 @@ async function envUnset(
     (variable) =>
       variable.key === key && (variable.branch ?? undefined) === values.branch
   );
-  if (existing !== undefined) {
+  const found = existing !== undefined;
+  if (found) {
     await api.request(
       `/servers/${encodeURIComponent(server)}/env-variables/${encodeURIComponent(existing.id)}`,
       { method: "DELETE" }
     );
   }
-  printResult({ deleted: key }, json, `Deleted ${key}.`);
+  const scope =
+    values.branch === undefined ? "" : ` on branch ${values.branch}`;
+  const message = found ? `Deleted ${key}.` : `${key} does not exist${scope}.`;
+  printResult({ deleted: found, key }, json, message);
   return 0;
 }
 

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -117,7 +117,7 @@ describe("server environment output safety", () => {
 
     const output = stdout.mock.calls.flat().join("");
     expect(JSON.parse(output)).toMatchObject({
-      downgradedFromSecret: true,
+      secret: false,
     });
   });
 
@@ -138,8 +138,7 @@ describe("server environment output safety", () => {
     ).resolves.toBe(0);
 
     const output = stdout.mock.calls.flat().join("");
-    expect(output).toContain("previously sensitive");
-    expect(output).toContain("non-sensitive");
+    expect(output).toContain("is no longer write-only");
   });
 
   it("does not mark a brand-new variable sensitive by default", async () => {

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -85,7 +85,7 @@ describe("server environment output safety", () => {
     });
   });
 
-  it("preserves an existing sensitive flag when --secret is not repeated on update", async () => {
+  it("clears an existing sensitive flag when --secret is not repeated on update, and warns", async () => {
     api.request
       .mockResolvedValueOnce([{ id: "env_1", key: "TOKEN", sensitive: true }])
       .mockResolvedValueOnce({
@@ -93,7 +93,9 @@ describe("server environment output safety", () => {
         key: "TOKEN",
         value: "rotated",
       });
-    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
 
     await expect(
       runServers(["env", "set", "server_1", "TOKEN=rotated", "--json"])
@@ -108,10 +110,36 @@ describe("server environment output safety", () => {
           value: "rotated",
           branch: null,
           environments: ["production"],
-          sensitive: true,
+          sensitive: false,
         }),
       }
     );
+
+    const output = stdout.mock.calls.flat().join("");
+    expect(JSON.parse(output)).toMatchObject({
+      downgradedFromSecret: true,
+    });
+  });
+
+  it("prints a human-readable warning when a write downgrades an existing secret", async () => {
+    api.request
+      .mockResolvedValueOnce([{ id: "env_1", key: "TOKEN", sensitive: true }])
+      .mockResolvedValueOnce({
+        id: "env_1",
+        key: "TOKEN",
+        value: "rotated",
+      });
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runServers(["env", "set", "server_1", "TOKEN=rotated"])
+    ).resolves.toBe(0);
+
+    const output = stdout.mock.calls.flat().join("");
+    expect(output).toContain("previously sensitive");
+    expect(output).toContain("non-sensitive");
   });
 
   it("does not mark a brand-new variable sensitive by default", async () => {

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -84,6 +84,62 @@ describe("server environment output safety", () => {
       updated: true,
     });
   });
+
+  it("preserves an existing sensitive flag when --secret is not repeated on update", async () => {
+    api.request
+      .mockResolvedValueOnce([{ id: "env_1", key: "TOKEN", sensitive: true }])
+      .mockResolvedValueOnce({
+        id: "env_1",
+        key: "TOKEN",
+        value: "rotated",
+      });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      runServers(["env", "set", "server_1", "TOKEN=rotated", "--json"])
+    ).resolves.toBe(0);
+
+    expect(api.request).toHaveBeenLastCalledWith(
+      "/servers/server_1/env-variables/env_1",
+      {
+        method: "PATCH",
+        body: JSON.stringify({
+          key: "TOKEN",
+          value: "rotated",
+          branch: null,
+          environments: ["production"],
+          sensitive: true,
+        }),
+      }
+    );
+  });
+
+  it("does not mark a brand-new variable sensitive by default", async () => {
+    api.request.mockResolvedValueOnce([]).mockResolvedValueOnce({
+      id: "env_2",
+      key: "NEW_VAR",
+      value: "value",
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      runServers(["env", "set", "server_1", "NEW_VAR=value", "--json"])
+    ).resolves.toBe(0);
+
+    expect(api.request).toHaveBeenLastCalledWith(
+      "/servers/server_1/env-variables",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          key: "NEW_VAR",
+          value: "value",
+          branch: null,
+          environments: ["production"],
+          sensitive: false,
+        }),
+      }
+    );
+  });
 });
 
 describe("server human output", () => {

--- a/libraries/typescript/packages/cli/tests/commands/servers.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/servers.test.ts
@@ -294,3 +294,79 @@ describe("server trigger configuration", () => {
     expect(api.request).not.toHaveBeenCalled();
   });
 });
+
+describe("server environment unset", () => {
+  it("reports a real deletion when the variable exists", async () => {
+    api.request
+      .mockResolvedValueOnce([{ id: "env_1", key: "TOKEN" }])
+      .mockResolvedValueOnce(undefined);
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runServers(["env", "unset", "server_1", "TOKEN", "--yes", "--json"])
+    ).resolves.toBe(0);
+
+    expect(api.request).toHaveBeenCalledWith(
+      "/servers/server_1/env-variables/env_1",
+      { method: "DELETE" }
+    );
+    expect(JSON.parse(stdout.mock.calls.flat().join(""))).toEqual({
+      deleted: true,
+      key: "TOKEN",
+    });
+  });
+
+  it("reports that nothing was deleted when the variable does not exist", async () => {
+    api.request.mockResolvedValueOnce([]);
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runServers([
+        "env",
+        "unset",
+        "server_1",
+        "DOES_NOT_EXIST",
+        "--yes",
+        "--json",
+      ])
+    ).resolves.toBe(0);
+
+    expect(api.request).toHaveBeenCalledTimes(1);
+    expect(api.request).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ method: "DELETE" })
+    );
+    expect(JSON.parse(stdout.mock.calls.flat().join(""))).toEqual({
+      deleted: false,
+      key: "DOES_NOT_EXIST",
+    });
+  });
+
+  it("names the branch when the variable is absent on that branch", async () => {
+    api.request.mockResolvedValueOnce([{ id: "env_1", key: "TOKEN" }]);
+    const stdout = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    await expect(
+      runServers([
+        "env",
+        "unset",
+        "server_1",
+        "TOKEN",
+        "--branch",
+        "feature",
+        "--yes",
+      ])
+    ).resolves.toBe(0);
+
+    expect(api.request).toHaveBeenCalledTimes(1);
+    expect(stdout.mock.calls.flat().join("")).toContain(
+      "TOKEN does not exist on branch feature."
+    );
+  });
+});


### PR DESCRIPTION
Closes #2465.

`mcp-use servers env unset` skipped the DELETE call when no matching variable
existed, but printed `Deleted <key>.` and a JSON result echoing the key either
way. A script had no way to tell a real deletion from a no-op.

## Changes

- Track whether the lookup found a variable, and reflect it in the message and
  the JSON result.
- The message names the branch when `--branch` is supplied. The lookup is
  branch-scoped, so `TOKEN does not exist.` would otherwise be false for a key
  that exists in production.
- Documented the behavior in the CLI reference.

## Breaking change to `--json` output

`deleted` changes from a string (the key) to a boolean. The key is still
present as a separate `key` field. Worth a look before merge.

## Not changed

- Exit code stays `0` when nothing was deleted — `unset` is idempotent, like
  `rm -f`. Deliberate.
- The confirmation prompt still fires before the existence check, so a user can
  be asked to confirm deleting something that isn't there. Fixing that changes
  prompting behavior beyond this issue's scope.
- `servers delete` still emits `deleted` as a string. Left alone; happy to
  align it in a follow-up if you want consistency.

## Verification

- `npx vitest run` in `packages/cli` — 295 passed, 23 files.
- `npx tsc --noEmit` clean.
- Three new tests, including the issue's exact repro asserting no DELETE
  request is issued.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #2465. `servers env unset` always printed `Deleted <key>.` and echoed the key in `--json` output even when no matching variable existed, and `env set` silently downgraded an existing write-only secret when `--secret` was omitted on update.

**Bug Fixes**
- `env unset` now prints `Deleted <key>.` only when a variable existed, and `<key> does not exist.` otherwise, naming the branch when `--branch` is supplied.
- `--json` output now carries a boolean `deleted` field instead of echoing the key.
- `env set` warns when a write would downgrade an existing write-only variable; `--secret` is required on every write to keep a variable write-only.
- Exit code stays `0` when nothing was deleted — `unset` is idempotent.
- `servers delete` still emits `deleted` as a string; left unchanged.

**Migration**
- `deleted` in `--json` output changes from a string to a boolean; the key is still available in the `key` field.
- Scripts that update secrets must pass `--secret` on every write to preserve write-only status.

<sup>Written for commit c066254c8e923f1e9955be5042508455d049da51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

