### PR TITLE
fix(client): implement listTools and protocol metadata on CodeModeConnector

### DIFF
--- a/libraries/typescript/.changeset/code-mode-connector-list-tools.md
+++ b/libraries/typescript/.changeset/code-mode-connector-list-tools.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Implement `listTools` and protocol metadata on `CodeModeConnector`

--- a/libraries/typescript/packages/client/src/code-mode/connector.ts
+++ b/libraries/typescript/packages/client/src/code-mode/connector.ts
@@ -1,4 +1,9 @@
-import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
+import type {
+  CallToolResult,
+  ProtocolEra,
+  RequestOptions,
+  Tool,
+} from "@modelcontextprotocol/client";
 import type { MCPClient } from "../core/node.js";
 import { BaseConnector } from "../transport/base.js";
 
@@ -112,6 +117,13 @@ export class CodeModeConnector extends BaseConnector {
     this.mcpClient = client;
     this.connected = true; // No connection phase needed - immediately ready
     this._tools = this._createToolsList();
+    this.toolsCache = this._tools;
+    this.capabilitiesCache = { tools: {} };
+    this.serverInfoCache = {
+      name: "code_mode",
+      version: "1.0.0",
+      description: "MCP Code Mode Internal Server",
+    };
   }
 
   async connect(): Promise<void> {
@@ -186,19 +198,85 @@ export class CodeModeConnector extends BaseConnector {
   }
 
   // Override tools getter to return static list immediately
-  get tools(): Tool[] {
+  override get tools(): Tool[] {
     return this._tools;
   }
 
-  async initialize(): Promise<any> {
-    this.toolsCache = this._tools;
-    return { capabilities: {}, version: "1.0.0" };
+  /**
+   * Returns fresh tools available in code mode.
+   *
+   * @param options - Optional per-request options (e.g. abort signal).
+   * @returns List of Tool objects for execute_code and search_tools.
+   */
+  override async listTools(options?: RequestOptions): Promise<Tool[]> {
+    if (!this.connected) {
+      throw new Error("MCP client is not connected");
+    }
+    options?.signal?.throwIfAborted();
+    return [...this._tools];
   }
 
-  async callTool(
+  override get protocolEra(): ProtocolEra | undefined {
+    return this.connected ? "modern" : undefined;
+  }
+
+  override get negotiatedProtocolVersion(): string | undefined {
+    return this.connected ? "2026-07-28" : undefined;
+  }
+
+  override async initialize(): Promise<any> {
+    this.toolsCache = this._tools;
+    this.capabilitiesCache = { tools: {} };
+    this.serverInfoCache = {
+      name: "code_mode",
+      version: "1.0.0",
+      description: "MCP Code Mode Internal Server",
+    };
+    return {
+      capabilities: this.capabilitiesCache,
+      serverInfo: this.serverInfoCache,
+      protocolVersion: "2026-07-28",
+    };
+  }
+
+  override async listResources(): Promise<{ resources: any[] }> {
+    if (!this.connected) {
+      throw new Error("MCP client is not connected");
+    }
+    return { resources: [] };
+  }
+
+  override async listAllResources(): Promise<{ resources: any[] }> {
+    if (!this.connected) {
+      throw new Error("MCP client is not connected");
+    }
+    return { resources: [] };
+  }
+
+  override async listPrompts(): Promise<{ prompts: any[] }> {
+    if (!this.connected) {
+      throw new Error("MCP client is not connected");
+    }
+    return { prompts: [] };
+  }
+
+  async listAllPrompts(): Promise<{ prompts: any[] }> {
+    if (!this.connected) {
+      throw new Error("MCP client is not connected");
+    }
+    return { prompts: [] };
+  }
+
+  override async callTool(
     name: string,
-    args: Record<string, any>
+    args: Record<string, any>,
+    options?: RequestOptions
   ): Promise<CallToolResult> {
+    if (!this.connected) {
+      throw new Error("MCP client is not connected");
+    }
+    options?.signal?.throwIfAborted();
+
     if (name === "execute_code") {
       const code = args.code as string;
       const timeout = (args.timeout as number) || 30000;

--- a/libraries/typescript/packages/client/src/code-mode/connector.ts
+++ b/libraries/typescript/packages/client/src/code-mode/connector.ts
@@ -284,10 +284,20 @@ export class CodeModeConnector extends BaseConnector {
     };
   }
 
+  /**
+   * Code mode internal server does not expose resources. Returns an empty list.
+   *
+   * @param _cursor - Optional pagination cursor (unused).
+   * @param options - Optional request options.
+   * @returns Empty resource list.
+   */
   override async listResources(
     _cursor?: string,
     options?: RequestOptions
-  ): Promise<{ resources: any[] }> {
+  ): Promise<{
+    /** Empty resource list in code mode. */
+    resources: any[];
+  }> {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }
@@ -295,9 +305,16 @@ export class CodeModeConnector extends BaseConnector {
     return { resources: [] };
   }
 
-  override async listAllResources(
-    options?: RequestOptions
-  ): Promise<{ resources: any[] }> {
+  /**
+   * Code mode internal server does not expose resources. Returns an empty list.
+   *
+   * @param options - Optional request options.
+   * @returns Empty resource list.
+   */
+  override async listAllResources(options?: RequestOptions): Promise<{
+    /** Empty resource list in code mode. */
+    resources: any[];
+  }> {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }
@@ -305,9 +322,16 @@ export class CodeModeConnector extends BaseConnector {
     return { resources: [] };
   }
 
-  override async listResourceTemplates(
-    options?: RequestOptions
-  ): Promise<{ resourceTemplates: any[] }> {
+  /**
+   * Code mode internal server does not expose resource templates. Returns an empty list.
+   *
+   * @param options - Optional request options.
+   * @returns Empty resource template list.
+   */
+  override async listResourceTemplates(options?: RequestOptions): Promise<{
+    /** Empty resource template list in code mode. */
+    resourceTemplates: any[];
+  }> {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }
@@ -315,9 +339,16 @@ export class CodeModeConnector extends BaseConnector {
     return { resourceTemplates: [] };
   }
 
-  override async listPrompts(
-    options?: RequestOptions
-  ): Promise<{ prompts: any[] }> {
+  /**
+   * Code mode internal server does not expose prompts. Returns an empty list.
+   *
+   * @param options - Optional request options.
+   * @returns Empty prompt list.
+   */
+  override async listPrompts(options?: RequestOptions): Promise<{
+    /** Empty prompt list in code mode. */
+    prompts: any[];
+  }> {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }
@@ -325,7 +356,16 @@ export class CodeModeConnector extends BaseConnector {
     return { prompts: [] };
   }
 
-  async listAllPrompts(options?: RequestOptions): Promise<{ prompts: any[] }> {
+  /**
+   * Code mode internal server does not expose prompts. Returns an empty list.
+   *
+   * @param options - Optional request options.
+   * @returns Empty prompt list.
+   */
+  async listAllPrompts(options?: RequestOptions): Promise<{
+    /** Empty prompt list in code mode. */
+    prompts: any[];
+  }> {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }

--- a/libraries/typescript/packages/client/src/code-mode/connector.ts
+++ b/libraries/typescript/packages/client/src/code-mode/connector.ts
@@ -99,6 +99,51 @@ Remember: Always discover and understand available tools before attempting to us
 const DETAIL_LEVELS = new Set(["names", "descriptions", "full"]);
 
 /**
+ * Throws if the signal is aborted, using the signal's reason or a standard AbortError.
+ */
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  if (typeof signal.throwIfAborted === "function") {
+    signal.throwIfAborted();
+  }
+  throw signal.reason ?? new Error("This operation was aborted");
+}
+
+/**
+ * Races an async operation against an AbortSignal, rejecting immediately if the signal aborts.
+ */
+function raceAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  throwIfAborted(signal);
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      try {
+        throwIfAborted(signal);
+      } catch (err) {
+        reject(err);
+      }
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
+/**
  * CodeModeConnector provides a special "code mode" interface for executing JavaScript/TypeScript
  * code with access to MCP tools. Unlike other connectors, it doesn't establish its own external
  * connection - instead, it wraps an already-connected BaseMCPClient and exposes special tools
@@ -212,7 +257,7 @@ export class CodeModeConnector extends BaseConnector {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }
-    options?.signal?.throwIfAborted();
+    throwIfAborted(options?.signal);
     return [...this._tools];
   }
 
@@ -239,31 +284,52 @@ export class CodeModeConnector extends BaseConnector {
     };
   }
 
-  override async listResources(): Promise<{ resources: any[] }> {
+  override async listResources(
+    _cursor?: string,
+    options?: RequestOptions
+  ): Promise<{ resources: any[] }> {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }
+    throwIfAborted(options?.signal);
     return { resources: [] };
   }
 
-  override async listAllResources(): Promise<{ resources: any[] }> {
+  override async listAllResources(
+    options?: RequestOptions
+  ): Promise<{ resources: any[] }> {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }
+    throwIfAborted(options?.signal);
     return { resources: [] };
   }
 
-  override async listPrompts(): Promise<{ prompts: any[] }> {
+  override async listResourceTemplates(
+    options?: RequestOptions
+  ): Promise<{ resourceTemplates: any[] }> {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }
+    throwIfAborted(options?.signal);
+    return { resourceTemplates: [] };
+  }
+
+  override async listPrompts(
+    options?: RequestOptions
+  ): Promise<{ prompts: any[] }> {
+    if (!this.connected) {
+      throw new Error("MCP client is not connected");
+    }
+    throwIfAborted(options?.signal);
     return { prompts: [] };
   }
 
-  async listAllPrompts(): Promise<{ prompts: any[] }> {
+  async listAllPrompts(options?: RequestOptions): Promise<{ prompts: any[] }> {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }
+    throwIfAborted(options?.signal);
     return { prompts: [] };
   }
 
@@ -275,7 +341,7 @@ export class CodeModeConnector extends BaseConnector {
     if (!this.connected) {
       throw new Error("MCP client is not connected");
     }
-    options?.signal?.throwIfAborted();
+    throwIfAborted(options?.signal);
 
     if (name === "execute_code") {
       const code = args.code as string;
@@ -283,7 +349,10 @@ export class CodeModeConnector extends BaseConnector {
 
       // We need to access executeCode on the client
       // Since BaseConnector doesn't know about executeCode, we cast client
-      const result = await this.mcpClient.executeCode(code, timeout);
+      const result = await raceAbort(
+        this.mcpClient.executeCode(code, timeout),
+        options?.signal
+      );
 
       return {
         content: [
@@ -300,9 +369,12 @@ export class CodeModeConnector extends BaseConnector {
         | "descriptions"
         | "full";
 
-      const result = await this.mcpClient.searchTools(
-        query,
-        DETAIL_LEVELS.has(detailLevel) ? detailLevel : "full"
+      const result = await raceAbort(
+        this.mcpClient.searchTools(
+          query,
+          DETAIL_LEVELS.has(detailLevel) ? detailLevel : "full"
+        ),
+        options?.signal
       );
 
       return {

--- a/libraries/typescript/packages/client/src/code-mode/connector.ts
+++ b/libraries/typescript/packages/client/src/code-mode/connector.ts
@@ -356,23 +356,6 @@ export class CodeModeConnector extends BaseConnector {
     return { prompts: [] };
   }
 
-  /**
-   * Code mode internal server does not expose prompts. Returns an empty list.
-   *
-   * @param options - Optional request options.
-   * @returns Empty prompt list.
-   */
-  async listAllPrompts(options?: RequestOptions): Promise<{
-    /** Empty prompt list in code mode. */
-    prompts: any[];
-  }> {
-    if (!this.connected) {
-      throw new Error("MCP client is not connected");
-    }
-    throwIfAborted(options?.signal);
-    return { prompts: [] };
-  }
-
   override async callTool(
     name: string,
     args: Record<string, any>,

--- a/libraries/typescript/packages/client/tests/unit/client/code-mode-connector.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/code-mode-connector.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it, vi } from "vitest";
+import { CodeModeConnector } from "../../../src/code-mode/connector.js";
+import { MCPSession } from "../../../src/core/session.js";
+import { MCPClient } from "../../../src/core/node.js";
+import { createAiSdkTools } from "../../../src/adapters/ai-sdk.js";
+
+describe("CodeModeConnector protocol contract", () => {
+  function createMockMcpClient() {
+    return {
+      executeCode: vi.fn(async (code: string, timeout: number) => ({
+        result: `executed:${code}`,
+        logs: [],
+        error: null,
+        execution_time: 1,
+      })),
+      searchTools: vi.fn(async (query: string, detailLevel: string) => [
+        { name: "test_tool", description: "A test tool" },
+      ]),
+    } as unknown as MCPClient;
+  }
+
+  describe("direct connector operations", () => {
+    it("exposes tools through synchronous getter", () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      expect(connector.tools.map((t) => t.name)).toEqual([
+        "execute_code",
+        "search_tools",
+      ]);
+    });
+
+    it("returns tool list from listTools()", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const tools = await connector.listTools();
+      expect(tools.map((t) => t.name)).toEqual([
+        "execute_code",
+        "search_tools",
+      ]);
+      // Should return a clone to avoid external mutation of internal list
+      expect(tools).not.toBe(connector.tools);
+    });
+
+    it("throws when listTools() is called on a disconnected connector", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      await connector.disconnect();
+      await expect(connector.listTools()).rejects.toThrow(
+        "MCP client is not connected"
+      );
+    });
+
+    it("throws when listTools() is called with an aborted signal", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const controller = new AbortController();
+      controller.abort();
+      await expect(
+        connector.listTools({ signal: controller.signal })
+      ).rejects.toThrow();
+    });
+
+    it("initializes capabilities and serverInfo caches", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const initResult = await connector.initialize();
+
+      expect(connector.serverCapabilities).toEqual({ tools: {} });
+      expect(connector.serverInfo).toEqual({
+        name: "code_mode",
+        version: "1.0.0",
+        description: "MCP Code Mode Internal Server",
+      });
+      expect(initResult.capabilities).toEqual({ tools: {} });
+      expect(initResult.serverInfo).toEqual(connector.serverInfo);
+      expect(initResult.protocolVersion).toBe("2026-07-28");
+    });
+
+    it("exposes modern protocol era and negotiated version when connected", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      expect(connector.protocolEra).toBe("modern");
+      expect(connector.negotiatedProtocolVersion).toBe("2026-07-28");
+
+      await connector.disconnect();
+      expect(connector.protocolEra).toBeUndefined();
+      expect(connector.negotiatedProtocolVersion).toBeUndefined();
+    });
+
+    it("returns empty arrays for resources and prompts without error", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      await expect(connector.listResources()).resolves.toEqual({
+        resources: [],
+      });
+      await expect(connector.listAllResources()).resolves.toEqual({
+        resources: [],
+      });
+      await expect(connector.listPrompts()).resolves.toEqual({ prompts: [] });
+      await expect(connector.listAllPrompts()).resolves.toEqual({
+        prompts: [],
+      });
+    });
+
+    it("throws for resources and prompts when disconnected", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      await connector.disconnect();
+
+      await expect(connector.listResources()).rejects.toThrow(
+        "MCP client is not connected"
+      );
+      await expect(connector.listAllResources()).rejects.toThrow(
+        "MCP client is not connected"
+      );
+      await expect(connector.listPrompts()).rejects.toThrow(
+        "MCP client is not connected"
+      );
+      await expect(connector.listAllPrompts()).rejects.toThrow(
+        "MCP client is not connected"
+      );
+    });
+
+    it("respects abort signal in callTool", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        connector.callTool(
+          "execute_code",
+          { code: "1+1" },
+          { signal: controller.signal }
+        )
+      ).rejects.toThrow();
+    });
+
+    it("executes code via callTool", async () => {
+      const mockClient = createMockMcpClient();
+      const connector = new CodeModeConnector(mockClient);
+
+      const res = await connector.callTool("execute_code", {
+        code: "console.log('hi')",
+        timeout: 5000,
+      });
+
+      expect(mockClient.executeCode).toHaveBeenCalledWith(
+        "console.log('hi')",
+        5000
+      );
+      expect(res.content[0]?.type).toBe("text");
+      expect(JSON.parse((res.content[0] as { text: string }).text)).toEqual({
+        result: "executed:console.log('hi')",
+        logs: [],
+        error: null,
+        execution_time: 1,
+      });
+    });
+  });
+
+  describe("MCPSession integration", () => {
+    it("delegates listTools() and tools cleanly through MCPSession", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const session = new MCPSession(connector);
+      await session.initialize();
+
+      expect(session.tools.map((t) => t.name)).toEqual([
+        "execute_code",
+        "search_tools",
+      ]);
+      const tools = await session.listTools();
+      expect(tools.map((t) => t.name)).toEqual([
+        "execute_code",
+        "search_tools",
+      ]);
+    });
+
+    it("reports supports('tools') as true and resources as false", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const session = new MCPSession(connector);
+      await session.initialize();
+
+      expect(session.supports("tools")).toBe(true);
+      expect(session.supports("resources")).toBe(false);
+      expect(session.supports("prompts")).toBe(false);
+    });
+
+    it("MCPSession.info returns normalized metadata without throwing", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const session = new MCPSession(connector);
+      await session.initialize();
+
+      expect(session.info).toEqual({
+        protocolEra: "modern",
+        protocolVersion: "2026-07-28",
+        server: {
+          name: "code_mode",
+          version: "1.0.0",
+          description: "MCP Code Mode Internal Server",
+        },
+        capabilities: { tools: {} },
+        instructions: undefined,
+        extensions: {},
+      });
+    });
+
+    it("adapts code_mode session tools for Vercel AI SDK dynamic tools", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const session = new MCPSession(connector);
+      await session.initialize();
+
+      const aiTools = await createAiSdkTools(session);
+      expect(Object.keys(aiTools).sort()).toEqual([
+        "execute_code",
+        "search_tools",
+      ]);
+      expect(aiTools["execute_code"]?.type).toBe("dynamic");
+      expect(aiTools["search_tools"]?.type).toBe("dynamic");
+    });
+  });
+
+  describe("MCPClient codeMode integration", () => {
+    it("registers an active code_mode session that can be inspected and listed", async () => {
+      const client = new MCPClient({}, { codeMode: true });
+      expect(client.activeSessions).toContain("code_mode");
+
+      const session = client.getSession("code_mode");
+      expect(session).toBeDefined();
+
+      const tools = await session!.listTools();
+      expect(tools.map((t) => t.name)).toEqual([
+        "execute_code",
+        "search_tools",
+      ]);
+      expect(session!.supports("tools")).toBe(true);
+    });
+  });
+});

--- a/libraries/typescript/packages/client/tests/unit/client/code-mode-connector.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/code-mode-connector.test.ts
@@ -89,10 +89,35 @@ describe("CodeModeConnector protocol contract", () => {
       await expect(connector.listAllResources()).resolves.toEqual({
         resources: [],
       });
+      await expect(connector.listResourceTemplates()).resolves.toEqual({
+        resourceTemplates: [],
+      });
       await expect(connector.listPrompts()).resolves.toEqual({ prompts: [] });
       await expect(connector.listAllPrompts()).resolves.toEqual({
         prompts: [],
       });
+    });
+
+    it("throws when resource and prompt listing are called with an aborted signal", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        connector.listResources(undefined, { signal: controller.signal })
+      ).rejects.toThrow();
+      await expect(
+        connector.listAllResources({ signal: controller.signal })
+      ).rejects.toThrow();
+      await expect(
+        connector.listResourceTemplates({ signal: controller.signal })
+      ).rejects.toThrow();
+      await expect(
+        connector.listPrompts({ signal: controller.signal })
+      ).rejects.toThrow();
+      await expect(
+        connector.listAllPrompts({ signal: controller.signal })
+      ).rejects.toThrow();
     });
 
     it("throws for resources and prompts when disconnected", async () => {
@@ -103,6 +128,9 @@ describe("CodeModeConnector protocol contract", () => {
         "MCP client is not connected"
       );
       await expect(connector.listAllResources()).rejects.toThrow(
+        "MCP client is not connected"
+      );
+      await expect(connector.listResourceTemplates()).rejects.toThrow(
         "MCP client is not connected"
       );
       await expect(connector.listPrompts()).rejects.toThrow(
@@ -125,6 +153,68 @@ describe("CodeModeConnector protocol contract", () => {
           { signal: controller.signal }
         )
       ).rejects.toThrow();
+    });
+
+    it("cancels execute_code mid-flight when signal is aborted during execution", async () => {
+      let resolveExecution!: (val: any) => void;
+      const executionPromise = new Promise((resolve) => {
+        resolveExecution = resolve;
+      });
+      const mockClient = createMockMcpClient();
+      vi.mocked(mockClient.executeCode).mockImplementation(
+        () => executionPromise as any
+      );
+      const connector = new CodeModeConnector(mockClient);
+
+      const controller = new AbortController();
+      const callPromise = connector.callTool(
+        "execute_code",
+        { code: "while(true){}" },
+        { signal: controller.signal }
+      );
+
+      expect(mockClient.executeCode).toHaveBeenCalled();
+      controller.abort(new Error("Operation cancelled mid-flight"));
+
+      await expect(callPromise).rejects.toThrow(
+        "Operation cancelled mid-flight"
+      );
+
+      resolveExecution({
+        result: "done",
+        logs: [],
+        error: null,
+        execution_time: 10,
+      });
+    });
+
+    it("cancels search_tools mid-flight when signal is aborted during execution", async () => {
+      let resolveSearch!: (val: any) => void;
+      const searchPromise = new Promise((resolve) => {
+        resolveSearch = resolve;
+      });
+      const mockClient = createMockMcpClient();
+      vi.mocked(mockClient.searchTools).mockImplementation(
+        () => searchPromise as any
+      );
+      const connector = new CodeModeConnector(mockClient);
+
+      const controller = new AbortController();
+      const callPromise = connector.callTool(
+        "search_tools",
+        { query: "test" },
+        { signal: controller.signal }
+      );
+
+      expect(mockClient.searchTools).toHaveBeenCalled();
+      controller.abort(new Error("Search cancelled mid-flight"));
+
+      await expect(callPromise).rejects.toThrow("Search cancelled mid-flight");
+
+      resolveSearch({
+        meta: { total_tools: 0, namespaces: [], result_count: 0 },
+        results: [],
+      });
     });
 
     it("executes code via callTool", async () => {
@@ -208,6 +298,25 @@ describe("CodeModeConnector protocol contract", () => {
       ]);
       expect(aiTools["execute_code"]?.type).toBe("dynamic");
       expect(aiTools["search_tools"]?.type).toBe("dynamic");
+    });
+
+    it("throws when session.listResources or listAllResources is called with an aborted signal", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const session = new MCPSession(connector);
+      await session.initialize();
+
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        session.listResources(undefined, { signal: controller.signal })
+      ).rejects.toThrow();
+      await expect(
+        session.listAllResources({ signal: controller.signal })
+      ).rejects.toThrow();
+      await expect(
+        session.listResourceTemplates({ signal: controller.signal })
+      ).rejects.toThrow();
     });
   });
 

--- a/libraries/typescript/packages/client/tests/unit/client/code-mode-connector.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/code-mode-connector.test.ts
@@ -93,9 +93,6 @@ describe("CodeModeConnector protocol contract", () => {
         resourceTemplates: [],
       });
       await expect(connector.listPrompts()).resolves.toEqual({ prompts: [] });
-      await expect(connector.listAllPrompts()).resolves.toEqual({
-        prompts: [],
-      });
     });
 
     it("throws when resource and prompt listing are called with an aborted signal", async () => {
@@ -115,9 +112,6 @@ describe("CodeModeConnector protocol contract", () => {
       await expect(
         connector.listPrompts({ signal: controller.signal })
       ).rejects.toThrow();
-      await expect(
-        connector.listAllPrompts({ signal: controller.signal })
-      ).rejects.toThrow();
     });
 
     it("throws for resources and prompts when disconnected", async () => {
@@ -134,9 +128,6 @@ describe("CodeModeConnector protocol contract", () => {
         "MCP client is not connected"
       );
       await expect(connector.listPrompts()).rejects.toThrow(
-        "MCP client is not connected"
-      );
-      await expect(connector.listAllPrompts()).rejects.toThrow(
         "MCP client is not connected"
       );
     });


### PR DESCRIPTION
### Summary

Fixes #2487

Fixes the protocol contract on `CodeModeConnector` in `@mcp-use/client`.

When enabling code mode on `MCPClient` (`{ codeMode: true }`), an internal synthetic session named `"code_mode"` is registered in `activeSessions`. Because `CodeModeConnector` extends `BaseConnector` without overriding `listTools()` and protocol metadata getters, invoking `session.listTools()`, inspecting `session.info`, checking `session.supports("tools")`, or adapting the session with `createAiSdkTools(session)` caused unhandled crashes (`MCP client is not connected` / `MCP connection is not initialized`).

This change brings TypeScript's `CodeModeConnector` into parity with Python's `libraries/python/mcp_use/client/connectors/code_mode.py:108-160`.

---

### Expected vs Actual Behavior

| Operation | Before (Actual) | After (Expected & Fixed) |
| :--- | :--- | :--- |
| `connector.listTools()` | ❌ Throws `Error: MCP client is not connected` | ✅ Returns cloned `Tool[]` containing `execute_code`, `search_tools` |
| `session.listTools()` | ❌ Throws `Error: MCP client is not connected` | ✅ Returns cloned `Tool[]` containing `execute_code`, `search_tools` |
| `createAiSdkTools(session)` | ❌ Throws `Error: MCP client is not connected` | ✅ Adapts both tools into Vercel AI SDK dynamic tools |
| `session.supports("tools")` | ❌ Returns `false` | ✅ Returns `true` |
| `session.serverCapabilities` | ❌ Returns `{}` | ✅ Returns `{ tools: {} }` |
| `session.serverInfo` | ❌ Returns `null` | ✅ Returns `{ name: "code_mode", version: "1.0.0", description: ... }` |
| `session.info` | ❌ Throws `Error: MCP connection is not initialized` | ✅ Returns normalized `MCPConnectionInfo` (`protocolEra: "modern"`, `protocolVersion: "2026-07-28"`) |
| `session.listResources()` | ❌ Throws `Error: MCP client is not connected` | ✅ Resolves with `{ resources: [] }` |
| `session.listPrompts()` | ❌ Throws `Error: MCP client is not connected` | ✅ Resolves with `{ prompts: [] }` |

---

### Key Changes

1. **`CodeModeConnector`**:
   - Implemented `override async listTools(options?: RequestOptions): Promise<Tool[]>` with connection check, `options?.signal?.throwIfAborted()`, and defensive clone of `_tools`.
   - Populated `this.toolsCache`, `this.capabilitiesCache = { tools: {} }`, and `this.serverInfoCache` eagerly in constructor and in `initialize()`.
   - Implemented `override get protocolEra()` (`"modern"`) and `override get negotiatedProtocolVersion()` (`"2026-07-28"`).
   - Implemented empty stubs for `listResources()`, `listAllResources()`, `listPrompts()`, and `listAllPrompts()`, returning empty arrays when connected.
   - Forwarded `options?: RequestOptions` and honored `signal` in `callTool()`.
2. **Tests**:
   - Added comprehensive suite in `packages/client/tests/unit/client/code-mode-connector.test.ts` (15 tests covering direct connector operations, session delegation, AI SDK adaptation, abort signals, disconnection guards, and end-to-end `MCPClient` discovery).
3. **Changeset**:
   - Added patch changeset for `@mcp-use/client`.

---

### Verification
- Vitest: 15/15 tests passing (`tests/unit/client/code-mode-connector.test.ts`).
- Typecheck: `tsc --emitDeclarationOnly --declaration` passed with 0 errors.
- Linters: `eslint` and `prettier --check` passed cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2487 by making the synthetic code-mode session satisfy the MCP protocol. Operations that previously crashed—`listTools()`, metadata inspection, and AI SDK adaptation—now return the expected tools and normalized connection metadata.

**Bug Fixes**
- Adds connection guards, cloned tool lists, empty resource and prompt responses, and modern protocol metadata (`2026-07-28`).
- Propagates abort signals through `execute_code` and `search_tools`, including cancellation of in-flight calls.
- Adds coverage for connector, `MCPSession`, and `MCPClient` behavior, plus a patch changeset for `@mcp-use/client`.

<sup>Written for commit 8d43e3cad25c30d468e008a7776ec935476c8591. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

