### PR TITLE
ci: use dedicated CLI mirror credential

### DIFF
--- a/.github/workflows/sync-cli.yml
+++ b/.github/workflows/sync-cli.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Clone mirror repo
         env:
-          MIRROR_TOKEN: ${{ secrets.INSPECTOR_MIRROR_TOKEN }}
+          MIRROR_TOKEN: ${{ secrets.CLI_MIRROR_TOKEN }}
         run: |
           set -euo pipefail
           test -n "$MIRROR_TOKEN"
@@ -87,7 +87,7 @@ jobs:
 
       - name: Commit and push to mirror repo
         env:
-          MIRROR_TOKEN: ${{ secrets.INSPECTOR_MIRROR_TOKEN }}
+          MIRROR_TOKEN: ${{ secrets.CLI_MIRROR_TOKEN }}
           TARGET_BRANCH: ${{ steps.vars.outputs.target_branch }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- use the dedicated `CLI_MIRROR_TOKEN` secret for the CLI mirror workflow
- keep the Inspector mirror credential scoped to the Inspector repository

## Context

The first live CLI mirror run successfully copied the package and generated the README notice, but the final push was rejected because `INSPECTOR_MIRROR_TOKEN` is scoped only to `mcp-use/inspector`.

## Verification

- `CLI_MIRROR_TOKEN` is present in the monorepo Actions secrets
- YAML parses locally
- `git diff --check` passes
- the target repository remains unarchived and the old implementation remains at `legacy/cli-v1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the CLI mirror workflow to use the dedicated `CLI_MIRROR_TOKEN` secret, fixing the push failure caused by `INSPECTOR_MIRROR_TOKEN` being scoped only to the Inspector repository.

<sup>Written for commit 01c728aaa88530d745fc583f9e3128888df84439. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

