### PR TITLE
docs: correct TypeScript test commands in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,11 +274,11 @@ pnpm --filter mcp-use test
 pnpm --filter @mcp-use/inspector test
 pnpm --filter @mcp-use/cli test
 
-# Run unit tests only (mcp-use package)
-pnpm --filter mcp-use test:unit
+# Run server tests
+pnpm --filter mcp-use test:run
 
 # Run agent integration tests (requires OPENAI_API_KEY)
-pnpm --filter mcp-use test:integration:agent
+pnpm --filter @mcp-use/agent test:integration:agent
 ```
 
 ### Changesets


### PR DESCRIPTION
## Language / Project Scope

- [x] Documentation only

## Changes

The TypeScript testing instructions reference two scripts that don't exist in the `mcp-use` package.

This updates the server command to `pnpm --filter mcp-use test:run` and points the agent integration command at `@mcp-use/agent`. The server test comment is also updated to match.

This follows up on #2213, which corrected the server command in CI but left the contributor guide unchanged.

## Testing

- Reproduced the missing-script errors from both documented commands.
- Checked the corrected commands against the packages' script definitions.
- `git diff --check` passes.
- A local agent integration run reached the tests but reported 8 failures, 6 passes and 3 skips. Failures included agent initialization and structured-output handling; this PR only changes documentation.

## Related Issues

Closes #2472

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TypeScript test commands in `CONTRIBUTING.md` so the documented commands match the actual package scripts.

- Replaces the nonexistent `test:unit` script with `pnpm --filter mcp-use test:run` for server tests.
- Points the agent integration test at the `@mcp-use/agent` package instead of `mcp-use`.
- Updates the server test comment to match the new command.

Closes #2472.

<sup>Written for commit 8ec00199c4361820112d571a9b3e7ca66d5effc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

