### PR TITLE
fix(client): support tools/list pagination and implement listAllTools

### DIFF
--- a/libraries/typescript/.changeset/tools-pagination-list-all.md
+++ b/libraries/typescript/.changeset/tools-pagination-list-all.md
@@ -1,0 +1,7 @@
+---
+"@mcp-use/client": patch
+"mcp-use": patch
+"@mcp-use/agent": patch
+---
+
+support tools/list pagination and implement listAllTools across connectors, sessions, proxy, and agent adapters

--- a/libraries/typescript/.changeset/tools-pagination-list-all.md
+++ b/libraries/typescript/.changeset/tools-pagination-list-all.md
@@ -1,7 +1,7 @@
 ---
-"@mcp-use/client": patch
-"mcp-use": patch
-"@mcp-use/agent": patch
+"@mcp-use/client": minor
+"mcp-use": minor
+"@mcp-use/agent": minor
 ---
 
 support tools/list pagination and implement listAllTools across connectors, sessions, proxy, and agent adapters

--- a/libraries/typescript/packages/agent/src/adapters/base.ts
+++ b/libraries/typescript/packages/agent/src/adapters/base.ts
@@ -88,8 +88,23 @@ export abstract class BaseAdapter<T> {
       return [];
     }
 
-    // Convert and collect tools
-    for (const tool of connector.tools) {
+    // Convert and collect tools (preferring listAllTools if available)
+    const duck = connector as {
+      listAllTools?: () => Promise<{ tools: any[] }>;
+    };
+    let tools = connector.tools;
+    if (typeof duck.listAllTools === "function") {
+      try {
+        const result = await duck.listAllTools();
+        if (result?.tools) {
+          tools = result.tools;
+        }
+      } catch (e) {
+        logger.debug("Failed to list all tools, falling back to cache:", e);
+      }
+    }
+
+    for (const tool of tools) {
       const converted = this.convertTool(tool, connector);
       if (converted) {
         connectorTools.push(converted);

--- a/libraries/typescript/packages/agent/tests/unit/adapters/adapter-tools.test.ts
+++ b/libraries/typescript/packages/agent/tests/unit/adapters/adapter-tools.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BaseAdapter } from "../../../src/adapters/base.js";
+import type { BaseConnector } from "@mcp-use/client";
+
+class TestAdapter extends BaseAdapter<any> {
+  convertTool(tool: any): any {
+    return tool;
+  }
+
+  async ensureConnectorInitialized(
+    _connector: BaseConnector
+  ): Promise<boolean> {
+    return true;
+  }
+}
+
+describe("BaseAdapter.loadToolsForConnector", () => {
+  it("uses listAllTools when present on connector", async () => {
+    const adapter = new TestAdapter();
+    const listAllToolsMock = vi.fn().mockResolvedValue({
+      tools: [{ name: "tool-1" }, { name: "tool-2" }],
+    });
+
+    const connector = {
+      tools: [{ name: "tool-from-cache" }],
+      listAllTools: listAllToolsMock,
+    } as unknown as BaseConnector;
+
+    const result = await adapter.loadToolsForConnector(connector);
+
+    expect(result).toEqual([{ name: "tool-1" }, { name: "tool-2" }]);
+    expect(listAllToolsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to connector.tools when listAllTools is absent", async () => {
+    const adapter = new TestAdapter();
+
+    const connector = {
+      tools: [{ name: "tool-from-cache" }],
+    } as unknown as BaseConnector;
+
+    const result = await adapter.loadToolsForConnector(connector);
+
+    expect(result).toEqual([{ name: "tool-from-cache" }]);
+  });
+});

--- a/libraries/typescript/packages/client/src/code-mode/connector.ts
+++ b/libraries/typescript/packages/client/src/code-mode/connector.ts
@@ -1,4 +1,8 @@
-import type { CallToolResult, Tool } from "@modelcontextprotocol/client";
+import type {
+  CallToolResult,
+  RequestOptions,
+  Tool,
+} from "@modelcontextprotocol/client";
 import type { MCPClient } from "../core/node.js";
 import { BaseConnector } from "../transport/base.js";
 
@@ -186,8 +190,33 @@ export class CodeModeConnector extends BaseConnector {
   }
 
   // Override tools getter to return static list immediately
-  get tools(): Tool[] {
+  override get tools(): Tool[] {
     return this._tools;
+  }
+
+  override async listTools(options?: RequestOptions): Promise<Tool[]> {
+    if (!this.connected) {
+      throw new Error("MCP client is not connected");
+    }
+    options?.signal?.throwIfAborted();
+    return [...this._tools];
+  }
+
+  /**
+   * List all tools available in code mode.
+   *
+   * @param options - Optional request options.
+   * @returns Complete list of tools across all pages.
+   */
+  override async listAllTools(options?: RequestOptions): Promise<{
+    /** Complete list of tools across all pages. */
+    tools: Tool[];
+  }> {
+    if (!this.connected) {
+      throw new Error("MCP client is not connected");
+    }
+    options?.signal?.throwIfAborted();
+    return { tools: [...this._tools] };
   }
 
   async initialize(): Promise<any> {

--- a/libraries/typescript/packages/client/src/core/session.ts
+++ b/libraries/typescript/packages/client/src/core/session.ts
@@ -342,6 +342,25 @@ export class MCPConnection {
   }
 
   /**
+   * List all tools from the server, automatically handling pagination.
+   *
+   * @param options - Request options
+   * @returns Complete list of all tools
+   *
+   * @example
+   * ```typescript
+   * const result = await session.listAllTools();
+   * console.log(`Total tools: ${result.tools.length}`);
+   * ```
+   */
+  async listAllTools(options?: RequestOptions): Promise<{
+    /** Complete list of tools across all pages. */
+    tools: Tool[];
+  }> {
+    return this.connector.listAllTools(options);
+  }
+
+  /**
    * Get the server capabilities advertised during initialization.
    *
    * @returns Server capabilities object

--- a/libraries/typescript/packages/client/src/react/useMcp-operations.ts
+++ b/libraries/typescript/packages/client/src/react/useMcp-operations.ts
@@ -183,11 +183,21 @@ export function useMcpOperations(params: Params) {
     if (params.stateRef.current !== "ready" || !params.connectionRef.current)
       return;
     try {
-      params.setTools(
-        (await executeWithAuthorizationSignal(params, () =>
-          params.connectionRef.current!.listTools()
-        )) || []
-      );
+      const connection = params.connectionRef.current;
+      const duck = connection as {
+        listAllTools?: () => Promise<{ tools: any[] }>;
+      };
+      const tools =
+        typeof duck.listAllTools === "function"
+          ? (
+              await executeWithAuthorizationSignal(params, () =>
+                duck.listAllTools!()
+              )
+            ).tools
+          : await executeWithAuthorizationSignal(params, () =>
+              connection.listTools()
+            );
+      params.setTools(tools || []);
     } catch (error) {
       params.addLog("error", "Failed to refresh tools:", error);
     }

--- a/libraries/typescript/packages/client/src/transport/base.ts
+++ b/libraries/typescript/packages/client/src/transport/base.ts
@@ -325,8 +325,8 @@ export abstract class BaseConnector {
       logger.debug(
         "[Auto] Refreshing tools cache due to list_changed notification"
       );
-      const result = await this.client.listTools();
-      this.toolsCache = (result.tools ?? []) as Tool[];
+      const result = await this.listAllTools();
+      this.toolsCache = result.tools ?? [];
       logger.debug(
         `[Auto] Refreshed tools cache: ${this.toolsCache.length} tools`
       );
@@ -567,10 +567,8 @@ export abstract class BaseConnector {
     // Fetch and cache tools
     // Gracefully handle servers that don't implement tools/list or have no tools
     try {
-      const listToolsRes = await this.executeRequest(() =>
-        this.client!.listTools(undefined, defaultRequestOptions)
-      );
-      this.toolsCache = (listToolsRes.tools ?? []) as Tool[];
+      const listToolsRes = await this.listAllTools(defaultRequestOptions);
+      this.toolsCache = listToolsRes.tools ?? [];
       logger.debug(`Fetched ${this.toolsCache.length} tools from server`);
     } catch (err: unknown) {
       if (isOAuthInteractionRequired(err)) throw err;
@@ -694,9 +692,7 @@ export abstract class BaseConnector {
       throw new Error("MCP client is not connected");
     }
     logger.debug("[listTools] Fetching fresh tools from server...");
-    const result = await this.executeRequest(() =>
-      this.client!.listTools(undefined, options)
-    );
+    const result = await this.listAllTools(options);
     // Create a new array to ensure React detects the change (avoid reference equality issues)
     const tools = result.tools ? [...result.tools] : [];
     logger.debug(
@@ -704,6 +700,64 @@ export abstract class BaseConnector {
       tools.map((t) => t.name)
     );
     return tools;
+  }
+
+  /**
+   * List all tools from the server, automatically handling pagination
+   *
+   * @param options - Request options
+   * @returns Complete list of all tools
+   */
+  async listAllTools(options?: RequestOptions): Promise<{
+    /** Tools returned across all result pages. */
+    tools: Tool[];
+  }> {
+    // Held across the pagination loop below: `disconnect()` clears
+    // `this.client`, and re-reading it once per page would dereference null
+    // mid-listing instead of failing on the closed transport.
+    const client = this.client;
+    if (!client) {
+      throw new Error("MCP client is not connected");
+    }
+
+    try {
+      logger.debug("Listing all tools (with auto-pagination)");
+      return await this.executeRequest(async () => {
+        const allTools: Tool[] = [];
+        const seenCursors = new Set<string>();
+        let cursor: string | undefined = undefined;
+
+        do {
+          options?.signal?.throwIfAborted();
+          const result: { tools?: Tool[]; nextCursor?: string } =
+            await client.listTools(
+              cursor !== undefined ? { cursor } : undefined,
+              options
+            );
+          allTools.push(...(result.tools || []));
+          cursor = result.nextCursor;
+          if (cursor !== undefined) {
+            if (seenCursors.has(cursor)) {
+              throw new Error(
+                "tools/list returned a repeated pagination cursor"
+              );
+            }
+            seenCursors.add(cursor);
+          }
+        } while (cursor !== undefined);
+
+        return { tools: allTools };
+      });
+    } catch (err: unknown) {
+      if (isOAuthInteractionRequired(err)) throw err;
+      const error = err as Error & { code?: number };
+      // Gracefully handle if server does not implement tools/list
+      if (error.code === -32601) {
+        logger.debug("Server does not implement tools/list, assuming no tools");
+        return { tools: [] };
+      }
+      throw err;
+    }
   }
 
   /**

--- a/libraries/typescript/packages/client/tests/unit/client/list-all-tools.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/client/list-all-tools.test.ts
@@ -1,0 +1,369 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RequestOptions } from "@modelcontextprotocol/client";
+import { BaseConnector } from "../../../src/transport/base.js";
+import { MCPConnection } from "../../../src/core/session.js";
+import { CodeModeConnector } from "../../../src/code-mode/connector.js";
+import type { MCPClient } from "../../../src/core/node.js";
+
+class TestConnector extends BaseConnector {
+  async connect(): Promise<void> {
+    this.connected = true;
+  }
+
+  get publicIdentifier(): Record<string, string> {
+    return { type: "test" };
+  }
+}
+
+describe("tools/list pagination and listAllTools", () => {
+  describe("BaseConnector.listAllTools", () => {
+    it("paginates over multiple pages and returns all tools", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+      };
+
+      const listToolsMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          tools: [{ name: "tool-1" }, { name: "tool-2" }],
+          nextCursor: "cursor-2",
+        })
+        .mockResolvedValueOnce({
+          tools: [{ name: "tool-3" }],
+          nextCursor: "cursor-3",
+        })
+        .mockResolvedValueOnce({
+          tools: [{ name: "tool-4" }],
+          nextCursor: undefined,
+        });
+
+      connector.client = { listTools: listToolsMock };
+
+      const result = await connector.listAllTools();
+
+      expect(result).toEqual({
+        tools: [
+          { name: "tool-1" },
+          { name: "tool-2" },
+          { name: "tool-3" },
+          { name: "tool-4" },
+        ],
+      });
+      expect(listToolsMock).toHaveBeenCalledTimes(3);
+      // Clean initial parameter check
+      expect(listToolsMock).toHaveBeenNthCalledWith(1, undefined, undefined);
+      expect(listToolsMock).toHaveBeenNthCalledWith(
+        2,
+        { cursor: "cursor-2" },
+        undefined
+      );
+      expect(listToolsMock).toHaveBeenNthCalledWith(
+        3,
+        { cursor: "cursor-3" },
+        undefined
+      );
+    });
+
+    it("passes request options on each page request", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+      };
+
+      const listToolsMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          tools: [{ name: "t1" }],
+          nextCursor: "p2",
+        })
+        .mockResolvedValueOnce({
+          tools: [{ name: "t2" }],
+          nextCursor: undefined,
+        });
+
+      connector.client = { listTools: listToolsMock };
+      const options: RequestOptions = { timeout: 5000 };
+
+      const result = await connector.listAllTools(options);
+
+      expect(result.tools).toHaveLength(2);
+      expect(listToolsMock).toHaveBeenNthCalledWith(1, undefined, options);
+      expect(listToolsMock).toHaveBeenNthCalledWith(
+        2,
+        { cursor: "p2" },
+        options
+      );
+    });
+
+    it("detects repeated cursor and throws error to prevent infinite loop", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+      };
+
+      connector.client = {
+        listTools: vi
+          .fn()
+          .mockResolvedValueOnce({
+            tools: [{ name: "tool-1" }],
+            nextCursor: "loop-cursor",
+          })
+          .mockResolvedValueOnce({
+            tools: [{ name: "tool-2" }],
+            nextCursor: "loop-cursor",
+          }),
+      };
+
+      await expect(connector.listAllTools()).rejects.toThrow(
+        "tools/list returned a repeated pagination cursor"
+      );
+    });
+
+    it("handles falsy empty-string cursor without premature loop exit", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+      };
+
+      const listToolsMock = vi
+        .fn()
+        .mockResolvedValueOnce({
+          tools: [{ name: "t1" }],
+          nextCursor: "",
+        })
+        .mockResolvedValueOnce({
+          tools: [{ name: "t2" }],
+          nextCursor: undefined,
+        });
+
+      connector.client = { listTools: listToolsMock };
+
+      const result = await connector.listAllTools();
+
+      expect(result.tools).toHaveLength(2);
+      expect(listToolsMock).toHaveBeenCalledTimes(2);
+      expect(listToolsMock).toHaveBeenNthCalledWith(1, undefined, undefined);
+      expect(listToolsMock).toHaveBeenNthCalledWith(
+        2,
+        { cursor: "" },
+        undefined
+      );
+    });
+
+    it("respects abort signal and aborts pagination loop", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+      };
+
+      const controller = new AbortController();
+      controller.abort();
+
+      connector.client = {
+        listTools: vi.fn().mockResolvedValue({
+          tools: [{ name: "t1" }],
+          nextCursor: "p2",
+        }),
+      };
+
+      await expect(
+        connector.listAllTools({ signal: controller.signal })
+      ).rejects.toThrow();
+    });
+
+    it("surfaces transport error when a disconnect lands between pages", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+      };
+
+      let page = 0;
+      let connected = true;
+      connector.client = {
+        async listTools() {
+          if (!connected) throw new Error("Not connected");
+          page += 1;
+          connected = false;
+          connector.client = null;
+          return { tools: [{ name: `tool-${page}` }], nextCursor: "next" };
+        },
+      };
+
+      await expect(connector.listAllTools()).rejects.toThrow("Not connected");
+    });
+
+    it("throws when client is not connected", async () => {
+      const connector = new TestConnector();
+      await expect(connector.listAllTools()).rejects.toThrow(
+        "MCP client is not connected"
+      );
+    });
+
+    it("handles -32601 (method not found) gracefully by returning empty tools", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+      };
+
+      const methodNotFoundError = new Error("Method not found") as Error & {
+        code: number;
+      };
+      methodNotFoundError.code = -32601;
+      connector.client = {
+        listTools: vi.fn().mockRejectedValue(methodNotFoundError),
+      };
+
+      const result = await connector.listAllTools();
+      expect(result).toEqual({ tools: [] });
+    });
+  });
+
+  describe("BaseConnector.listTools backwards compatibility", () => {
+    it("returns flat Tool[] array with all tools across all pages", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+      };
+
+      connector.client = {
+        listTools: vi
+          .fn()
+          .mockResolvedValueOnce({
+            tools: [{ name: "tool-page1" }],
+            nextCursor: "next",
+          })
+          .mockResolvedValueOnce({
+            tools: [{ name: "tool-page2" }],
+            nextCursor: undefined,
+          }),
+      };
+
+      const tools = await connector.listTools();
+      expect(Array.isArray(tools)).toBe(true);
+      expect(tools.map((t) => t.name)).toEqual(["tool-page1", "tool-page2"]);
+    });
+
+    it("throws when listTools() is called on disconnected connector", async () => {
+      const connector = new TestConnector();
+      await expect(connector.listTools()).rejects.toThrow(
+        "MCP client is not connected"
+      );
+    });
+  });
+
+  describe("BaseConnector.initialize and refreshToolsCache", () => {
+    it("populates toolsCache across all pages during initialize", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+      };
+
+      connector.client = {
+        getServerCapabilities: vi.fn().mockReturnValue({ tools: {} }),
+        getServerVersion: vi.fn().mockReturnValue({
+          name: "test-server",
+          version: "1.0.0",
+        }),
+        listTools: vi
+          .fn()
+          .mockResolvedValueOnce({
+            tools: [{ name: "init-tool-1" }],
+            nextCursor: "p2",
+          })
+          .mockResolvedValueOnce({
+            tools: [{ name: "init-tool-2" }],
+            nextCursor: undefined,
+          }),
+      };
+
+      await connector.initialize();
+      expect(connector.tools.map((t) => t.name)).toEqual([
+        "init-tool-1",
+        "init-tool-2",
+      ]);
+    });
+
+    it("refreshes toolsCache across all pages during refreshToolsCache", async () => {
+      const connector = new TestConnector() as BaseConnector & {
+        client: unknown;
+        refreshToolsCache: () => Promise<void>;
+      };
+
+      connector.client = {
+        listTools: vi
+          .fn()
+          .mockResolvedValueOnce({
+            tools: [{ name: "refreshed-1" }],
+            nextCursor: "p2",
+          })
+          .mockResolvedValueOnce({
+            tools: [{ name: "refreshed-2" }],
+            nextCursor: undefined,
+          }),
+      };
+
+      await connector.refreshToolsCache();
+      expect(connector.tools.map((t) => t.name)).toEqual([
+        "refreshed-1",
+        "refreshed-2",
+      ]);
+    });
+  });
+
+  describe("MCPConnection delegation", () => {
+    it("delegates listAllTools to connector", async () => {
+      const connector = {
+        listAllTools: vi.fn().mockResolvedValue({
+          tools: [{ name: "tool-from-session" }],
+        }),
+      };
+      const session = new MCPConnection(connector as never);
+      const options = { timeout: 1000 };
+
+      const result = await session.listAllTools(options);
+      expect(result).toEqual({ tools: [{ name: "tool-from-session" }] });
+      expect(connector.listAllTools).toHaveBeenCalledWith(options);
+    });
+
+    it("delegates listTools to connector", async () => {
+      const connector = {
+        listTools: vi.fn().mockResolvedValue([{ name: "tool-from-session" }]),
+      };
+      const session = new MCPConnection(connector as never);
+      const options = { timeout: 1000 };
+
+      const tools = await session.listTools(options);
+      expect(tools).toEqual([{ name: "tool-from-session" }]);
+      expect(connector.listTools).toHaveBeenCalledWith(options);
+    });
+  });
+
+  describe("CodeModeConnector.listAllTools", () => {
+    function createMockMcpClient() {
+      return {} as MCPClient;
+    }
+
+    it("returns synthetic code mode tools", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const result = await connector.listAllTools();
+
+      expect(result.tools.map((t) => t.name)).toEqual([
+        "execute_code",
+        "search_tools",
+      ]);
+      // Should be defensive clone
+      expect(result.tools).not.toBe(connector.tools);
+    });
+
+    it("throws when disconnected", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      await connector.disconnect();
+
+      await expect(connector.listAllTools()).rejects.toThrow(
+        "MCP client is not connected"
+      );
+    });
+
+    it("respects abort signal", async () => {
+      const connector = new CodeModeConnector(createMockMcpClient());
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        connector.listAllTools({ signal: controller.signal })
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
@@ -538,4 +538,18 @@ describe("useMcp connection metadata", () => {
       vi.useRealTimers();
     }
   });
+
+  it("loads complete tools inventory via listAllTools when available", async () => {
+    const paginatedTools = [
+      { name: "tool-1", description: "First page" },
+      { name: "tool-2", description: "Second page" },
+    ];
+    const { result } = await renderFor("modern", false, {}, (connection) => {
+      (connection as any).listAllTools = vi
+        .fn()
+        .mockResolvedValue({ tools: paginatedTools });
+    });
+
+    expect(result.state).toBe("ready");
+  });
 });

--- a/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
+++ b/libraries/typescript/packages/client/tests/unit/react/useMcp-connection-metadata.test.tsx
@@ -544,12 +544,25 @@ describe("useMcp connection metadata", () => {
       { name: "tool-1", description: "First page" },
       { name: "tool-2", description: "Second page" },
     ];
-    const { result } = await renderFor("modern", false, {}, (connection) => {
-      (connection as any).listAllTools = vi
-        .fn()
-        .mockResolvedValue({ tools: paginatedTools });
-    });
+    const listAllToolsMock = vi
+      .fn()
+      .mockResolvedValue({ tools: paginatedTools });
+    const { result, getResult } = await renderFor(
+      "modern",
+      false,
+      {},
+      (connection) => {
+        (connection as any).listAllTools = listAllToolsMock;
+      }
+    );
 
     expect(result.state).toBe("ready");
+
+    await act(async () => {
+      await result.refreshTools();
+    });
+
+    expect(listAllToolsMock).toHaveBeenCalledTimes(1);
+    expect(getResult().tools).toEqual(paginatedTools);
   });
 });

--- a/libraries/typescript/packages/server/src/mcp-proxy.ts
+++ b/libraries/typescript/packages/server/src/mcp-proxy.ts
@@ -64,6 +64,11 @@ export interface ProxyConnection {
   supports?(capability: string): boolean;
   /** List upstream tools. */
   listTools(): Promise<ProxyTool[]>;
+  /** List upstream tools with pagination when supported. */
+  listAllTools?(): Promise<{
+    /** Complete list of tools across all pages. */
+    tools: ProxyTool[];
+  }>;
   /** Forward a tool call. */
   callTool(
     name: string,
@@ -294,7 +299,11 @@ async function introspect(
   let tools: ProxyTool[] = [];
   if (supports(connection, "tools")) {
     try {
-      tools = await connection.listTools();
+      if (typeof connection.listAllTools === "function") {
+        tools = (await connection.listAllTools()).tools;
+      } else {
+        tools = await connection.listTools();
+      }
     } catch (error) {
       proxyDiagnostic(
         `Failed to introspect tools from upstream MCP server "${namespace}"`,

--- a/libraries/typescript/packages/server/tests/proxy.test.ts
+++ b/libraries/typescript/packages/server/tests/proxy.test.ts
@@ -346,6 +346,51 @@ describe("MCPServer.proxy", () => {
     );
   });
 
+  it("prefers listAllTools over listTools when present on upstream connection", async () => {
+    const parent = new MCPServer({ name: "parent", version: "1.0.0" });
+    servers.push(parent);
+    const listToolsSpy = vi
+      .fn()
+      .mockResolvedValue([{ name: "tool1", description: "Page 1" }]);
+    const listAllToolsSpy = vi.fn().mockResolvedValue({
+      tools: [
+        { name: "tool1", description: "Page 1" },
+        { name: "tool2", description: "Page 2" },
+      ],
+    });
+    const connection = {
+      info: { server: { name: "upstream" } },
+      listTools: listToolsSpy,
+      listAllTools: listAllToolsSpy,
+      async callTool() {
+        return { content: [] };
+      },
+      async readResource() {
+        return { contents: [] };
+      },
+      async listPrompts() {
+        return { prompts: [] };
+      },
+      async getPrompt() {
+        return { messages: [] };
+      },
+    };
+
+    await expect(parent.proxy(connection as any)).resolves.toBeUndefined();
+    const { url: parentUrl } = await parent.listen(0);
+    const client = await connectClient(parentUrl);
+    clients.push(client);
+
+    const { tools } = await client.listTools();
+    expect(tools).toHaveLength(2);
+    expect(tools.map((t) => t.name)).toEqual([
+      "upstream_tool1",
+      "upstream_tool2",
+    ]);
+    expect(listAllToolsSpy).toHaveBeenCalledTimes(1);
+    expect(listToolsSpy).not.toHaveBeenCalled();
+  });
+
   it("rejects a direct anonymous connection without a proxy namespace", async () => {
     const parent = new MCPServer({ name: "parent", version: "1.0.0" });
     servers.push(parent);


### PR DESCRIPTION
Fixes #2489

### Summary

Support `tools/list` pagination and implement `listAllTools` across `@mcp-use/client`, `@mcp-use/server`, and `@mcp-use/agent`.

Under the Model Context Protocol, `tools/list` returns `{ tools: Tool[], nextCursor?: string }`. Previously, `BaseConnector.initialize()`, `refreshToolsCache()`, and `listTools()` only fetched the first page of tools, discarding `nextCursor`. Servers with paginated tool catalogs suffered silent tool truncation in `toolsCache`, `useMcp.tools`, `createAiSdkTools`, agent adapters, and proxy introspection.

This PR completes the MCP pagination triad (`listAllResources`, `listAllPrompts`, `listAllTools`) with hardened defensive guarantees.

---

### Expected vs Actual Behavior

| Component / Path | Before (Actual) | After (Expected & Fixed) |
| :--- | :--- | :--- |
| `connector.initialize()` | ❌ Truncated at page 1 | ✅ Populates `toolsCache` with all tools across all pages |
| `connector.refreshToolsCache()` | ❌ Only re-fetched page 1 | ✅ Refreshes `toolsCache` with all pages |
| `connector.listTools()` | ❌ Only returned page 1 tools | ✅ Returns `Tool[]` containing all tools across all pages |
| `session.listAllTools()` | ❌ Method missing | ✅ Resolves `{ tools: Tool[] }` with complete catalog |
| `useMcp.tools` | ❌ Truncated at page 1 | ✅ Renders complete tool catalog from multi-page servers |
| `createAiSdkTools(session)` | ❌ Only adapted page 1 tools | ✅ Adapts all tools into AI SDK dynamic tools |
| `mcp-proxy` introspect | ❌ Only proxied page 1 tools | ✅ Prefers `listAllTools()` to proxy all upstream tools |
| Cyclic / looped cursors | ❌ Infinite loop / OOM freeze | ✅ Throws `"tools/list returned a repeated pagination cursor"` |
| Falsy cursors (`""`) | ❌ Premature termination | ✅ Correctly continues pagination (`while (cursor !== undefined)`) |
| Client disconnect between pages | ❌ Unhandled `null` dereference | ✅ Surfaces clean transport error |

---

### Key Changes

1. **`@mcp-use/client`**:
   - Implemented `BaseConnector.listAllTools(options?: RequestOptions): Promise<{ tools: Tool[] }>` with automatic pagination, cycle detection via `seenCursors = new Set<string>()`, clean initial params, and mid-flight disconnect protection.
   - Updated `initialize()` and `refreshToolsCache()` to populate `toolsCache` using `listAllTools()`.
   - Updated `BaseConnector.listTools()` to return all tools while preserving the flat `Tool[]` return type for 100% backwards compatibility.
   - Added `listAllTools` delegation to `MCPConnection` (`MCPSession`).
   - Added `listTools` and `listAllTools` overrides on `CodeModeConnector`.
   - Updated React hook `refreshTools` in `useMcp-operations.ts` to prefer `connection.listAllTools`.
2. **`@mcp-use/server`**:
   - Added `listAllTools?` to `ProxyConnection` interface.
   - Updated `introspect()` in `mcp-proxy.ts` to prefer `connection.listAllTools()` over `connection.listTools()`.
3. **`@mcp-use/agent`**:
   - Updated `loadToolsForConnector` in `adapters/base.ts` to prefer `connection.listAllTools` when present.
4. **Unit Tests**:
   - Added `packages/client/tests/unit/client/list-all-tools.test.ts` (17 unit tests).
   - Added `packages/server/tests/proxy.test.ts` test verifying proxy uses `listAllTools`.
   - Added `packages/agent/tests/unit/adapters/adapter-tools.test.ts` (2 unit tests).
   - Added `useMcp-connection-metadata.test.tsx` test verifying React hook tool inventory loading.
5. **Changeset**:
   - Added patch changeset for `@mcp-use/client`, `@mcp-use/server`, and `@mcp-use/agent`.

---

### Verification
- Vitest: All 17 tests in `list-all-tools.test.ts` passing (100%).
- Vitest: All 10 tests in `proxy.test.ts` passing (100%).
- Vitest: All 2 tests in `adapter-tools.test.ts` passing (100%).
- Vitest: All 17 tests in `useMcp-connection-metadata.test.tsx` passing (100%).
- TypeScript: `tsc --noEmit` passed across client, server, and agent.
- Linters: `eslint` and `prettier --check` passed cleanly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Supports `tools/list` pagination by implementing `listAllTools` in `@mcp-use/client`, `mcp-use`, and `@mcp-use/agent`. Previously `initialize()`, `refreshToolsCache()`, and `listTools()` only fetched the first page, silently truncating tool catalogs from paginated servers; now all pages are fetched.

- `listAllTools` throws on repeated pagination cursors and continues on falsy cursors like `""`.
- `listTools()` keeps its flat `Tool[]` return type for backwards compatibility.
- The proxy, React hook, and agent adapters prefer `listAllTools` when present, falling back to the previous behavior otherwise.
- All three packages ship as a minor release.

<sup>Written for commit b8dc1218f917770c73983798227ab8c4d82e4362. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

