### PR TITLE
fix(server): forward cancellation signal to upstream getPrompt in reverse proxy

### DIFF
--- a/libraries/typescript/packages/server/src/mcp-proxy.ts
+++ b/libraries/typescript/packages/server/src/mcp-proxy.ts
@@ -84,7 +84,8 @@ export interface ProxyConnection {
   /** Render an upstream prompt. */
   getPrompt(
     name: string,
-    args: Record<string, unknown>
+    args: Record<string, unknown>,
+    options?: ProxyRequestOptions
   ): Promise<GetPromptResult>;
 }
 
@@ -437,7 +438,8 @@ function mountPlan(host: ProxyMountHost, plan: ProxyNamespacePlan): void {
         }),
         schema: passthroughJsonSchema(promptArgsToJsonSchema(prompt.arguments)),
       },
-      async (params) => plan.connection.getPrompt(upstreamName, params)
+      async (params, ctx) =>
+        plan.connection.getPrompt(upstreamName, params, { signal: ctx.signal })
     );
   }
 }

--- a/libraries/typescript/packages/server/tests/proxy.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy.test.ts
@@ -505,4 +505,70 @@ describe("MCPServer.proxy", () => {
     await call;
     expect(forwarded).toEqual([1, 2]);
   });
+
+  it("forwards cancellation signal to upstream getPrompt when rendering a proxied prompt", async () => {
+    let mountedPrompt:
+      | ((
+          params: Record<string, unknown>,
+          ctx: { signal: AbortSignal }
+        ) => Promise<unknown>)
+      | undefined;
+    const host: ProxyMountHost = {
+      isStarted: () => false,
+      hasTool: () => false,
+      hasResource: () => false,
+      hasPrompt: () => false,
+      registerTool: () => {
+        throw new Error("unexpected tool registration");
+      },
+      registerResource: () => {
+        throw new Error("unexpected resource registration");
+      },
+      registerPrompt: (_definition, callback) => {
+        mountedPrompt = callback as unknown as typeof mountedPrompt;
+      },
+      trackOwner: () => {},
+    };
+    const getPromptSpy = vi.fn().mockResolvedValue({ messages: [] });
+    const connection: ProxyConnection = {
+      info: { server: { name: "prompt-cancellation" } },
+      supports: (capability) => capability === "prompts",
+      async listTools() {
+        return [];
+      },
+      async callTool() {
+        return { content: [] };
+      },
+      async readResource() {
+        return { contents: [] };
+      },
+      async listPrompts() {
+        return {
+          prompts: [
+            {
+              name: "generate",
+              arguments: [{ name: "topic", required: true }],
+            },
+          ],
+        };
+      },
+      getPrompt: getPromptSpy,
+    };
+
+    await mountProxyConnection(host, connection);
+    expect(mountedPrompt).toBeDefined();
+
+    const controller = new AbortController();
+    await mountedPrompt!(
+      { topic: "architecture" },
+      { signal: controller.signal }
+    );
+
+    expect(getPromptSpy).toHaveBeenCalledTimes(1);
+    expect(getPromptSpy).toHaveBeenCalledWith(
+      "generate",
+      { topic: "architecture" },
+      { signal: controller.signal }
+    );
+  });
 });


### PR DESCRIPTION
# Pull Request Description

## Where did you find this issue?

Encountered when aggregating multiple upstream MCP servers behind an API gateway using `MCPServer.proxy` (`packages/server/src/mcp-proxy.ts`).

While the proxy implementation correctly forwards the client's `AbortSignal` (`{ signal: ctx.signal }`) for tool calls (`tools/call`) and resource reads (`resources/read`), the registration for prompt rendering (`prompts/get`) invoked `plan.connection.getPrompt(upstreamName, params)` without passing the cancellation signal option.

When an external consumer cancelled an in-flight prompt request (or disconnected before prompt generation finished), the cancellation was never propagated to the upstream server. The upstream continued executing expensive prompt compilation, template evaluation, and upstream LLM calls unnecessarily.

### Minimal Runnable Reproduction

```typescript
import { MCPServer } from "mcp-use";

const server = new MCPServer({ name: "proxy-gateway" });
await server.proxy({
  namespace: "upstream",
  transport: { type: "http", url: "https://upstream.example.com/mcp" },
});

const controller = new AbortController();
// Trigger prompt render and immediately abort:
const promptPromise = server.getPrompt(
  "upstream_summarize_doc",
  { id: "doc_123" },
  { signal: controller.signal }
);
controller.abort();

// Observed: Upstream server never receives an abort signal and continues processing.
// Expected: Upstream getPrompt receives the AbortSignal and aborts immediately.
```

---

Fixes #2473

### Summary of Changes
1. **Forward `AbortSignal` for Proxied Prompts**:
   - In `mcp-proxy.ts` `mountPlan`, updated `registerPrompt` callback from `async (params) => plan.connection.getPrompt(upstreamName, params)` to `async (params, ctx) => plan.connection.getPrompt(upstreamName, params, { signal: ctx.signal })`.
   - Ensures that client disconnections, aborts, and timeouts propagate upstream to terminate zombie prompt generation requests, matching the cancellation behavior of `callTool` and `readResource`.

2. **Update `ProxyConnection.getPrompt` Interface**:
   - Added optional `options?: ProxyRequestOptions` to `ProxyConnection.getPrompt(name, args, options?)`.

3. **Unit Tests**:
   - Added unit test in `packages/server/tests/proxy.test.ts` verifying that `ctx.signal` is forwarded to upstream `connection.getPrompt`.
