### PR TITLE
fix(server): keep upstream resource annotations and _meta when proxying

### DIFF
--- a/libraries/typescript/.changeset/proxy-resource-metadata.md
+++ b/libraries/typescript/.changeset/proxy-resource-metadata.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Fix proxied resources losing their `annotations` and `_meta`. `ResourceDefinition` carries both and the local registration path preserves them, but the proxy mount copied only `title`, `description` and `mimeType`, so composing an upstream server through `use()` stripped its client hints and extension metadata from `resources/list`.

--- a/libraries/typescript/packages/server/src/mcp-proxy.ts
+++ b/libraries/typescript/packages/server/src/mcp-proxy.ts
@@ -116,6 +116,10 @@ export interface ProxyResource {
   description?: string | undefined;
   /** Resource media type. */
   mimeType?: string | undefined;
+  /** Upstream client hints, e.g. audience and priority. */
+  annotations?: ResourceDefinition["annotations"] | undefined;
+  /** Upstream extension metadata advertised on `resources/list`. */
+  _meta?: ResourceDefinition["_meta"] | undefined;
 }
 
 /** Prompt metadata consumed while introspecting an upstream connection. */
@@ -413,6 +417,10 @@ function mountPlan(host: ProxyMountHost, plan: ProxyNamespacePlan): void {
         ...(resource.mimeType !== undefined && {
           mimeType: resource.mimeType,
         }),
+        ...(resource.annotations !== undefined && {
+          annotations: resource.annotations,
+        }),
+        ...(resource._meta !== undefined && { _meta: resource._meta }),
       },
       async (_uri, ctx) =>
         plan.connection.readResource(upstreamUri, { signal: ctx.signal })

--- a/libraries/typescript/packages/server/tests/proxy.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy.test.ts
@@ -505,4 +505,62 @@ describe("MCPServer.proxy", () => {
     await call;
     expect(forwarded).toEqual([1, 2]);
   });
+
+  it("preserves upstream resource annotations and _meta", async () => {
+    let mounted: Record<string, unknown> | undefined;
+    const host: ProxyMountHost = {
+      isStarted: () => false,
+      hasTool: () => false,
+      hasResource: () => false,
+      hasPrompt: () => false,
+      registerTool: () => {
+        throw new Error("unexpected tool registration");
+      },
+      registerResource: (definition) => {
+        mounted = definition as unknown as Record<string, unknown>;
+      },
+      registerPrompt: () => {
+        throw new Error("unexpected prompt registration");
+      },
+      trackOwner: () => {},
+    };
+    const connection: ProxyConnection = {
+      info: { server: { name: "docs" } },
+      supports: (capability) => capability === "resources",
+      async listTools() {
+        return [];
+      },
+      async callTool() {
+        return { content: [] };
+      },
+      async listResources() {
+        return {
+          resources: [
+            {
+              name: "guide",
+              uri: "https://docs.example.com/guide",
+              annotations: { audience: ["user"], priority: 0.8 },
+              _meta: { "example.com/category": "reference" },
+            },
+          ],
+        };
+      },
+      async readResource() {
+        return { contents: [] };
+      },
+      async listPrompts() {
+        return { prompts: [] };
+      },
+      async getPrompt() {
+        return { messages: [] };
+      },
+    };
+
+    await mountProxyConnection(host, connection);
+
+    expect(mounted).toMatchObject({
+      annotations: { audience: ["user"], priority: 0.8 },
+      _meta: { "example.com/category": "reference" },
+    });
+  });
 });


### PR DESCRIPTION
## Why

`ResourceDefinition` carries `annotations` and `_meta` (`resources.ts:28` and `:36`), and both survive local registration. The proxy mount copies only three fields (`mcp-proxy.ts:405`):

```ts
host.registerResource(
  {
    name,
    uri: proxiedResourceUri(plan.namespace, upstreamUri),
    ...(resource.title !== undefined && { title: resource.title }),
    ...(resource.description !== undefined && { description: resource.description }),
    ...(resource.mimeType !== undefined && { mimeType: resource.mimeType }),
  },
  ...
```

`ProxyResource` does not even declare the other two, so they are dropped at the introspection boundary. The moment a server is composed with `use()`, its upstream resources lose their client hints and their extension metadata from `resources/list`, with nothing reported.

Driving `mountProxyConnection` with an upstream resource that has both, the mounted definition comes back as `{ name: 'docs_guide', uri }` and nothing else.

## Why this one is a straight passthrough

Both fields are documented on the resource descriptor and neither has a framework-derived counterpart. That is not true of a tool's `_meta`, where the server computes `_meta.ui.*` from `view` and `visibility` and those derived values take precedence over colliding entries. There is no such derivation for resources, so there is nothing to collide with and no precedence question to answer.

Prompts need no equivalent change: `PromptDefinition` has no `_meta`.

## The tool case, deliberately not in this PR

Proxied **tools** drop `_meta` the same way, and `ProxyTool` does not declare it either. I left that out because it is a policy question rather than a bug fix: forwarding upstream `_meta` verbatim would let an upstream set framework-owned `_meta.ui.*` keys, including `visibility`, on a tool this server re-exposes. That wants your call on whether to pass it through, or to forward everything except the framework-owned namespace. Happy to send that separately once you say which.

## Test

Added to `tests/proxy.test.ts`, which already exercises `mountProxyConnection` with a fake host. On the unfixed source it fails with `expected { name: 'docs_guide', …(1) } to match object { annotations: { …(2) }, …(1) }`.

## Validation

From `libraries/typescript/packages/server`: `vitest run` — 476 passed, 44 files.
`tsc --noEmit`, `eslint`, `prettier --check` — clean.
Monorepo preflight — 0 failing packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes proxied resources losing their `annotations` and `_meta` fields when composed through `use()`.

- `ProxyResource` now declares and forwards these fields from upstream resources.
- Tools' `_meta` is intentionally left unchanged; forwarding upstream `_meta.ui.*` would conflict with server-computed values.

<sup>Written for commit 94131b9d344f83595b049b5eb243a844a64b5042. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

