### PR TITLE
fix(client): guard listAllResources against pagination loops and empty cursor truncation

### DIFF
--- a/libraries/typescript/packages/client/src/transport/base.ts
+++ b/libraries/typescript/packages/client/src/transport/base.ts
@@ -752,14 +752,26 @@ export abstract class BaseConnector {
       logger.debug("Listing all resources (with auto-pagination)");
       return await this.executeRequest(async () => {
         const allResources: any[] = [];
+        const seenCursors = new Set<string>();
         let cursor: string | undefined = undefined;
 
         do {
           const result: { resources?: any[]; nextCursor?: string } =
-            await client.listResources({ cursor }, options);
+            await client.listResources(
+              cursor !== undefined ? { cursor } : undefined,
+              options
+            );
           allResources.push(...(result.resources || []));
           cursor = result.nextCursor;
-        } while (cursor);
+          if (cursor !== undefined) {
+            if (seenCursors.has(cursor)) {
+              throw new Error(
+                "resources/list returned a repeated pagination cursor"
+              );
+            }
+            seenCursors.add(cursor);
+          }
+        } while (cursor !== undefined);
 
         return { resources: allResources };
       });

--- a/libraries/typescript/packages/client/tests/unit/client/list-all-resources.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/list-all-resources.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BaseConnector } from "../../../src/transport/base.js";
+
+class TestConnector extends BaseConnector {
+  async connect(): Promise<void> {}
+
+  get publicIdentifier(): Record<string, string> {
+    return { type: "test" };
+  }
+}
+
+describe("listAllResources pagination resilience", () => {
+  it("paginates across multiple pages until nextCursor is undefined", async () => {
+    const connector = new TestConnector() as BaseConnector & {
+      client: unknown;
+      capabilitiesCache: unknown;
+    };
+    connector.capabilitiesCache = { resources: {} };
+
+    const listResourcesMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        resources: [{ uri: "res://1", name: "One" }],
+        nextCursor: "cursor-page-2",
+      })
+      .mockResolvedValueOnce({
+        resources: [{ uri: "res://2", name: "Two" }],
+        nextCursor: "cursor-page-3",
+      })
+      .mockResolvedValueOnce({
+        resources: [{ uri: "res://3", name: "Three" }],
+        nextCursor: undefined,
+      });
+
+    connector.client = { listResources: listResourcesMock };
+
+    const result = await connector.listAllResources();
+
+    expect(result).toEqual({
+      resources: [
+        { uri: "res://1", name: "One" },
+        { uri: "res://2", name: "Two" },
+        { uri: "res://3", name: "Three" },
+      ],
+    });
+    expect(listResourcesMock).toHaveBeenCalledTimes(3);
+    // First call must omit cursor or pass undefined, NOT { cursor: undefined }
+    expect(listResourcesMock).toHaveBeenNthCalledWith(1, undefined, undefined);
+    expect(listResourcesMock).toHaveBeenNthCalledWith(
+      2,
+      { cursor: "cursor-page-2" },
+      undefined
+    );
+    expect(listResourcesMock).toHaveBeenNthCalledWith(
+      3,
+      { cursor: "cursor-page-3" },
+      undefined
+    );
+  });
+
+  it("detects immediate repeated cursor cycles and throws an error", async () => {
+    const connector = new TestConnector() as BaseConnector & {
+      client: unknown;
+      capabilitiesCache: unknown;
+    };
+    connector.capabilitiesCache = { resources: {} };
+
+    const listResourcesMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        resources: [{ uri: "res://1", name: "One" }],
+        nextCursor: "repeat-cursor",
+      })
+      .mockResolvedValueOnce({
+        resources: [{ uri: "res://2", name: "Two" }],
+        nextCursor: "repeat-cursor",
+      });
+
+    connector.client = { listResources: listResourcesMock };
+
+    await expect(connector.listAllResources()).rejects.toThrow(
+      "resources/list returned a repeated pagination cursor"
+    );
+    expect(listResourcesMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("detects multi-hop cursor cycles (A -> B -> A) and throws an error", async () => {
+    const connector = new TestConnector() as BaseConnector & {
+      client: unknown;
+      capabilitiesCache: unknown;
+    };
+    connector.capabilitiesCache = { resources: {} };
+
+    const listResourcesMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        resources: [{ uri: "res://1" }],
+        nextCursor: "cursor-A",
+      })
+      .mockResolvedValueOnce({
+        resources: [{ uri: "res://2" }],
+        nextCursor: "cursor-B",
+      })
+      .mockResolvedValueOnce({
+        resources: [{ uri: "res://3" }],
+        nextCursor: "cursor-A",
+      });
+
+    connector.client = { listResources: listResourcesMock };
+
+    await expect(connector.listAllResources()).rejects.toThrow(
+      "resources/list returned a repeated pagination cursor"
+    );
+    expect(listResourcesMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not terminate prematurely when nextCursor is an empty string", async () => {
+    const connector = new TestConnector() as BaseConnector & {
+      client: unknown;
+      capabilitiesCache: unknown;
+    };
+    connector.capabilitiesCache = { resources: {} };
+
+    const listResourcesMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        resources: [{ uri: "res://1" }],
+        nextCursor: "",
+      })
+      .mockResolvedValueOnce({
+        resources: [{ uri: "res://2" }],
+        nextCursor: undefined,
+      });
+
+    connector.client = { listResources: listResourcesMock };
+
+    const result = await connector.listAllResources();
+
+    expect(result).toEqual({
+      resources: [{ uri: "res://1" }, { uri: "res://2" }],
+    });
+    expect(listResourcesMock).toHaveBeenCalledTimes(2);
+    expect(listResourcesMock).toHaveBeenNthCalledWith(1, undefined, undefined);
+    expect(listResourcesMock).toHaveBeenNthCalledWith(
+      2,
+      { cursor: "" },
+      undefined
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2470

### Summary of Changes
1. **Defensive Cycle Detection**:
   - Added `seenCursors = new Set<string>()` inside `BaseConnector.listAllResources` loop.
   - Throws `new Error("resources/list returned a repeated pagination cursor")` if an upstream MCP server yields an already-seen cursor, matching the existing defensive pattern in `listAllSkills` (`session.ts:673`).
   - Prevents unconstrained memory growth and event-loop-blocking DoS crashes caused by circular cursor loops.

2. **Empty-String Cursor Handling**:
   - Changed loop condition from `while (cursor);` to `while (cursor !== undefined);`.
   - Ensures servers that use empty-string cursor values (such as `""` offset markers) do not have pagination prematurely halted on page 1.

3. **Clean First-Page Parameter Hygiene**:
   - Passed `cursor !== undefined ? { cursor } : undefined` to `client.listResources(...)` instead of `{ cursor }`.
   - Prevents sending `{ cursor: undefined }` to strict JSON-RPC servers on initial listing requests.

4. **Unit Tests**:
   - Added `packages/client/tests/unit/client/list-all-resources.test.ts` verifying:
     - Multi-page resource aggregation and clean initial parameters.
     - Immediate repeated cursor cycle detection.
     - Multi-hop cursor cycle detection (`A -> B -> A`).
     - Empty-string cursor continuation without premature termination.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `listAllResources` resilient to misbehaving pagination cursors. Previously, a repeated cursor caused an infinite loop and an empty-string cursor stopped pagination after the first page. Now repeated cursors throw an error and empty-string cursors continue correctly.

**Changes**
- Detects repeated pagination cursors and throws an error instead of looping forever.
- Treats empty-string cursors as valid continuation tokens instead of terminating pagination.
- Omits the `cursor` parameter on the first request to avoid sending `{ cursor: undefined }`.
- Adds unit tests covering multi-page aggregation, cycle detection, and empty-string cursor continuation.

<sup>Written for commit 45fd45bcc2a483d59ea8101b287fa1c34467048b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

