### PR TITLE
ci: make Deno PR preview resilient to esm.sh CDN timeouts

### DIFF
--- a/.github/workflows/typescript-pr-preview.yml
+++ b/.github/workflows/typescript-pr-preview.yml
@@ -73,17 +73,18 @@ jobs:
       - name: Create temporary deno.json with PR preview imports
         working-directory: libraries/typescript/packages/server/tests/deno
         env:
-          PR_NUMBER: ${{ needs.preview.outputs.pr-number }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         # Note: Hybrid mapping to satisfy conflicting Zod requirements:
         # - SDK imports "zod/v3" and needs "z.custom" (available in Zod v3)
         # - Other deps import "zod/v4" and "zod/v4-mini"
         # - We map "zod/v3" to "zod@3.24.4" (aliasing v3 import to root v3 package)
         # - We use esm.sh for zod to match the PR preview environment
         run: |
+          SHORT_SHA="${COMMIT_SHA:0:7}"
           cat > deno.json << EOF
           {
             "imports": {
-              "mcp-use": "https://esm.sh/pr/mcp-use/mcp-use@$PR_NUMBER?no-dts&external=zod",
+              "mcp-use": "https://esm.sh/pr/mcp-use/mcp-use@$SHORT_SHA?no-dts&external=zod",
               "zod": "https://esm.sh/zod@3.24.4",
               "zod/v3": "https://esm.sh/zod@3.24.4",
               "zod/v4": "https://esm.sh/zod@4.2.0",
@@ -93,13 +94,12 @@ jobs:
             }
           }
           EOF
-          echo "Generated deno.json with PR #$PR_NUMBER preview packages:"
+          echo "Generated deno.json with commit $SHORT_SHA preview packages:"
           cat deno.json
 
       - name: Wait for esm.sh to pick up the package
         id: wait-for-esm
         env:
-          PR_NUMBER: ${{ needs.preview.outputs.pr-number }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           echo "Waiting for esm.sh to pick up the preview package..."
@@ -108,36 +108,32 @@ jobs:
           MAX_RETRIES=10
           RETRY_DELAY=30
           
-          PR_URL="https://esm.sh/pr/mcp-use/mcp-use@${PR_NUMBER}"
-          COMMIT_URL="https://esm.sh/pr/mcp-use/mcp-use@${SHORT_SHA}"
+          IMPORT_URL="https://esm.sh/pr/mcp-use/mcp-use@${SHORT_SHA}?no-dts&external=zod"
           
-          echo "Checking URLs:"
-          echo "  PR URL: $PR_URL"
-          echo "  Commit URL: $COMMIT_URL"
+          echo "Checking import URL: $IMPORT_URL"
           
-          PR_READY=false
+          READY=false
           RETRY_COUNT=0
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            # Check PR number URL with lightweight range GET to trigger on-demand build worker
-            if [ "$PR_READY" = false ]; then
-              if curl -s -f -r 0-0 --max-time 15 "$PR_URL" > /dev/null 2>&1; then
-                echo "✅ PR URL is available"
-                PR_READY=true
+            # Check the exact import URL with lightweight range GET to trigger on-demand build worker
+            if [ "$READY" = false ]; then
+              if curl -s -f -r 0-0 --max-time 15 "$IMPORT_URL" > /dev/null 2>&1; then
+                echo "✅ Preview import URL is available"
+                READY=true
                 break
               fi
             fi
             
             RETRY_COUNT=$((RETRY_COUNT + 1))
             if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-              echo "Waiting for packages... (attempt $RETRY_COUNT/$MAX_RETRIES, PR: $PR_READY)"
+              echo "Waiting for package... (attempt $RETRY_COUNT/$MAX_RETRIES)"
               sleep $RETRY_DELAY
             else
-              echo "⚠️ Packages didn't become fully available after ${MAX_RETRIES} attempts (5 minutes)"
-              echo "  PR URL ready: $PR_READY"
+              echo "⚠️ Package didn't become available after ${MAX_RETRIES} attempts (5 minutes)"
             fi
           done
-          echo "ready=$PR_READY" >> $GITHUB_OUTPUT
+          echo "ready=$READY" >> $GITHUB_OUTPUT
 
       - name: Report Preview Status
         if: steps.wait-for-esm.outputs.ready != 'true'

--- a/.github/workflows/typescript-pr-preview.yml
+++ b/.github/workflows/typescript-pr-preview.yml
@@ -60,6 +60,7 @@ jobs:
     name: Test with Deno (PR Preview)
     runs-on: ubuntu-latest
     needs: preview
+    continue-on-error: true
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -96,6 +97,7 @@ jobs:
           cat deno.json
 
       - name: Wait for esm.sh to pick up the package
+        id: wait-for-esm
         env:
           PR_NUMBER: ${{ needs.preview.outputs.pr-number }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
@@ -114,45 +116,36 @@ jobs:
           echo "  Commit URL: $COMMIT_URL"
           
           PR_READY=false
-          COMMIT_READY=false
           RETRY_COUNT=0
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            # Check PR number URL
+            # Check PR number URL with lightweight range GET to trigger on-demand build worker
             if [ "$PR_READY" = false ]; then
-              if curl -s -f -I "$PR_URL" > /dev/null 2>&1; then
+              if curl -s -f -r 0-0 --max-time 15 "$PR_URL" > /dev/null 2>&1; then
                 echo "✅ PR URL is available"
                 PR_READY=true
+                break
               fi
-            fi
-            
-            # Check commit SHA URL
-            if [ "$COMMIT_READY" = false ]; then
-              if curl -s -f -I "$COMMIT_URL" > /dev/null 2>&1; then
-                echo "✅ Commit URL is available"
-                COMMIT_READY=true
-              fi
-            fi
-            
-            # Both ready?
-            if [ "$PR_READY" = true ] && [ "$COMMIT_READY" = true ]; then
-              echo "✅ Both package URLs are available on esm.sh"
-              break
             fi
             
             RETRY_COUNT=$((RETRY_COUNT + 1))
             if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
-              echo "Waiting for packages... (attempt $RETRY_COUNT/$MAX_RETRIES, PR: $PR_READY, Commit: $COMMIT_READY)"
+              echo "Waiting for packages... (attempt $RETRY_COUNT/$MAX_RETRIES, PR: $PR_READY)"
               sleep $RETRY_DELAY
             else
               echo "⚠️ Packages didn't become fully available after ${MAX_RETRIES} attempts (5 minutes)"
               echo "  PR URL ready: $PR_READY"
-              echo "  Commit URL ready: $COMMIT_READY"
-              echo "Proceeding with tests anyway..."
             fi
           done
+          echo "ready=$PR_READY" >> $GITHUB_OUTPUT
+
+      - name: Report Preview Status
+        if: steps.wait-for-esm.outputs.ready != 'true'
+        run: |
+          echo "::notice::Preview package was not available on esm.sh within the polling window. Skipping Deno smoke test."
 
       - name: Cache Deno Dependencies
+        if: steps.wait-for-esm.outputs.ready == 'true'
         working-directory: libraries/typescript/packages/server/tests/deno
         env:
           DENO_DOWNLOAD_TIMEOUT: "300000"  # 5 minutes in milliseconds
@@ -178,6 +171,7 @@ jobs:
           done
 
       - name: Run Deno Tests
+        if: steps.wait-for-esm.outputs.ready == 'true'
         working-directory: libraries/typescript/packages/server/tests/deno
         env:
           MCP_USE_ANONYMIZED_TELEMETRY: false


### PR DESCRIPTION
## Summary

Hardens `.github/workflows/typescript-pr-preview.yml` against external `esm.sh` CDN latency and timeouts on ephemeral `pkg.pr.new` packages.

Fixes #2499.

### Problem
Across recent pull requests (e.g. #2488, #2498, and Dependabot), the `Test with Deno (PR Preview)` job consistently hangs for ~18 minutes and fails with `408 Request Timeout`:
1. **`curl -I` uses `HEAD`**: In the polling step, `curl -s -f -I` sends `HEAD` requests. In `esm.sh`'s edge architecture, `HEAD` requests do not trigger background build worker tasks on ephemeral preview packages.
2. **Coupled URL readiness**: The script checked both `PR_URL` and `COMMIT_URL`, waiting all 5 minutes even if the PR package needed for the test was already available.
3. **No graceful skip on timeout**: When the 5-minute polling loop expired with packages not ready, it unconditionally proceeded to cache and run `deno test`, burning an additional 13 minutes before crashing with an unhandled `408 Request Timeout`.
4. **Advisory preview failures break CI**: An external 3rd-party CDN timeout caused the entire pull request status check to fail, even when all 34 core conformance, unit, and build suites passed.

### Changes
1. **Add `continue-on-error: true`**: Ensures external CDN downtime or queue latency on advisory PR preview smoke tests does not block contributor PRs or maintainer merges.
2. **Lightweight Range `GET`**: Changes the polling probe to `curl -s -f -r 0-0 --max-time 15 "$PR_URL"` to actively initiate background compilation on `esm.sh`.
3. **Early Exit on Readiness**: Breaks out of the retry loop as soon as `PR_URL` is available (the only URL imported by `deno.json`).
4. **Graceful Skip**: Exports `ready=$PR_READY` from `wait-for-esm`. If packages did not become available during the polling window, logs an explanatory GitHub Actions notice and skips `deno cache` / `deno test` instead of crashing.

### Verification
- Parsed and verified `.github/workflows/typescript-pr-preview.yml` with `js-yaml`:
  - 2 jobs, 7 steps in `deno-test`.
  - Confirmed step conditions (`if: steps.wait-for-esm.outputs.ready == 'true'` and `!= 'true'`).
- Validated `continue-on-error: true` placement under `deno-test`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Deno preview import to the PR's commit SHA and gates the smoke test on `esm.sh` readiness, so CDN timeouts don't cause long CI failures while real test failures still block. Fixes #2499.

- Probes the exact import URL with a bounded range `GET` to trigger `esm.sh`'s on-demand build.
- Emits a GitHub Actions notice when the package isn't available after the polling window (~7 minutes).
- Uses step conditions instead of `continue-on-error` to skip unavailable previews.

<sup>Written for commit d1dbbe2bb27243d1bed04a18367727fa8b834b4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

