### PR TITLE
fix(python): use monotonic clock for execution timing

### DIFF
--- a/libraries/python/mcp_use/client/code_executor.py
+++ b/libraries/python/mcp_use/client/code_executor.py
@@ -9,8 +9,8 @@ direct tool calls.
 import asyncio
 import io
 import re
-import time
 from contextlib import redirect_stderr, redirect_stdout
+from time import perf_counter
 from typing import TYPE_CHECKING, Any
 
 from mcp_use.logging import logger
@@ -59,7 +59,7 @@ class CodeExecutor:
             logger.debug("Connecting to configured servers for code execution...")
             await self.client.create_all_sessions()
 
-        start_time = time.time()
+        start_time = perf_counter()
         logs: list[str] = []
         result = None
         error = None
@@ -93,7 +93,7 @@ class CodeExecutor:
             error = str(e)
             logger.error(f"Code execution error: {e}")
 
-        execution_time = time.time() - start_time
+        execution_time = perf_counter() - start_time
 
         # Capture any stdout/stderr that wasn't captured by our print wrapper
         if stdout_capture.getvalue():

--- a/libraries/python/tests/unit/test_code_executor.py
+++ b/libraries/python/tests/unit/test_code_executor.py
@@ -5,7 +5,7 @@ Tests the code execution functionality for MCP code mode.
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -36,12 +36,13 @@ class TestCodeExecutorBasics:
         """Test executing simple Python code."""
         code = "result = 1 + 1\nreturn result"
 
-        result = await code_executor.execute(code, timeout=5.0)
+        with patch("mcp_use.client.code_executor.perf_counter", side_effect=[100.0, 100.125]):
+            result = await code_executor.execute(code, timeout=5.0)
 
         assert result["error"] is None
         assert result["result"] == 2
         assert isinstance(result["execution_time"], float)
-        assert result["execution_time"] > 0
+        assert result["execution_time"] == pytest.approx(0.125)
 
     @pytest.mark.asyncio
     async def test_execute_with_print(self, code_executor):


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

- [ ] TypeScript
- [x] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

Fix `CodeExecutor.execute()` reporting an `execution_time` of exactly `0.0` for short executions on Windows.

The executor previously measured elapsed time using `time.time()`. On the affected Windows environment, that clock has a resolution of approximately 15.625 milliseconds, so fast executions often started and finished within the same clock tick.

This PR replaces the wall clock with `time.perf_counter()`, a monotonic, high-resolution clock designed for measuring short durations.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. Replace both `time.time()` calls in `CodeExecutor.execute()` with `time.perf_counter()`.
2. Update the existing unit test to mock the performance counter with deterministic start and end values.
3. Verify the exact elapsed-time calculation with `pytest.approx()`.
4. Preserve the existing return structure, timeout handling, and error behavior.
5. No dependencies or public APIs were changed.

---

## TypeScript Checklist

Not applicable. This PR only changes the Python package.

---

## Python Checklist

- [x] Code formatted with `ruff format format`
- [x] Linting passes with `ruff check`
- [x] Added or updated tests
- [x] Documentation update is not required because the public API and usage remain unchanged

---

## Example Usage (Before)

On Windows, a short execution could lose all timing information:

```python
result = await executor.execute("return 1 + 1")

assert result["result"] == 2
assert result["execution_time"] == 0.0
```

This also caused the existing unit test to fail intermittently:

```text
assert result["execution_time"] > 0
E assert 0.0 > 0
```

Running the affected test 12 times on the reporting machine produced:

```text
passed=2 failed=10
```

## Example Usage (After)

Short executions are measured with a monotonic, high-resolution clock:

```python
result = await executor.execute("return 1 + 1")

assert result["result"] == 2
assert result["execution_time"] > 0
```

A 100-execution verification after the fix produced:

```text
zero_count=0
```

## Documentation Updates

No documentation changes are required. The `execution_time` field remains a floating-point duration in seconds, and no public API changed.

## Testing

Run from `libraries/python`:

```powershell
uvx --from "ruff==0.15.22" ruff check .
uvx --from "ruff==0.15.22" ruff format --check .
.\.venv\Scripts\python.exe -m pytest -q tests\unit\test_code_executor.py
.\.venv\Scripts\python.exe -m pytest -q tests\unit
```

Results:

```text
Ruff lint: passed
Ruff format: passed
CodeExecutor tests: 21 passed
Full Python unit suite: 305 passed
```

Manual verification:

```text
100 short executions
zero execution times before fix: frequently reproducible
zero execution times after fix: 0
```

## Backwards Compatibility

This change is fully backwards compatible.

The result schema, duration unit, timeout behavior, exception handling, and public API remain unchanged. The only behavioral difference is that short executions now retain accurate timing information.

## Related Issues

Closes #2481

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `CodeExecutor.execute()` reporting `execution_time` as `0.0` for short executions on Windows by replacing `time.time()` with `time.perf_counter()`. The old clock had ~15.625ms resolution, so fast executions often finished within the same tick; the new monotonic clock measures short durations accurately.

- Updates the unit test to mock `perf_counter` with deterministic start/end values and assert exact elapsed time.
- Preserves the existing return structure, timeout handling, and error behavior; no public API or dependencies changed.

<sup>Written for commit fea9b2348b80775dc21f06ac5504f1907894a2e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

