### PR TITLE
feat(cli): respect .gitignore rules by default when packaging deployments

### DIFF
--- a/libraries/typescript/.changeset/smart-deploy-gitignore.md
+++ b/libraries/typescript/.changeset/smart-deploy-gitignore.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": minor
+---
+
+Apply `.gitignore` rules by default when packaging projects for managed deployments (`mcp-use deploy --no-github`), supporting standard ignore semantics including wildcards, directory rules, and negation while preserving baseline cloud exclusions.

--- a/libraries/typescript/packages/cli/package.json
+++ b/libraries/typescript/packages/cli/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@tailwindcss/vite": "4.3.3",
     "@vitejs/plugin-react": "6.0.5",
+    "ignore": "^5.3.2",
     "tailwindcss": "4.3.3",
     "vite": "8.0.16"
   },

--- a/libraries/typescript/packages/cli/src/commands/deploy.ts
+++ b/libraries/typescript/packages/cli/src/commands/deploy.ts
@@ -12,6 +12,8 @@ import { createInterface } from "node:readline/promises";
 import { parseArgs, promisify } from "node:util";
 import { createGzip } from "node:zlib";
 
+import ignore, { type Ignore } from "ignore";
+
 import {
   cloudApiForOrganization,
   cloudWebUrl,
@@ -1349,7 +1351,8 @@ async function packProject(projectRoot: string): Promise<Buffer> {
     }
   })();
   try {
-    await addDirectoryToArchive(gzip, projectRoot, "");
+    const ig = await loadGitIgnore(projectRoot);
+    await addDirectoryToArchive(gzip, projectRoot, "", ig);
     await writeArchiveChunk(gzip, Buffer.alloc(1024));
     gzip.end();
   } catch (error) {
@@ -1360,10 +1363,22 @@ async function packProject(projectRoot: string): Promise<Buffer> {
   return Buffer.concat(chunks);
 }
 
+async function loadGitIgnore(projectRoot: string): Promise<Ignore | undefined> {
+  try {
+    const gitignorePath = join(projectRoot, ".gitignore");
+    const content = await readFile(gitignorePath, "utf8");
+    return ignore().add(content);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return undefined;
+  }
+}
+
 async function addDirectoryToArchive(
   gzip: ReturnType<typeof createGzip>,
   projectRoot: string,
-  relativeDirectory: string
+  relativeDirectory: string,
+  ig?: Ignore
 ): Promise<void> {
   const directory = await opendir(
     relativeDirectory === ""
@@ -1380,9 +1395,18 @@ async function addDirectoryToArchive(
         ? entry.name
         : join(relativeDirectory, entry.name);
     if (!shouldArchive(relativePath)) continue;
+    const posixPath = relativePath.replaceAll("\\", "/");
+    if (ig !== undefined) {
+      if (entry.isDirectory() && ig.ignores(`${posixPath}/`)) {
+        continue;
+      }
+      if (entry.isFile() && ig.ignores(posixPath)) {
+        continue;
+      }
+    }
     const absolutePath = join(projectRoot, relativePath);
     const stats = await lstat(absolutePath);
-    const archivePath = `app/${relativePath.replaceAll("\\", "/")}`;
+    const archivePath = `app/${posixPath}`;
     const common = {
       path: archivePath,
       mode: stats.mode & 0o777,
@@ -1391,7 +1415,7 @@ async function addDirectoryToArchive(
 
     if (stats.isDirectory()) {
       await writeTarHeader(gzip, { ...common, type: "directory", size: 0 });
-      await addDirectoryToArchive(gzip, projectRoot, relativePath);
+      await addDirectoryToArchive(gzip, projectRoot, relativePath, ig);
     } else if (stats.isFile()) {
       await writeTarHeader(gzip, {
         ...common,

--- a/libraries/typescript/packages/cli/tests/commands/deploy.test.ts
+++ b/libraries/typescript/packages/cli/tests/commands/deploy.test.ts
@@ -384,6 +384,113 @@ describe("deploy agent contract", () => {
     });
   });
 
+  it("applies .gitignore patterns and negation when packaging managed servers", async () => {
+    const directory = await project("gitignore-managed-app");
+    await writeFile(join(directory, "index.ts"), "export const ok = true;\n");
+    await writeFile(
+      join(directory, ".gitignore"),
+      [
+        "# Ignore local database",
+        "*.sqlite",
+        "",
+        "# Ignore temporary logs with negation exception",
+        "logs/*",
+        "!logs/keep.log",
+        "",
+        "# Directory pattern with trailing slash",
+        "temp-cache/",
+        "",
+        "# Root-anchored pattern",
+        "/root-only.txt",
+        "",
+        "# Relative path glob",
+        "nested/*.tmp",
+      ].join("\n")
+    );
+    await writeFile(join(directory, "data.sqlite"), "binary data\n");
+    await mkdir(join(directory, "logs"));
+    await writeFile(join(directory, "logs", "app.log"), "error\n");
+    await writeFile(join(directory, "logs", "keep.log"), "retained\n");
+    await mkdir(join(directory, "temp-cache"));
+    await writeFile(join(directory, "temp-cache", "scratch.json"), "123\n");
+    await writeFile(join(directory, "root-only.txt"), "ignored at root\n");
+    await mkdir(join(directory, "sub"));
+    await writeFile(
+      join(directory, "sub", "root-only.txt"),
+      "included in sub\n"
+    );
+    await mkdir(join(directory, "nested"));
+    await writeFile(join(directory, "nested", "one.tmp"), "temp\n");
+    await mkdir(join(directory, "nested", "deep"));
+    await writeFile(
+      join(directory, "nested", "deep", "two.tmp"),
+      "not matched by nested/*.tmp\n"
+    );
+
+    api.multipartRequest.mockResolvedValue({
+      server: { id: "srv_gitignore", slug: "gitignore-managed-app" },
+      deploymentId: "dep_gitignore",
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      runDeploy([directory, "--no-github", "--region", "US", "--json"])
+    ).resolves.toBe(0);
+
+    const form = api.multipartRequest.mock.calls[0]![1] as FormData;
+    const entries = await archiveEntries(form.get("sourceFile") as Blob);
+
+    // Included files
+    expect(entries).toContain("app/index.ts");
+    expect(entries).toContain("app/.gitignore");
+    expect(entries).toContain("app/logs/keep.log");
+    expect(entries).toContain("app/sub/root-only.txt");
+    expect(entries).toContain("app/nested/deep/two.tmp");
+
+    // Excluded files by .gitignore
+    expect(entries).not.toContain("app/data.sqlite");
+    expect(entries).not.toContain("app/logs/app.log");
+    expect(entries).not.toContain("app/root-only.txt");
+    expect(entries).not.toContain("app/nested/one.tmp");
+    expect(entries.some((entry) => entry.includes("temp-cache"))).toBe(false);
+  });
+
+  it("ensures critical baseline exclusions cannot be bypassed by .gitignore negation", async () => {
+    const directory = await project("gitignore-bypass-safety");
+    await writeFile(join(directory, "index.ts"), "export const ok = true;\n");
+    await writeFile(
+      join(directory, ".gitignore"),
+      ["!.env", "!.envrc", "!.git", "!node_modules", "!.DS_Store"].join("\n")
+    );
+    await writeFile(join(directory, ".env"), "SECRET=leak\n");
+    await writeFile(join(directory, ".envrc"), "SECRET=leak\n");
+    await writeFile(join(directory, ".DS_Store"), "os metadata\n");
+    await mkdir(join(directory, "node_modules"));
+    await writeFile(
+      join(directory, "node_modules", "dep.js"),
+      "console.log('dep');\n"
+    );
+
+    api.multipartRequest.mockResolvedValue({
+      server: { id: "srv_bypass", slug: "gitignore-bypass-safety" },
+      deploymentId: "dep_bypass",
+    });
+    vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await expect(
+      runDeploy([directory, "--no-github", "--region", "US", "--json"])
+    ).resolves.toBe(0);
+
+    const form = api.multipartRequest.mock.calls[0]![1] as FormData;
+    const entries = await archiveEntries(form.get("sourceFile") as Blob);
+
+    expect(entries).toContain("app/index.ts");
+    expect(entries).not.toContain("app/.env");
+    expect(entries).not.toContain("app/.envrc");
+    expect(entries).not.toContain("app/.DS_Store");
+    expect(entries.some((entry) => entry.includes("node_modules"))).toBe(false);
+  });
+
   it("accepts -y as the documented non-interactive consent alias", async () => {
     const directory = await project("short-yes");
     api.multipartRequest.mockResolvedValue({

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -207,6 +207,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 6.0.5
         version: 6.0.5(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      ignore:
+        specifier: ^5.3.2
+        version: 5.3.2
       tailwindcss:
         specifier: 4.3.3
         version: 4.3.3
@@ -12409,7 +12412,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.10':
     dependencies:


### PR DESCRIPTION
# Pull Request Description

## Where did you find this issue?

Encountered when packaging an MCP server project for cloud deployment via `mcp-use deploy` (`packages/cli/src/commands/deploy.ts`).

In standard Node/TypeScript repositories, private environment secrets (`.env.local`, `.env`), local database files (`sqlite.db`), and heavy build caches are specified in the project's root `.gitignore`. The CLI's deployment packager only applied a hardcoded static exclude list (`node_modules`, `.git`). It did not inspect or evaluate the local `.gitignore` rules, causing private files and sensitive local development assets to be bundled into the deployment archive and uploaded to the remote server. Maintainer @khandrew1 confirmed this requirement in [Issue #2484](https://github.com/mcp-use/mcp-use/issues/2484#issuecomment-5590115835).

### Minimal Runnable Reproduction

```bash
# In an MCP server project directory:
echo ".env.local" >> .gitignore
echo "API_SECRET=super_secret_token" > .env.local

# Run deployment packaging
mcp-use deploy --no-github
# Inspect the resulting file bundle:
# Observed: .env.local is included in the package archive despite being in .gitignore.
# Expected: .gitignore rules are respected by default when packaging.
```

---

### Summary
Resolves #2484.

As requested by @khandrew1 in https://github.com/mcp-use/mcp-use/issues/2484#issuecomment-5590115835, this PR scopes deployment packaging in `@mcp-use/cli` to respect `.gitignore` rules by default when preparing managed deployment archives (`mcp-use deploy --no-github`).

### Key Changes
1. **`.gitignore` Evaluation**: When packaging a project, loads and evaluates `.gitignore` from the project root using standard ignore semantics:
   - Wildcards (`*`, `**`, `?`)
   - Directory-specific patterns (trailing `/`)
   - Negation rules (`!pattern`)
   - Root-anchored patterns (`/pattern`)
   - Comments (`#`) and escaped characters
2. **Subtree Pruning Optimization**: When visiting directory entries (`entry.isDirectory()`), evaluates `ig.ignores(`${posixPath}/`)`. If ignored, the directory header is skipped and recursion terminates immediately, avoiding traversal and `lstat` calls on large excluded subtrees.
3. **Defense-in-Depth for Baseline Exclusions**: Baseline safety exclusions (`EXCLUDED_DIRECTORIES`, `.env*` secrets, OS metadata, and symlinks) remain unconditionally enforced *before* `.gitignore` rules, preventing accidental secret leakage even if a user `.gitignore` contains `!.env`.
4. **Automated Tests**:
   - Added `it("applies .gitignore patterns and negation when packaging managed servers")` in `deploy.test.ts` covering wildcards, directories, negation, root anchoring, and nested path globs.
   - Added `it("ensures critical baseline exclusions cannot be bypassed by .gitignore negation")` asserting baseline cloud security exclusions cannot be overridden.

### Test Validation
- `pnpm --filter @mcp-use/cli test`: 23/23 test files passed, 298 passed tests.
- `pnpm --filter @mcp-use/cli typecheck`: 0 type errors.
- `pnpm --filter @mcp-use/cli build`: 0 errors across build, license copy, and package verification scripts.
- `pnpm lint`: clean.
- `pnpm knip`: clean.
