### PR TITLE
fix(client): forward roots and defaultRequestOptions in the browser client

### DIFF
--- a/libraries/typescript/.changeset/browser-client-roots-forwarding.md
+++ b/libraries/typescript/.changeset/browser-client-roots-forwarding.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Fix `roots` and `defaultRequestOptions` being ignored by the browser client. Both are declared on the shared `BaseServerConfig` and forwarded on the Node path, but `BrowserMCPClient` builds its own connector options and dropped them, so browser callers advertised no roots and got the SDK default request options instead of theirs.

--- a/libraries/typescript/packages/client/src/core/browser.ts
+++ b/libraries/typescript/packages/client/src/core/browser.ts
@@ -94,6 +94,8 @@ export class BrowserMCPClient extends BaseMCPClient {
       gatewayUrl,
       serverId,
       reconnectionOptions,
+      roots,
+      defaultRequestOptions,
     } = serverConfig;
 
     if (!url) {
@@ -130,6 +132,8 @@ export class BrowserMCPClient extends BaseMCPClient {
       gatewayUrl,
       serverId,
       reconnectionOptions,
+      roots,
+      defaultRequestOptions,
     };
 
     logger.debug(

--- a/libraries/typescript/packages/client/tests/unit/client/browser-server-config-forwarding.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/browser-server-config-forwarding.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { BrowserMCPClient } from "../../../src/core/browser.js";
+
+/**
+ * `roots` and `defaultRequestOptions` are declared on the shared
+ * `BaseServerConfig`, so both environments accept them. The Node path forwards
+ * them through `createConnectorFromConfig`; the browser client builds its own
+ * connector options and used to drop both without a word.
+ */
+describe("BrowserMCPClient server configuration", () => {
+  it("forwards roots and defaultRequestOptions to the connector", () => {
+    const client = new BrowserMCPClient({}) as unknown as {
+      createConnectorFromConfig(config: Record<string, unknown>): {
+        opts: Record<string, unknown>;
+      };
+    };
+
+    const connector = client.createConnectorFromConfig({
+      url: "https://api.example.com/mcp",
+      roots: [{ uri: "file:///work", name: "work" }],
+      defaultRequestOptions: { timeout: 1234 },
+    });
+
+    expect(connector.opts).toMatchObject({
+      roots: [{ uri: "file:///work", name: "work" }],
+      defaultRequestOptions: { timeout: 1234 },
+    });
+  });
+});


### PR DESCRIPTION
## Why

`BaseServerConfig` is documented as "Options shared by HTTP and stdio server configurations" (`core/config.ts:111`) and declares both:

```ts
/** Initial roots advertised to the server. */
roots?: Root[];
/** Default timeout/cancellation options for requests. */
defaultRequestOptions?: RequestOptions;
```

The shared `createConnectorFromConfig` forwards both (`config.ts:372` and `:374`), so the Node client honours them. `BrowserMCPClient` builds its own connector options (`core/browser.ts:80`) and destructures neither, so both are dropped.

Reading the connector back out of the browser path, with `authToken` included as a control so it is clear the probe is looking at the right object:

```
roots                  null
defaultRequestOptions  null
authToken              present
```

A browser caller therefore advertises no roots to the server, and gets the SDK's default request options rather than the timeout and cancellation options it configured. Neither is reported.

## The change

Two fields added to the destructure and to `connectorOptions`, so the browser path forwards what the shared type already promises and the Node path already sends. Nothing else moves.

## Test

`tests/unit/client/browser-server-config-forwarding.test.ts` builds a connector through the browser client and asserts both values arrive. On the unfixed source it fails with `expected { headers: undefined, …(15) } to match object { roots: [ { …(2) } ], …(1) }`.

## Validation

From `libraries/typescript/packages/client`: `vitest run` — 220 passed. `tests/unit/view-renderer.test.ts` fails to start locally on a dangling `@csstools/css-calc` symlink in my pnpm store; it is unrelated to this diff and green in CI.
`tsc --noEmit`, `eslint`, `prettier --check` — clean.
Monorepo preflight — 0 failing packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the browser client so it forwards `roots` and `defaultRequestOptions` from the shared `BaseServerConfig` to the connector. Previously, `BrowserMCPClient` built its own connector options and dropped both, so browser callers advertised no roots and used the SDK default request options instead of their own.

<sup>Written for commit 67319ab28f5a778428759c87eb52f6f77a350e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

