### PR TITLE
docs: fix the TypeScript test commands in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,11 +274,11 @@ pnpm --filter mcp-use test
 pnpm --filter @mcp-use/inspector test
 pnpm --filter @mcp-use/cli test
 
-# Run unit tests only (mcp-use package)
-pnpm --filter mcp-use test:unit
+# Run tests once without watch mode (mcp-use package)
+pnpm --filter mcp-use test:run
 
 # Run agent integration tests (requires OPENAI_API_KEY)
-pnpm --filter mcp-use test:integration:agent
+pnpm --filter @mcp-use/agent test:integration:agent
 ```
 
 ### Changesets


### PR DESCRIPTION
Fixes #2472.

## Why

Both commands in the TypeScript testing section fail when run as written from `libraries/typescript`:

```console
$ pnpm --filter mcp-use test:unit
[ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT] None of the selected packages has a "test:unit" script

$ pnpm --filter mcp-use test:integration:agent
[ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT] None of the selected packages has a "test:integration:agent" script
```

Two different causes:

- The `mcp-use` package has `test` and `test:run`, and no `test:unit`. #2213 moved CI onto `test:run` when #2203 reported the missing script, and the contributor guide was left behind.
- `test:integration:agent` does exist, but on `@mcp-use/agent`. Filtering to `mcp-use` selects a package that has never had it.

## The change

```diff
-# Run unit tests only (mcp-use package)
-pnpm --filter mcp-use test:unit
+# Run tests once without watch mode (mcp-use package)
+pnpm --filter mcp-use test:run

 # Run agent integration tests (requires OPENAI_API_KEY)
-pnpm --filter mcp-use test:integration:agent
+pnpm --filter @mcp-use/agent test:integration:agent
```

The comment above the first command changes too: `test:run` is the whole suite without watch mode, not a unit-only subset, so calling it "unit tests only" would be the next thing to go stale.

Both replacements verified against the package manifests and by running `pnpm --filter <pkg> run` to confirm the script is listed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TypeScript test commands in CONTRIBUTING so they run successfully from `libraries/typescript` instead of failing with `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`.

- `test:unit` doesn't exist on `mcp-use`; the guide now uses `test:run`, which CI also uses.
- `test:integration:agent` lives on `@mcp-use/agent`, not `mcp-use`, so the filter now points to the right package.
- The comment above the first command now says "tests once without watch mode" instead of "unit tests only," since `test:run` runs the whole suite.

<sup>Written for commit 79747f3713259a37a3ff786fcb93ab55134b9e00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

