### PR TITLE
chore(typescript): use official ext-apps 2.0.0

### DIFF
--- a/libraries/typescript/.changeset/retire-ext-apps-fork.md
+++ b/libraries/typescript/.changeset/retire-ext-apps-fork.md
@@ -1,0 +1,6 @@
+---
+"@mcp-use/client": patch
+"mcp-use": patch
+---
+
+Replace the temporary `@mcp-use/ext-apps` package alias with the official `@modelcontextprotocol/ext-apps` 2.0.0 release. The upstream release includes the SDK v2 role-isolation work previously carried by the fork.

--- a/libraries/typescript/packages/client/package.json
+++ b/libraries/typescript/packages/client/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@modelcontextprotocol/client": "2.0.0",
     "@modelcontextprotocol/core": "2.0.0",
-    "@modelcontextprotocol/ext-apps": "npm:@mcp-use/ext-apps@1.7.4-pr720.1"
+    "@modelcontextprotocol/ext-apps": "2.0.0"
   },
   "peerDependencies": {
     "@e2b/code-interpreter": "^2.6.1",

--- a/libraries/typescript/packages/server/package.json
+++ b/libraries/typescript/packages/server/package.json
@@ -125,7 +125,7 @@
     "@mcp-use/inspector": "workspace:*",
     "@modelcontextprotocol/client": "2.0.0",
     "@modelcontextprotocol/core": "2.0.0",
-    "@modelcontextprotocol/ext-apps": "npm:@mcp-use/ext-apps@1.7.4-pr720.1",
+    "@modelcontextprotocol/ext-apps": "2.0.0",
     "@modelcontextprotocol/server": "2.0.0",
     "hono": "^4.12.34",
     "jose": "^6.1.3"

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -266,8 +266,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       '@modelcontextprotocol/ext-apps':
-        specifier: npm:@mcp-use/ext-apps@1.7.4-pr720.1
-        version: '@mcp-use/ext-apps@1.7.4-pr720.1(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/core@2.0.0)(@modelcontextprotocol/server@2.0.0(patch_hash=2a5f5402571efdc40802e9603a3dd09e22588b4aacad710814c204d79568091e))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)'
+        specifier: 2.0.0
+        version: 2.0.0(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/core@2.0.0)(@modelcontextprotocol/server@2.0.0(patch_hash=2a5f5402571efdc40802e9603a3dd09e22588b4aacad710814c204d79568091e))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
     devDependencies:
       '@e2b/code-interpreter':
         specifier: ^2.6.1
@@ -558,8 +558,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       '@modelcontextprotocol/ext-apps':
-        specifier: npm:@mcp-use/ext-apps@1.7.4-pr720.1
-        version: '@mcp-use/ext-apps@1.7.4-pr720.1(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/core@2.0.0)(@modelcontextprotocol/server@2.0.0(patch_hash=2a5f5402571efdc40802e9603a3dd09e22588b4aacad710814c204d79568091e))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)'
+        specifier: 2.0.0
+        version: 2.0.0(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/core@2.0.0)(@modelcontextprotocol/server@2.0.0(patch_hash=2a5f5402571efdc40802e9603a3dd09e22588b4aacad710814c204d79568091e))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       '@modelcontextprotocol/server':
         specifier: 2.0.0
         version: 2.0.0(patch_hash=2a5f5402571efdc40802e9603a3dd09e22588b4aacad710814c204d79568091e)
@@ -2458,26 +2458,6 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mcp-use/ext-apps@1.7.4-pr720.1':
-    resolution: {integrity: sha512-op0LJm6N9Npt8GQaZ2dF3WwdldvYCw7skD1lRnAOXqpUbyKGiM1l3eMHsJiEE1KRSNLNBYVZrODRG0q38W09iw==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@modelcontextprotocol/client': 2.0.0
-      '@modelcontextprotocol/core': 2.0.0
-      '@modelcontextprotocol/server': 2.0.0
-      react: ^19.2.0
-      react-dom: ^19.2.0
-      zod: 4.4.3
-    peerDependenciesMeta:
-      '@modelcontextprotocol/client':
-        optional: true
-      '@modelcontextprotocol/server':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
 
@@ -2497,6 +2477,24 @@ packages:
   '@modelcontextprotocol/core@2.0.0':
     resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
     engines: {node: '>=20'}
+
+  '@modelcontextprotocol/ext-apps@2.0.0':
+    resolution: {integrity: sha512-a6tXzFcIbIIdnqumQ7W8Oxd8W/KAPkAKYpoxpD9nDgxZ24ywgxG5pK/8G9W5pOFUygS7gWHQhPv8cwRB44/8yg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/client': ^2.0.0
+      '@modelcontextprotocol/core': ^2.0.0
+      '@modelcontextprotocol/server': ^2.0.0
+      react: ^19.2.0
+      react-dom: ^19.2.0
+      zod: 4.4.3
+    peerDependenciesMeta:
+      '@modelcontextprotocol/server':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -9978,17 +9976,6 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mcp-use/ext-apps@1.7.4-pr720.1(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/core@2.0.0)(@modelcontextprotocol/server@2.0.0(patch_hash=2a5f5402571efdc40802e9603a3dd09e22588b4aacad710814c204d79568091e))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
-    dependencies:
-      '@modelcontextprotocol/core': 2.0.0
-      '@standard-schema/spec': 1.1.0
-      zod: 4.4.3
-    optionalDependencies:
-      '@modelcontextprotocol/client': 2.0.0
-      '@modelcontextprotocol/server': 2.0.0(patch_hash=2a5f5402571efdc40802e9603a3dd09e22588b4aacad710814c204d79568091e)
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
@@ -10019,6 +10006,17 @@ snapshots:
   '@modelcontextprotocol/core@2.0.0':
     dependencies:
       zod: 4.4.3
+
+  '@modelcontextprotocol/ext-apps@2.0.0(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/core@2.0.0)(@modelcontextprotocol/server@2.0.0(patch_hash=2a5f5402571efdc40802e9603a3dd09e22588b4aacad710814c204d79568091e))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)':
+    dependencies:
+      '@modelcontextprotocol/client': 2.0.0
+      '@modelcontextprotocol/core': 2.0.0
+      '@standard-schema/spec': 1.1.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@modelcontextprotocol/server': 2.0.0(patch_hash=2a5f5402571efdc40802e9603a3dd09e22588b4aacad710814c204d79568091e)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
## Summary

- replace the temporary `npm:@mcp-use/ext-apps@1.7.4-pr720.1` alias in `@mcp-use/client` and `mcp-use` with the official `@modelcontextprotocol/ext-apps@2.0.0` release
- regenerate the TypeScript workspace lockfile, removing the fork from the root install graph
- add patch changesets for `@mcp-use/client` and `mcp-use`

Upstream PRs [#720](https://github.com/modelcontextprotocol/ext-apps/pull/720) and [#768](https://github.com/modelcontextprotocol/ext-apps/pull/768) landed the SDK v2 role-isolation work previously carried by our fork. The official [v2.0.0 release](https://github.com/modelcontextprotocol/ext-apps/releases/tag/v2.0.0) is now published to npm with provenance.

Linear: [MCP-3235](https://linear.app/manufact/issue/MCP-3235/replace-mcp-useext-apps-fork-with-official-ext-apps-200)

## Verification

- `npm view @modelcontextprotocol/ext-apps@2.0.0` — verified version, exports, split SDK peers, integrity, and provenance
- `pnpm install --frozen-lockfile`
- `pnpm changeset status`
- `pnpm --filter mcp-use... build`
- `pnpm --filter @mcp-use/client test:run` — 61 files, 373 tests passed
- `pnpm --filter mcp-use test:run` — typecheck plus 44 files, 477 tests passed
- Prettier check on all changed files
- `git diff --check`
- packed both public packages and inspected their manifests; each declares `"@modelcontextprotocol/ext-apps": "2.0.0"`
- `pnpm why @mcp-use/ext-apps` returns no effective root-workspace dependency; `pnpm why @modelcontextprotocol/ext-apps` resolves one official 2.0.0 version for both public packages

## Boundary

`packages/client/examples/_demo-servers/pnpm-lock.yaml` remains unchanged. It is an independent consumer lockfile pinned to the previously published `mcp-use@2.0.4`, so it correctly retains that old release transitive graph until the demo is updated to a post-migration published version. It is not part of the workspace package graph or either published tarball.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the temporary `@mcp-use/ext-apps` alias with the official `@modelcontextprotocol/ext-apps@2.0.0` in both `@mcp-use/client` and `mcp-use`. The upstream release carries the SDK v2 role-isolation work previously held by the fork, so no behavior change is expected. This also removes the fork from the workspace lockfile and adds patch changesets for both packages. The demo server lockfile remains unchanged because it's an independent consumer pinned to the previous published version. Linear: [MCP-3235](https://linear.app/manufact/issue/MCP-3235/replace-mcp-useext-apps-fork-with-official-ext-apps-200).

<sup>Written for commit 3ac2a7fcb21a3e52a2625a4a17f52a6848b243d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

