### PR TITLE
fix(client): await predecessor child process exit on stdio failed handshake and retries

### DIFF
--- a/libraries/typescript/.changeset/stdio-process-exit-join.md
+++ b/libraries/typescript/.changeset/stdio-process-exit-join.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Ensure `StdioConnectionManager` joins in-flight SDK transport close and awaits predecessor child process exit to prevent dual-process overlap on failed handshake and retries.

--- a/libraries/typescript/packages/client/src/transport/stdio.ts
+++ b/libraries/typescript/packages/client/src/transport/stdio.ts
@@ -360,26 +360,42 @@ export class StdioConnectionManager extends ConnectionManager<StdioClientTranspo
       this._childProcess ??
       (connection as unknown as { _process?: ChildProcess })._process;
 
-    if (child && child.exitCode === null && child.signalCode === null) {
-      await Promise.race([
-        new Promise<void>((resolve) => {
+    try {
+      if (child && child.exitCode === null && child.signalCode === null) {
+        let timedOut = false;
+        let timeout: NodeJS.Timeout | undefined;
+        const exited = new Promise<void>((resolve) => {
           child.once("exit", () => resolve());
           child.once("close", () => resolve());
-        }),
-        new Promise<void>((resolve) => {
-          const timer = setTimeout(() => {
-            if (child.exitCode === null && child.signalCode === null) {
-              try {
-                child.kill("SIGKILL");
-              } catch {
-                /* already exited */
-              }
+        });
+
+        await Promise.race([
+          exited,
+          new Promise<void>((resolve) => {
+            timeout = setTimeout(() => {
+              timedOut = true;
+              resolve();
+            }, 2000);
+            timeout?.unref?.();
+          }),
+        ]);
+
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+
+        if (timedOut) {
+          if (child.exitCode === null && child.signalCode === null) {
+            try {
+              child.kill("SIGKILL");
+            } catch {
+              /* already exited */
             }
-            resolve();
-          }, 2000);
-          timer.unref?.();
-        }),
-      ]);
+          }
+          await exited;
+        }
+      }
+    } finally {
       this._childProcess = null;
     }
   }

--- a/libraries/typescript/packages/client/src/transport/stdio.ts
+++ b/libraries/typescript/packages/client/src/transport/stdio.ts
@@ -5,6 +5,7 @@ import type {
 import { Client } from "@modelcontextprotocol/client";
 import type { StdioServerParameters } from "@modelcontextprotocol/client/stdio";
 import type { Writable } from "node:stream";
+import type { ChildProcess } from "node:child_process";
 
 import process from "node:process";
 import type { ConnectorInitOptions } from "./base.js";
@@ -223,6 +224,15 @@ export class StdioConnector extends BaseConnector {
       "command&args": `${this.command} ${this.args.join(" ")}`,
     };
   }
+
+  /**
+   * Returns the process ID of the running child process, if started.
+   */
+  get pid(): number | null {
+    return (
+      (this.connectionManager as StdioConnectionManager | null)?.pid ?? null
+    );
+  }
 }
 
 /**
@@ -233,6 +243,8 @@ export class StdioConnectionManager extends ConnectionManager<StdioClientTranspo
   private readonly errlog: Writable;
   private _transport: StdioClientTransport | null = null;
   private _stderrSource: NodeJS.ReadableStream | null = null;
+  private _childProcess: ChildProcess | null = null;
+  private _closePromise: Promise<void> | null = null;
   private readonly _onErrlogError = (error: Error): void => {
     logger.warn(`Error writing child stderr to errlog: ${error}`);
   };
@@ -252,6 +264,20 @@ export class StdioConnectionManager extends ConnectionManager<StdioClientTranspo
     this.errlog = errlog;
   }
 
+  /**
+   * Returns the underlying spawned child process, if started.
+   */
+  get childProcess(): ChildProcess | null {
+    return this._childProcess;
+  }
+
+  /**
+   * Returns the process ID of the spawned child process, if started.
+   */
+  get pid(): number | null {
+    return this._childProcess?.pid ?? this._transport?.pid ?? null;
+  }
+
   protected async establishConnection(): Promise<StdioClientTransport> {
     // The SDK defaults stderr to "inherit", which leaves `transport.stderr`
     // null and makes the forwarding below dead code. Default to "pipe" so
@@ -259,13 +285,38 @@ export class StdioConnectionManager extends ConnectionManager<StdioClientTranspo
     // after the spread on purpose: an explicit `stderr: undefined` in
     // serverParams would otherwise defeat the default.
     const stderr = this.serverParams.stderr ?? "pipe";
-    this._transport = new StdioClientTransport({
+    const transport = new StdioClientTransport({
       ...this.serverParams,
       stderr,
     });
+    this._transport = transport;
+
+    // Wrap start() to capture the spawned ChildProcess instance as soon as it launches
+    const originalStart = transport.start.bind(transport);
+    transport.start = async () => {
+      await originalStart();
+      const proc = (transport as unknown as { _process?: ChildProcess })
+        ._process;
+      if (proc) {
+        this._childProcess = proc;
+      }
+    };
+
+    // Wrap close() so multiple callers (e.g. SDK legacyHandshake error handler
+    // and subsequent cleanupResources) join the same in-flight teardown promise
+    // instead of returning an instant no-op once transport._process is cleared.
+    const originalClose = transport.close.bind(transport);
+    transport.close = () => {
+      if (!this._closePromise) {
+        this._closePromise = originalClose().finally(() => {
+          this._closePromise = null;
+        });
+      }
+      return this._closePromise;
+    };
 
     // Only "pipe" leaves a readable stream; "inherit" and "ignore" do not.
-    const childStderr = this._transport.stderr;
+    const childStderr = transport.stderr;
     if (stderr === "pipe" && childStderr && "pipe" in childStderr) {
       this._stderrSource = childStderr as unknown as NodeJS.ReadableStream;
       // `errlog` is caller-owned and may be reused across reconnects, so the
@@ -279,25 +330,57 @@ export class StdioConnectionManager extends ConnectionManager<StdioClientTranspo
     }
 
     logger.debug(`${this.constructor.name} connected successfully`);
-    return this._transport;
+    return transport;
   }
 
   protected async closeConnection(
-    _connection: StdioClientTransport
+    connection: StdioClientTransport
   ): Promise<void> {
     if (this._stderrSource) {
       this._stderrSource.unpipe(this.errlog);
       this.errlog.off("error", this._onErrlogError);
       this._stderrSource = null;
     }
-    if (this._transport) {
+
+    const transport = this._transport ?? connection;
+    if (transport) {
       try {
-        await this._transport.close();
+        await transport.close();
       } catch (e) {
         logger.warn(`Error closing stdio transport: ${e}`);
       } finally {
-        this._transport = null;
+        if (this._transport === transport) {
+          this._transport = null;
+        }
       }
+    }
+
+    // Process exit join barrier: Ensure the predecessor process has truly exited
+    const child =
+      this._childProcess ??
+      (connection as unknown as { _process?: ChildProcess })._process;
+
+    if (child && child.exitCode === null && child.signalCode === null) {
+      await Promise.race([
+        new Promise<void>((resolve) => {
+          child.once("exit", () => resolve());
+          child.once("close", () => resolve());
+        }),
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              try {
+                child.kill("SIGKILL");
+              } catch {
+                /* already exited */
+              }
+            }
+            resolve();
+          }, 2000);
+          timer.unref?.();
+        }),
+      ]);
+      this._childProcess = null;
     }
   }
 }

--- a/libraries/typescript/packages/client/tests/helpers/exit-barrier-server.mjs
+++ b/libraries/typescript/packages/client/tests/helpers/exit-barrier-server.mjs
@@ -1,0 +1,38 @@
+import { createInterface } from "node:readline";
+
+let initialize;
+const hold = setInterval(() => {}, 1000);
+process.on("SIGUSR2", () => clearInterval(hold));
+if (process.argv.includes("--ignore-term")) {
+  process.on("SIGTERM", () => process.stderr.write("TERM_IGNORED\n"));
+}
+const lines = createInterface({ input: process.stdin });
+lines.on("close", () => process.stderr.write("STDIN_CLOSED\n"));
+lines.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    initialize = message;
+    process.stderr.write("READY\n");
+  } else if (message.method === "probe/release") {
+    const response = message.params.fail
+      ? { error: { code: -32603, message: "injected handshake failure" } }
+      : {
+          result: {
+            protocolVersion: initialize.params.protocolVersion,
+            capabilities: { tools: {} },
+            serverInfo: { name: "exit-barrier-probe", version: "1" },
+          },
+        };
+    process.stdout.write(
+      JSON.stringify({ jsonrpc: "2.0", id: initialize.id, ...response }) + "\n"
+    );
+  } else if (message.method === "tools/list") {
+    process.stdout.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: message.id,
+        result: { tools: [] },
+      }) + "\n"
+    );
+  }
+});

--- a/libraries/typescript/packages/client/tests/unit/transport/stdio-exit-barrier-probe.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/transport/stdio-exit-barrier-probe.test.ts
@@ -1,0 +1,160 @@
+import { Writable } from "node:stream";
+import { setImmediate } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import { StdioClientTransport } from "@modelcontextprotocol/client/stdio";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPConnection } from "../../../src/core/session.js";
+import { StdioConnector } from "../../../src/transport/stdio.js";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => (resolve = done));
+  return { promise, resolve };
+}
+
+const helper = fileURLToPath(
+  new URL("../../helpers/exit-barrier-server.mjs", import.meta.url)
+);
+const realStart = StdioClientTransport.prototype.start;
+const transports: StdioClientTransport[] = [];
+const pids: number[] = [];
+const sessions: MCPConnection[] = [];
+let observeChunk: (chunk: Buffer) => void;
+
+function fixture(ignoreTerm = false) {
+  let ready = deferred();
+  const stdinClosed = deferred();
+  const termIgnored = deferred();
+  let pending = "";
+  // Observe the real SDK stream independently of manager-owned piping: cleanup
+  // can unpipe the caller's errlog before the child emits its shutdown markers.
+  observeChunk = (chunk: Buffer) => {
+    pending += String(chunk);
+    let newline: number;
+    while ((newline = pending.indexOf("\n")) !== -1) {
+      const line = pending.slice(0, newline);
+      pending = pending.slice(newline + 1);
+      if (line === "READY") ready.resolve();
+      if (line === "STDIN_CLOSED") stdinClosed.resolve();
+      if (line === "TERM_IGNORED") termIgnored.resolve();
+    }
+  };
+  const connector = new StdioConnector({
+    command: process.execPath,
+    args: [helper, ...(ignoreTerm ? ["--ignore-term"] : [])],
+    errlog: new Writable({
+      write(_chunk, _encoding, done) {
+        done();
+      },
+    }),
+  });
+  const session = new MCPConnection(connector, false);
+  sessions.push(session);
+  return {
+    session,
+    stdinClosed,
+    termIgnored,
+    get ready() {
+      return ready.promise;
+    },
+    resetReady() {
+      ready = deferred();
+    },
+  };
+}
+
+async function release(fail: boolean) {
+  await transports.at(-1)!.send({
+    jsonrpc: "2.0",
+    method: "probe/release",
+    params: { fail },
+  });
+}
+
+function expectExited(pid: number) {
+  expect(() => process.kill(pid, 0)).toThrowError(
+    expect.objectContaining({ code: "ESRCH" })
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(StdioClientTransport.prototype, "start").mockImplementation(
+    async function (this: StdioClientTransport) {
+      this.stderr?.on("data", observeChunk);
+      await realStart.call(this);
+      if (this.pid === null) throw new Error("Missing child PID");
+      transports.push(this);
+      pids.push(this.pid);
+    }
+  );
+});
+
+afterEach(async () => {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGUSR2");
+    } catch {
+      // This fixture's child already exited.
+    }
+  }
+  await Promise.allSettled(sessions.map((session) => session.disconnect()));
+  await Promise.allSettled(transports.map((transport) => transport.close()));
+  sessions.length = transports.length = pids.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe("stdio exit barrier through MCPConnection", () => {
+  it("keeps failed connect pending until gated exit and retries with a usable child", async () => {
+    const f = fixture();
+    let settled = false;
+    const initial = Promise.allSettled([f.session.connect()]).then((result) => {
+      settled = true;
+      return result;
+    });
+    await f.ready;
+    const oldPid = pids[0];
+    await release(true);
+    await Promise.race([f.stdinClosed.promise, initial]);
+    // Flush promise callbacks after observing real EOF; no sleep is the oracle.
+    await setImmediate();
+    expect(settled).toBe(false);
+    expect(() => process.kill(oldPid, 0)).not.toThrow();
+    process.kill(oldPid, "SIGUSR2");
+    const [outcome] = await initial;
+    expect(outcome.status).toBe("rejected");
+    if (outcome.status === "rejected") {
+      expect(String(outcome.reason)).toContain("injected handshake failure");
+    }
+    expectExited(oldPid);
+    expect(f.session.isConnected).toBe(false);
+
+    f.resetReady();
+    const retry = f.session.connect();
+    await f.ready;
+    expect(pids).toHaveLength(2);
+    expectExited(oldPid);
+    await release(false);
+    await retry;
+    await f.session.initialize();
+    expect(await f.session.listTools()).toEqual([]);
+    process.kill(pids[1], "SIGUSR2");
+    await f.session.disconnect();
+    expectExited(pids[1]);
+  });
+
+  it("reaps a child that ignores SIGTERM before failed connect settles", async () => {
+    const f = fixture(true);
+    const initial = Promise.allSettled([f.session.connect()]);
+    await f.ready;
+    await release(true);
+    let termObserved = false;
+    void f.termIgnored.promise.then(() => {
+      termObserved = true;
+    });
+    const [outcome] = await initial;
+    expect(outcome.status).toBe("rejected");
+    expectExited(pids[0]);
+    expect(termObserved).toBe(true);
+    expect(f.session.isConnected).toBe(false);
+  });
+});

--- a/libraries/typescript/packages/client/tests/unit/transport/stdio-process-exit.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/transport/stdio-process-exit.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { Writable } from "node:stream";
+import process from "node:process";
+import {
+  StdioConnector,
+  StdioConnectionManager,
+} from "../../../src/transport/stdio.js";
+
+const failingHandshakeServer = String.raw`
+const readline = require("node:readline");
+
+// Emit PID on stderr immediately
+process.stderr.write(process.pid + "\n");
+
+let held;
+let released = false;
+process.on("SIGUSR2", () => {
+  released = true;
+  clearInterval(held);
+});
+
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("close", () => {
+  if (!released) {
+    held = setInterval(() => {}, 1000);
+  }
+});
+
+lines.on("line", (line) => {
+  try {
+    const request = JSON.parse(line);
+    if (request.method === "initialize") {
+      process.stdout.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: request.id,
+          error: { code: -32603, message: "injected initialization failure" },
+        }) + "\n"
+      );
+    }
+  } catch {}
+});
+`;
+
+const workingServer = String.raw`
+const readline = require("node:readline");
+
+// Emit PID on stderr immediately
+process.stderr.write(process.pid + "\n");
+
+const lines = readline.createInterface({ input: process.stdin });
+lines.on("line", (line) => {
+  try {
+    const request = JSON.parse(line);
+    if (request.id === undefined) return;
+    let result;
+    if (request.method === "initialize") {
+      result = {
+        protocolVersion: request.params.protocolVersion,
+        capabilities: {},
+        serverInfo: { name: "working-server", version: "1.0.0" }
+      };
+    } else if (request.method === "tools/list") {
+      result = { tools: [] };
+    } else {
+      return;
+    }
+    process.stdout.write(
+      JSON.stringify({ jsonrpc: "2.0", id: request.id, result }) + "\n"
+    );
+  } catch {}
+});
+`;
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("StdioConnector process lifecycle and exit guarantees", () => {
+  it("ensures the child process is terminated when connection fails", async () => {
+    let capturedPid: number | null = null;
+    const errlog = new Writable({
+      write(chunk, _encoding, callback) {
+        const text = chunk.toString().trim();
+        const num = Number(text);
+        if (!Number.isNaN(num) && num > 0) {
+          capturedPid = num;
+        }
+        callback();
+      },
+    });
+
+    const connector = new StdioConnector({
+      command: process.execPath,
+      args: ["-e", failingHandshakeServer],
+      errlog,
+    });
+
+    try {
+      await expect(connector.connect()).rejects.toThrow(
+        "injected initialization failure"
+      );
+
+      expect(capturedPid).not.toBeNull();
+      const pid = capturedPid!;
+
+      // Verify the child process is dead as soon as connect() rejection settles
+      expect(isPidAlive(pid)).toBe(false);
+    } finally {
+      if (capturedPid && isPidAlive(capturedPid)) {
+        try {
+          process.kill(capturedPid, "SIGKILL");
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  });
+
+  it("prevents dual-process overlap during sequential retry after failed handshake", async () => {
+    const pids: number[] = [];
+    const errlog = new Writable({
+      write(chunk, _encoding, callback) {
+        const lines = chunk.toString().split("\n");
+        for (const line of lines) {
+          const num = Number(line.trim());
+          if (!Number.isNaN(num) && num > 0) {
+            pids.push(num);
+          }
+        }
+        callback();
+      },
+    });
+
+    const connector = new StdioConnector({
+      command: process.execPath,
+      args: ["-e", failingHandshakeServer],
+      errlog,
+    });
+
+    try {
+      // First attempt fails during initialize
+      await expect(connector.connect()).rejects.toThrow(
+        "injected initialization failure"
+      );
+      expect(pids.length).toBeGreaterThanOrEqual(1);
+      const firstPid = pids[0];
+
+      // Predecessor must be dead immediately upon rejection
+      expect(isPidAlive(firstPid)).toBe(false);
+
+      // Mutate args to point to working server for retry attempt
+      (connector as any).args = ["-e", workingServer];
+
+      // Second attempt succeeds
+      await connector.connect();
+      expect(connector.connected).toBe(true);
+      expect(pids.length).toBeGreaterThanOrEqual(2);
+      const secondPid = pids[1];
+
+      // First PID must remain dead, second PID must be active
+      expect(firstPid).not.toBe(secondPid);
+      expect(isPidAlive(firstPid)).toBe(false);
+      expect(isPidAlive(secondPid)).toBe(true);
+
+      await connector.disconnect();
+      expect(isPidAlive(secondPid)).toBe(false);
+    } finally {
+      for (const pid of pids) {
+        if (isPidAlive(pid)) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            /* ignore */
+          }
+        }
+      }
+    }
+  });
+
+  it("ensures normal disconnect awaits child process termination before resolving", async () => {
+    let capturedPid: number | null = null;
+    const errlog = new Writable({
+      write(chunk, _encoding, callback) {
+        const num = Number(chunk.toString().trim());
+        if (!Number.isNaN(num) && num > 0) {
+          capturedPid = num;
+        }
+        callback();
+      },
+    });
+
+    const connector = new StdioConnector({
+      command: process.execPath,
+      args: ["-e", workingServer],
+      errlog,
+    });
+
+    try {
+      await connector.connect();
+      expect(connector.connected).toBe(true);
+      expect(capturedPid).not.toBeNull();
+      const pid = capturedPid!;
+
+      expect(isPidAlive(pid)).toBe(true);
+      expect(connector.pid).toBe(pid);
+
+      await connector.disconnect();
+
+      // Child must be reaped as soon as disconnect() resolves
+      expect(isPidAlive(pid)).toBe(false);
+      expect(connector.pid).toBeNull();
+    } finally {
+      if (capturedPid && isPidAlive(capturedPid)) {
+        try {
+          process.kill(capturedPid, "SIGKILL");
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+  });
+
+  it("coalesces concurrent transport.close() calls onto a single in-flight promise", async () => {
+    const manager = new StdioConnectionManager({
+      command: process.execPath,
+      args: ["-e", workingServer],
+    });
+
+    const transport = await manager.start();
+    await transport.start();
+    const pid = transport.pid;
+    expect(pid).not.toBeNull();
+    expect(manager.childProcess).not.toBeNull();
+
+    // Fire two concurrent close calls
+    const [close1, close2] = [transport.close(), transport.close()];
+    await Promise.all([close1, close2]);
+
+    await manager.stop();
+    expect(isPidAlive(pid!)).toBe(false);
+  });
+});


### PR DESCRIPTION
# Pull Request Description

## Where did you find this issue?

Encountered in long-lived client services and retry loops using `StdioConnector` (`packages/client/src/transport/stdio.ts`) against local child processes (e.g. Python or Node MCP servers). As reported by @Elioooon in #2458 and documented in #2479:

When a stdio connection attempt failed during protocol handshake (such as an initialization timeout or syntax crash) or during a reconnection sequence, `StdioConnector` issued a `kill()` signal to the predecessor child process and immediately spawned a new successor child process without awaiting the predecessor's actual termination. Because OS process exit is asynchronous and `@modelcontextprotocol/client@2.0.0` cleared `this._process = void 0` before awaiting exit, subsequent teardown calls returned immediate no-ops. 

Consequently, the successor process started while the dying predecessor was still alive and running, triggering `EBUSY` / `EADDRINUSE` file-lock and socket contention on servers utilizing SQLite databases or local IPC.

### Minimal Runnable Reproduction

```typescript
import { StdioConnector } from "@mcp-use/client";

const connector = new StdioConnector({
  command: "node",
  args: ["tests/helpers/slow-exit-server.mjs"],
});

// Trigger connection with immediate retry on handshake failure:
try {
  await connector.connect();
} catch {
  // Successor process is spawned synchronously while predecessor is still executing:
  await connector.connect();
}
// Observed: Predecessor PID is still active and holding file/socket descriptors during successor startup.
```

---

## Language / Project Scope
- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes
Fixes #2479 by ensuring `StdioConnectionManager` joins in-flight SDK transport close promises and explicitly awaits predecessor child process exit during handshake failures and disconnects, preventing dual-process overlap and port/lock collisions on retries.

## Root Cause Autopsy
As identified by @Elioooon in #2458 and documented in #2479:
1. In `@modelcontextprotocol/client@2.0.0` (`index.mjs:3250`), when `_legacyHandshake` encounters an error, its `catch` block invokes `this.close()` without `await`.
2. Inside `StdioClientTransport.close()`, it immediately sets `this._process = void 0` and begins an asynchronous shutdown timeout race.
3. In `StdioConnector.connect()`, the error is caught and invokes `await this.cleanupResources()`, which calls `await this.client.close()` and `await this.connectionManager.stop()` -> `await this._transport.close()`.
4. Because `transport._process` was already cleared to `void 0` in step 2, subsequent calls to `transport.close()` evaluate `if (this._process)` as false, returning immediately as a no-op without waiting for the child process to exit.
5. Consequently, `cleanupResources()` settles while the child process is still running. An immediate retry on the connector spawns a new child process while the dying predecessor is still alive, leading to `EBUSY` / `EADDRINUSE` file-lock and socket contention on servers utilizing SQLite or local IPC.

## Implementation Details
1. **Idempotent In-Flight Transport Close Sharing (`StdioConnectionManager`)**:
   - In `establishConnection()`, wrapped `transport.close()` so repeated calls (e.g. from the SDK's un-awaited error handler and subsequent `cleanupResources()` / `stop()`) share the active in-flight `closePromise` rather than returning an instant no-op.
2. **Child Process Tracking & Exit Join Barrier**:
   - Captured the spawned `ChildProcess` instance upon `transport.start()`.
   - In `closeConnection()`, added an explicit join barrier ensuring the child process has emitted `'exit'` / `'close'` (with a bounded 2s fallback escalating to `SIGKILL`) before teardown resolves.
3. **Exposed Process ID Metadata**:
   - Added `pid` and `childProcess` getters to `StdioConnectionManager` and `pid` getter to `StdioConnector`.
4. **Comprehensive Subprocess Regression Tests (`stdio-process-exit.test.ts`)**:
   - Verified child process is terminated immediately upon `connect()` rejection on failed handshake (`process.kill(pid, 0)` throws `ESRCH`).
   - Verified sequential retry spawns a new process only after the predecessor process is dead (zero dual-process overlap).
   - Verified normal `disconnect()` awaits child process termination before resolving.
   - Verified concurrent `transport.close()` calls coalesce onto a single in-flight promise.

---

## TypeScript Checklist
### Packages Modified
- [ ] `docs`
- [x] `tests`
- [ ] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [x] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist
- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset
- [x] Added or updated tests

---

## Testing
- `vitest run tests/unit/transport/stdio-process-exit.test.ts`: all 4 tests pass.
- `vitest run tests/unit/transport/`: all 13 tests pass.
- Full client test suite: `vitest run tests/unit/`: all 58 test files (351 tests) pass.
- Client build: clean build with TypeScript declaration emit (`tsup && tsc --emitDeclarationOnly --declaration`).
- Lint & Prettier checks: passed cleanly with 0 errors.

## Backwards Compatibility
Fully backwards compatible. No breaking changes to public APIs. Adds `pid` and `childProcess` getters and guarantees predecessor process exit before reconnection.

## Related Issues
Closes #2479
