### PR TITLE
docs(cli): document env unset failure when the variable is missing

### DIFF
--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -506,8 +506,7 @@ mcp-use servers env unset srv_abc123 API_KEY --yes
 - `env set` creates a production variable when `--branch` is omitted, or a preview variable when it is supplied.
 - `--secret` marks a value sensitive.
 - `--branch <name>` scopes preview environment variables to a branch. Omit `--branch` for production resolution.
-- `env unset` prompts for confirmation unless `--yes` is set.
-- `env unset` fails when no matching variable exists in the resolved scope. It exits non-zero with the error code `env_variable_not_found` instead of reporting a deletion that did not happen. `--branch` is part of that resolution, so unsetting a production key while `--branch` is supplied is a miss, not a fallback.
+- `env unset` prompts for confirmation unless `--yes` is set. If the key doesn't exist in the selected production or branch scope, it fails with `env_variable_not_found`.
 
 ## `client`
 

--- a/docs/v2/typescript/api-reference/cli-reference.mdx
+++ b/docs/v2/typescript/api-reference/cli-reference.mdx
@@ -507,6 +507,7 @@ mcp-use servers env unset srv_abc123 API_KEY --yes
 - `--secret` marks a value sensitive.
 - `--branch <name>` scopes preview environment variables to a branch. Omit `--branch` for production resolution.
 - `env unset` prompts for confirmation unless `--yes` is set.
+- `env unset` fails when no matching variable exists in the resolved scope. It exits non-zero with the error code `env_variable_not_found` instead of reporting a deletion that did not happen. `--branch` is part of that resolution, so unsetting a production key while `--branch` is supplied is a miss, not a fallback.
 
 ## `client`
 


### PR DESCRIPTION
#2411 changed `servers env unset` to throw `env_variable_not_found` when no
matching variable exists, rather than printing `Deleted <key>.` and exiting 0.
The CLI reference was not updated alongside it — it still documents only the
confirmation prompt, so nothing tells a reader the command can now fail.

Extends the existing `env unset` bullet with the failure and the error code, so
the note sits next to the confirmation behavior it relates to. A single changed
line, docs only, no code change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `mcp-use` CLI reference to document that `servers env unset` fails with `env_variable_not_found` when no matching variable exists in the resolved scope, instead of incorrectly reporting a successful deletion. Also clarifies that `--branch` is part of scope resolution, so unsetting a production key with `--branch` set is a miss, not a fallback. Docs only, no code changes.

<sup>Written for commit ba71050b3dbbc94b6031312fe393db836d104355. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


