### PR TITLE
fix(client): resolve views capability and forward roots and defaultRequestOptions in BrowserMCPClient

### DIFF
--- a/libraries/typescript/packages/client/src/core/browser.ts
+++ b/libraries/typescript/packages/client/src/core/browser.ts
@@ -1,6 +1,10 @@
 import type { OAuthClientProvider } from "@modelcontextprotocol/client";
 import type { AutoOAuthOptions, CallbackConfig } from "./config.js";
-import { normalizeClientInfo, resolveCallbacks } from "./config.js";
+import {
+  normalizeClientInfo,
+  resolveCallbacks,
+  resolveClientOptions,
+} from "./config.js";
 import type { BaseConnector } from "../transport/base.js";
 import { HttpConnector } from "../transport/http.js";
 import {
@@ -94,6 +98,8 @@ export class BrowserMCPClient extends BaseMCPClient {
       gatewayUrl,
       serverId,
       reconnectionOptions,
+      roots,
+      defaultRequestOptions,
     } = serverConfig;
 
     if (!url) {
@@ -120,7 +126,9 @@ export class BrowserMCPClient extends BaseMCPClient {
       authProvider,
       detectMixedAuth,
       wrapTransport,
-      clientOptions,
+      clientOptions: resolveClientOptions(clientOptions),
+      roots,
+      defaultRequestOptions,
       onSampling: resolved.onSampling,
       onElicitation: resolved.onElicitation,
       onNotification: resolved.onNotification,

--- a/libraries/typescript/packages/client/tests/unit/client/browser-client.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/browser-client.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { BrowserMCPClient } from "../../../src/core/browser.js";
+import { HttpConnector } from "../../../src/transport/http.js";
+
+class ExposedBrowserMCPClient extends BrowserMCPClient {
+  public exposeCreateConnectorFromConfig(serverConfig: Record<string, any>) {
+    return this.createConnectorFromConfig(serverConfig);
+  }
+}
+
+describe("BrowserMCPClient createConnectorFromConfig", () => {
+  it("resolves capabilities.views shorthand into io.modelcontextprotocol/ui extension", () => {
+    const client = new ExposedBrowserMCPClient({
+      mcpServers: {
+        uiServer: {
+          url: "https://example.com/mcp",
+          clientOptions: {
+            capabilities: {
+              views: true,
+              experimental: { customFeature: true },
+            },
+          },
+        },
+      },
+    });
+
+    const connector = client.exposeCreateConnectorFromConfig({
+      url: "https://example.com/mcp",
+      clientOptions: {
+        capabilities: {
+          views: true,
+          experimental: { customFeature: true },
+        },
+      },
+    }) as HttpConnector & { opts: Record<string, any> };
+
+    expect(connector).toBeInstanceOf(HttpConnector);
+    expect(connector.opts.clientOptions).toEqual({
+      capabilities: {
+        experimental: { customFeature: true },
+        extensions: {
+          "io.modelcontextprotocol/ui": {
+            mimeTypes: ["text/html;profile=mcp-app"],
+          },
+        },
+      },
+    });
+  });
+
+  it("forwards roots to connector and initializes rootsCache", () => {
+    const client = new ExposedBrowserMCPClient();
+    const roots = [{ uri: "file:///workspace", name: "Workspace Root" }];
+
+    const connector = client.exposeCreateConnectorFromConfig({
+      url: "https://example.com/mcp",
+      roots,
+    }) as HttpConnector & { opts: Record<string, any>; rootsCache: unknown[] };
+
+    expect(connector.opts.roots).toEqual(roots);
+    expect(connector.rootsCache).toEqual(roots);
+  });
+
+  it("forwards defaultRequestOptions to connector", () => {
+    const client = new ExposedBrowserMCPClient();
+    const defaultRequestOptions = {
+      timeout: 15000,
+    };
+
+    const connector = client.exposeCreateConnectorFromConfig({
+      url: "https://example.com/mcp",
+      defaultRequestOptions,
+    }) as HttpConnector & { opts: Record<string, any> };
+
+    expect(connector.opts.defaultRequestOptions).toEqual(defaultRequestOptions);
+  });
+
+  it("preserves clientOptions when views capability is not requested", () => {
+    const client = new ExposedBrowserMCPClient();
+    const clientOptions = {
+      capabilities: {
+        tools: {},
+      },
+    };
+
+    const connector = client.exposeCreateConnectorFromConfig({
+      url: "https://example.com/mcp",
+      clientOptions,
+    }) as HttpConnector & { opts: Record<string, any> };
+
+    expect(connector.opts.clientOptions).toEqual(clientOptions);
+  });
+});


### PR DESCRIPTION
# Pull Request Description

## Where did you find this issue?

Encountered when migrating browser-based client applications to `BrowserMCPClient` (`packages/client/src/core/browser.ts`).

While `BrowserMCPClient` accepted `roots` and `defaultRequestOptions` (for custom HTTP headers like `Authorization` or `X-Tenant-ID`) in its constructor options interface, it failed to pass them through to the underlying `HttpConnector`. Furthermore, `clientOptions` was passed un-normalized without invoking `resolveClientOptions()`, which expands `capabilities.views: true` into the standard `io.modelcontextprotocol/ui` extension during the protocol handshake.

As a result:
1. Authenticated MCP backends requiring custom headers rejected browser requests with `401 Unauthorized`.
2. Servers querying client workspace `roots` received an empty list.
3. Interactive UI view components failed to register because servers (`ctx.client.supportsViews()`) saw raw `{ views: true }` instead of the expected protocol extension.

### Minimal Runnable Reproduction

```typescript
import { BrowserMCPClient } from "@mcp-use/client";

const client = new BrowserMCPClient({
  url: "https://api.example.com/mcp",
  defaultRequestOptions: {
    headers: { Authorization: "Bearer token123" },
  },
  roots: [{ uri: "file:///workspace", name: "Workspace" }],
  clientOptions: {
    capabilities: { views: true },
  },
});

await client.connect();
// Observed: Network inspection shows headers are dropped from HTTP requests; 
// Client capabilities sent to server omit views extension and roots declarations.
```

---

Fixes #2475

### Overview & Motivation
In `@mcp-use/client`, `index-browser.ts` exports `BrowserMCPClient as MCPClient` for browser and worker runtimes. 

While the Node client (`core/node.ts:520`) and shared config builder (`core/config.ts:373`) invoke `resolveClientOptions()` to expand `capabilities.views: true` into the official `io.modelcontextprotocol/ui` extension and forward `roots`/`defaultRequestOptions`, `BrowserMCPClient.createConnectorFromConfig` (`core/browser.ts`) omitted these steps.

This caused browser clients to:
1. Announce raw `{ views: true }` during the `initialize` handshake instead of the `io.modelcontextprotocol/ui` extension, causing MCP servers (`ctx.client.supportsViews()`) to treat the browser as non-UI capable and refuse to render interactive views.
2. Drop configured `roots` and `defaultRequestOptions` from `serverConfig`.

### Summary of Changes
1. **Views Shorthand Resolution**:
   - Wrapped `clientOptions` with `resolveClientOptions(clientOptions)` in `BrowserMCPClient.createConnectorFromConfig`.
   - Restores the documented contract ([`docs/typescript/client/migration.mdx:180`](https://github.com/mcp-use/mcp-use/blob/main/docs/typescript/client/migration.mdx#L180)): setting `clientOptions: { capabilities: { views: true } }` now correctly advertises `io.modelcontextprotocol/ui` (`text/html;profile=mcp-app`).
2. **Options Parity**:
   - De-structured and forwarded `roots` and `defaultRequestOptions` from `serverConfig` to `connectorOptions`, populating `connector.rootsCache` and default request options.
3. **Unit Tests**:
   - Added `packages/client/tests/unit/client/browser-client.test.ts` (4 unit tests):
     - `capabilities.views: true` expansion into `io.modelcontextprotocol/ui`.
     - `roots` forwarding and `rootsCache` initialization.
     - `defaultRequestOptions` forwarding.
     - Preservation of existing capabilities when `views` is not set.

### Verification
- `tests/unit/client/browser-client.test.ts`: Passed (4/4).
- Full `@mcp-use/client` test suite: 57 test files passed, 349 tests passed (100%).
- `npm run build`: `tsup` and `tsc --emitDeclarationOnly` generated declarations cleanly.
- Prettier and ESLint: 0 errors.
