### PR TITLE
fix(release): propagate bundled Inspector releases and validate peers

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -108,6 +108,7 @@ jobs:
         working-directory: libraries/typescript
         run: |
           pnpm release-channel prepare --channel canary
+          pnpm release-channel preflight --channel canary
           pnpm changeset status --since origin/main --output "$RUNNER_TEMP/canary-changeset-status.json"
           pnpm release-channel validate --channel canary --plan "$RUNNER_TEMP/canary-changeset-status.json"
 
@@ -118,6 +119,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           pnpm changeset version
+          pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile
           cd ../..
           git add .
           git commit -m "chore(typescript): version packages (canary)" || echo "No changes to commit"
@@ -302,6 +304,8 @@ jobs:
         with:
           name: railway-deploy-marker
           path: .railway-deploy-marker
+          include-hidden-files: true
+          if-no-files-found: error
           retention-days: 1
 
       # ============================================================================
@@ -469,6 +473,8 @@ jobs:
         with:
           name: railway-deploy-marker
           path: .railway-deploy-marker
+          include-hidden-files: true
+          if-no-files-found: error
           retention-days: 1
 
       - name: Reset canary to main

--- a/libraries/typescript/.changeset/repair-inspector-bundled-release.md
+++ b/libraries/typescript/.changeset/repair-inspector-bundled-release.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/inspector": patch
+---
+
+Rebuild the standalone Inspector with the current Agent OpenRouter Responses API fix and repair the published framework peer metadata. Automatically propagate future bundle rebuilds and metadata changes through the release plan without adding Inspector runtime dependencies.

--- a/libraries/typescript/knip.json
+++ b/libraries/typescript/knip.json
@@ -12,7 +12,8 @@
   ],
   "workspaces": {
     ".": {
-      "project": ["*.{js,ts}"]
+      "entry": ["scripts/release-channel.mjs", "scripts/version-packages.mjs", "scripts/release-*.test.mjs"],
+      "project": ["*.{js,ts}", "scripts/release-*.mjs", "scripts/version-packages.mjs"]
     },
     "packages/server": {
       "entry": ["src/oauth/**/*.ts", "tests/**/*.{ts,tsx}"],

--- a/libraries/typescript/package.json
+++ b/libraries/typescript/package.json
@@ -35,10 +35,10 @@
     "dev": "pnpm run -r --parallel dev",
     "prepare": "cd ../.. && husky libraries/typescript/.husky",
     "changeset": "changeset",
-    "version": "changeset version && pnpm install --no-frozen-lockfile",
+    "version": "node scripts/version-packages.mjs && pnpm install --no-frozen-lockfile",
     "version:exit-prerelease": "node scripts/version-packages.mjs",
     "release-channel": "node scripts/release-channel.mjs",
-    "test:release-channel": "node --test scripts/release-channel.test.mjs",
+    "test:release-channel": "node --test scripts/release-channel.test.mjs scripts/release-propagation.test.mjs",
     "release": "pnpm build && changeset publish",
     "version:check": "changeset status",
     "verify:release-install": "node scripts/verify-release-install.mjs",
@@ -49,7 +49,10 @@
     "test_app:blank": "rimraf test_app && pnpm build && node packages/create-mcp-use-app/dist/index.js test_app --dev --template blank && cd test_app && pnpm install && pnpm dev"
   },
   "devDependencies": {
+    "@changesets/assemble-release-plan": "6.0.10",
     "@changesets/cli": "^2.31.1",
+    "@changesets/config": "3.1.4",
+    "@changesets/read": "0.6.7",
     "@types/node": "^25.6.0",
     "@types/react": "19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/libraries/typescript/pnpm-lock.yaml
+++ b/libraries/typescript/pnpm-lock.yaml
@@ -80,9 +80,18 @@ importers:
         specifier: ^9.39.4
         version: 9.39.4
     devDependencies:
+      '@changesets/assemble-release-plan':
+        specifier: 6.0.10
+        version: 6.0.10
       '@changesets/cli':
         specifier: ^2.31.1
         version: 2.31.1(@types/node@25.6.0)
+      '@changesets/config':
+        specifier: 3.1.4
+        version: 3.1.4
+      '@changesets/read':
+        specifier: 0.6.7
+        version: 0.6.7
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -12407,7 +12416,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@22.20.1)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(jsdom@27.4.0(@noble/hashes@2.2.0))(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/expect@4.1.10':
     dependencies:

--- a/libraries/typescript/scripts/RELEASING.md
+++ b/libraries/typescript/scripts/RELEASING.md
@@ -1,0 +1,31 @@
+# Automatic release propagation
+
+Write a changeset for the package you changed. The release preparation step uses
+Changesets' version planner to add the other published artifacts that must move.
+
+`release-propagation.mjs` declares bundled build inputs separately from npm
+dependencies: Inspector embeds Agent and Client, and CLI embeds Tunnel. A release
+of a build input schedules a patch of its bundle owner. This does not add runtime
+dependencies or change Inspector's standalone installation size.
+
+Preparation also reconciles internal peer ranges against planned versions. Every
+package whose peer metadata changes receives a release. Changesets then propagates
+normal package dependencies, including mcp-use's exact Inspector dependency. The
+calculation repeats until both the release set and compatibility ranges agree.
+Explicit minor/major changesets retain their priority. Compatibility with a new
+upstream major must be declared explicitly; the script cannot infer it.
+
+Generated `propagated-*.md` changesets have deterministic IDs based on the pending
+user changesets, so retries are idempotent. Applied prerelease changesets do not
+trigger another bundle rebuild. The same preparation runs when exiting Canary
+for stable release and through `pnpm version`.
+
+Before publication, `release-channel snapshot` packs the packages and checks their
+actual internal metadata against the registry. Changed metadata under an already
+published version is an error. All peer ranges must accept the exact versions in
+the release set using normal npm prerelease semantics. Registry verification
+checks the same metadata after publication, in addition to package files and tags.
+
+When adding a package that embeds workspace code, add its build inputs to
+`bundledInputs` and a regression case in `release-propagation.test.mjs`. Do not add
+runtime dependencies just to influence release selection.

--- a/libraries/typescript/scripts/release-channel.mjs
+++ b/libraries/typescript/scripts/release-channel.mjs
@@ -1,8 +1,20 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  mkdtempSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import semver from "semver";
+import {
+  prepareRelease,
+  internalMetadata,
+  metadataErrors,
+} from "./release-propagation.mjs";
 
 import {
   packedArtifactErrors,
@@ -131,107 +143,6 @@ function packageNamesForChangesets(ids) {
   return new Set(releasesForChangesets(ids).map(({ name }) => name));
 }
 
-function stableVersion(version) {
-  const parsed = semver.parse(version);
-  if (!parsed) throw new Error(`Invalid package version: ${version}`);
-  return `${parsed.major}.${parsed.minor}.${parsed.patch}`;
-}
-
-function stablePeerParts(range, tag, baseline) {
-  if (range.startsWith("workspace:")) {
-    const workspaceRange = range.slice("workspace:".length);
-    if (workspaceRange === "~") return [`~${stableVersion(baseline)}`];
-    if (workspaceRange !== "*" && workspaceRange !== "^") {
-      return [workspaceRange];
-    }
-    return [`^${stableVersion(baseline)}`];
-  }
-
-  const retained = range
-    .split("||")
-    .map((part) => part.trim())
-    .filter(Boolean)
-    .filter((part) => !part.includes(`-${tag}.`));
-  return retained.length ? retained : [`^${stableVersion(baseline)}`];
-}
-
-function prepareCanaryPeerRanges(channel) {
-  const pre = prereleaseState();
-  if (channel !== "canary") {
-    throw new Error("Peer-range preparation is only supported for canary");
-  }
-  if (pre?.mode !== "pre" || pre.tag !== "canary") {
-    throw new Error(
-      "Canary peer-range preparation requires .changeset/pre.json in canary prerelease mode"
-    );
-  }
-
-  const directTypes = highestReleaseTypes(
-    releasesForChangesets(pendingChangesets())
-  );
-  const entries = manifestEntries();
-  const packages = new Map(
-    entries.map((entry) => [entry.manifest.name, entry])
-  );
-  const changed = new Set();
-
-  for (const [dependency, type] of directTypes) {
-    if (type === "major") continue;
-    const dependencyEntry = packages.get(dependency);
-    if (!dependencyEntry) continue;
-
-    const nextBase = semver.inc(dependencyEntry.manifest.version, type);
-    if (!nextBase) {
-      throw new Error(
-        `Cannot calculate the next ${type} version for ${dependency}@${dependencyEntry.manifest.version}`
-      );
-    }
-    const nextCanary = `${nextBase}-${pre.tag}.0`;
-    const baseline =
-      pre.initialVersions?.[dependency] ?? dependencyEntry.manifest.version;
-
-    for (const entry of entries) {
-      const currentRange = entry.manifest.peerDependencies?.[dependency];
-      if (!currentRange) continue;
-      if (
-        !currentRange.startsWith("workspace:") &&
-        semver.satisfies(dependencyEntry.manifest.version, currentRange) &&
-        semver.satisfies(nextCanary, currentRange)
-      ) {
-        continue;
-      }
-
-      const prereleaseRange = `^${nextBase}-${pre.tag}.0`;
-      const currentBase = stableVersion(dependencyEntry.manifest.version);
-      const currentPrereleaseRange = semver.prerelease(
-        dependencyEntry.manifest.version
-      )
-        ? `^${currentBase}-${pre.tag}.0`
-        : undefined;
-      const desiredRange = [
-        ...stablePeerParts(currentRange, pre.tag, baseline),
-        currentPrereleaseRange,
-        prereleaseRange,
-      ]
-        .filter(Boolean)
-        .filter((part, index, parts) => parts.indexOf(part) === index)
-        .join(" || ");
-      if (desiredRange === currentRange) continue;
-
-      entry.manifest.peerDependencies[dependency] = desiredRange;
-      changed.add(entry);
-      console.log(
-        `${entry.manifest.name} peer ${dependency}: ${currentRange} -> ${desiredRange}`
-      );
-    }
-  }
-
-  for (const entry of changed) writeJson(entry.file, entry.manifest);
-  console.log(
-    `Prepared ${changed.size} package(s) for the Canary release plan`
-  );
-}
-
 function validateReleasePlan(channel, planFile) {
   const plan = readJson(planFile);
   if (channel !== "canary") {
@@ -343,16 +254,84 @@ function sameJson(left, right) {
   );
 }
 
+function sameMetadata(left, right) {
+  return ["dependencies", "optionalDependencies", "peerDependencies"].every(
+    (field) => sameJson(left[field], right[field])
+  );
+}
+
+function packManifest(entry) {
+  const scratch = mkdtempSync(join(tmpdir(), "release-manifest-"));
+  try {
+    const result = spawnSync(
+      "pnpm",
+      ["pack", "--pack-destination", scratch, "--json"],
+      {
+        cwd: join(entry.file, ".."),
+        encoding: "utf8",
+        env: { ...process.env, npm_config_ignore_scripts: "true" },
+      }
+    );
+    if (result.status !== 0) throw new Error(result.stderr || result.stdout);
+    const tarballs = readdirSync(scratch).filter((file) =>
+      file.endsWith(".tgz")
+    );
+    if (tarballs.length !== 1)
+      throw new Error(
+        `Expected one packed artifact for ${entry.manifest.name}`
+      );
+    const manifest = spawnSync(
+      "tar",
+      ["-xOf", join(scratch, tarballs[0]), "package/package.json"],
+      { encoding: "utf8" }
+    );
+    if (manifest.status !== 0) throw new Error(manifest.stderr);
+    return JSON.parse(manifest.stdout);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
 async function snapshot(channel, output) {
   const tag = channel === "stable" ? "latest" : "canary";
   const releases = [];
+  const entries = manifestEntries();
+  const versionsInPlan = new Map(
+    entries.map(({ manifest }) => [manifest.name, manifest.version])
+  );
+  const effective = [];
 
-  for (const manifest of manifests()) {
+  for (const entry of entries) {
+    const manifest = option("--registry-file")
+      ? entry.manifest
+      : packManifest(entry);
     const metadata = await registryMetadata(manifest.name);
     const versions = metadata.versions ?? {};
     const distTags = metadata["dist-tags"] ?? {};
     const published = Object.hasOwn(versions, manifest.version);
     const latest = distTags.latest;
+    const expectedMetadata = internalMetadata(manifest, versionsInPlan);
+    const publishedManifest = versions[manifest.version];
+    if (
+      published &&
+      !sameMetadata(
+        expectedMetadata,
+        internalMetadata(publishedManifest, versionsInPlan)
+      )
+    ) {
+      throw new Error(
+        `${manifest.name}@${manifest.version} has changed published metadata but no new version; release this package`
+      );
+    }
+    effective.push(
+      published
+        ? {
+            ...publishedManifest,
+            name: manifest.name,
+            version: manifest.version,
+          }
+        : manifest
+    );
 
     if (!published) {
       if (channel === "stable" && semver.prerelease(manifest.version)) {
@@ -390,8 +369,12 @@ async function snapshot(channel, output) {
       target: !published,
       channelTag: tag,
       distTagsBefore: distTags,
+      expectedMetadata,
     });
   }
+
+  const errors = metadataErrors(effective);
+  if (errors.length) throw new Error(errors.join("\n"));
 
   const plan = { channel, releases };
   writeFileSync(output, `${JSON.stringify(plan, null, 2)}\n`);
@@ -402,10 +385,33 @@ async function snapshot(channel, output) {
 
 async function verifyOnce(plan) {
   const errors = [];
+  const versionsInPlan = new Map(
+    plan.releases.map((release) => [release.name, release.version])
+  );
+  const effective = [];
   for (const release of plan.releases) {
     const metadata = await registryMetadata(release.name);
     const versions = metadata.versions ?? {};
     const afterTags = metadata["dist-tags"] ?? {};
+    const published = versions[release.version];
+    if (published) {
+      effective.push({
+        ...published,
+        name: release.name,
+        version: release.version,
+      });
+      if (
+        release.expectedMetadata &&
+        !sameMetadata(
+          release.expectedMetadata,
+          internalMetadata(published, versionsInPlan)
+        )
+      ) {
+        errors.push(
+          `${release.name}@${release.version} published metadata differs from the verified release plan`
+        );
+      }
+    }
 
     if (release.target) {
       if (!Object.hasOwn(versions, release.version)) {
@@ -435,6 +441,7 @@ async function verifyOnce(plan) {
       );
     }
   }
+  errors.push(...metadataErrors(effective));
   if (errors.length) throw new Error(errors.join("\n"));
 }
 
@@ -479,7 +486,7 @@ try {
   if (command === "pending") {
     console.log(pendingChangesets().join("\n"));
   } else if (command === "prepare") {
-    prepareCanaryPeerRanges(option("--channel"));
+    await prepareRelease(workspaceRoot, option("--channel"));
   } else if (command === "validate") {
     validateReleasePlan(
       option("--channel"),

--- a/libraries/typescript/scripts/release-channel.test.mjs
+++ b/libraries/typescript/scripts/release-channel.test.mjs
@@ -18,6 +18,22 @@ function fixture({ localVersion, latest, canary, published = [] }) {
   mkdirSync(join(root, "packages", "server"), { recursive: true });
   mkdirSync(join(root, ".changeset"));
   writeFileSync(
+    join(root, ".changeset", "config.json"),
+    JSON.stringify({
+      changelog: false,
+      commit: false,
+      fixed: [],
+      linked: [],
+      access: "public",
+      baseBranch: "main",
+      updateInternalDependencies: "patch",
+      ignore: [],
+      ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+        onlyUpdatePeerDependentsWhenOutOfRange: true,
+      },
+    })
+  );
+  writeFileSync(
     join(root, "packages", "server", "package.json"),
     JSON.stringify({ name: "mcp-use", version: localVersion })
   );

--- a/libraries/typescript/scripts/release-propagation.mjs
+++ b/libraries/typescript/scripts/release-propagation.mjs
@@ -11,7 +11,7 @@ const readChangesets = readModule.default ?? readModule;
 const generatedPrefix = "propagated-";
 
 // Build inputs, not npm dependencies. These packages ship embedded workspace code.
-export const bundledInputs = {
+const bundledInputs = {
   "@mcp-use/inspector": ["@mcp-use/agent", "@mcp-use/client"],
   "@mcp-use/cli": ["@mcp-use/tunnel"],
 };

--- a/libraries/typescript/scripts/release-propagation.mjs
+++ b/libraries/typescript/scripts/release-propagation.mjs
@@ -1,0 +1,252 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import assembleModule from "@changesets/assemble-release-plan";
+import * as configModule from "@changesets/config";
+import readModule from "@changesets/read";
+import semver from "semver";
+
+const assemble = assembleModule.default ?? assembleModule;
+const readChangesets = readModule.default ?? readModule;
+const generatedPrefix = "propagated-";
+
+// Build inputs, not npm dependencies. These packages ship embedded workspace code.
+export const bundledInputs = {
+  "@mcp-use/inspector": ["@mcp-use/agent", "@mcp-use/client"],
+  "@mcp-use/cli": ["@mcp-use/tunnel"],
+};
+
+export function packageEntries(root) {
+  return readdirSync(join(root, "packages"), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(root, "packages", entry.name, "package.json"))
+    .filter(existsSync)
+    .map((file) => ({
+      dir: dirname(file),
+      packageJson: JSON.parse(readFileSync(file, "utf8")),
+    }))
+    .filter(({ packageJson }) => !packageJson.private);
+}
+
+function json(file, value) {
+  writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function internalMetadata(manifest, versions) {
+  return Object.fromEntries(
+    ["dependencies", "optionalDependencies", "peerDependencies"].map(
+      (field) => [
+        field,
+        Object.fromEntries(
+          Object.entries(manifest[field] ?? {})
+            .filter(([name]) => versions.has(name))
+            .map(([name, range]) => {
+              if (range.startsWith("workspace:")) {
+                range = range.slice(10);
+                if (range === "*") range = versions.get(name);
+                else if (range === "^" || range === "~")
+                  range += versions.get(name);
+              }
+              return [name, range];
+            })
+        ),
+      ]
+    )
+  );
+}
+
+export function metadataErrors(manifests) {
+  const versions = new Map(
+    manifests.map((manifest) => [manifest.name, manifest.version])
+  );
+  const errors = [];
+  for (const manifest of manifests) {
+    for (const [field, entries] of Object.entries(
+      internalMetadata(manifest, versions)
+    )) {
+      for (const [name, range] of Object.entries(entries)) {
+        if (!semver.satisfies(versions.get(name), range)) {
+          errors.push(
+            `${manifest.name}@${manifest.version} ${field}.${name} (${range}) rejects ${versions.get(name)}`
+          );
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+export async function prepareRelease(root, channel) {
+  const preFile = join(root, ".changeset/pre.json");
+  const pre = existsSync(preFile)
+    ? JSON.parse(readFileSync(preFile, "utf8"))
+    : undefined;
+  if (channel === "canary" && (pre?.mode !== "pre" || pre.tag !== "canary")) {
+    throw new Error("Canary preparation requires canary prerelease mode");
+  }
+  const entries = packageEntries(root);
+  const names = new Set(entries.map(({ packageJson }) => packageJson.name));
+  const packages = {
+    root: {
+      dir: root,
+      packageJson: { name: "release-workspace", private: true },
+    },
+    packages: entries,
+  };
+  const config = await configModule.read(root, packages);
+  const changesets = await readChangesets(root);
+  const applied = new Set(pre?.mode === "pre" ? pre.changesets : []);
+  const pending = changesets.filter(({ id }) => !applied.has(id));
+  const seeds = pending.filter(({ id }) => !id.startsWith(generatedPrefix));
+  if (!seeds.length && pre?.mode !== "exit") return;
+  const id =
+    generatedPrefix +
+    createHash("sha256")
+      .update(
+        seeds
+          .map(({ id }) => id)
+          .sort()
+          .join("\n")
+      )
+      .digest("hex")
+      .slice(0, 16);
+  const generated = changesets.find((change) => change.id === id) ?? {
+    id,
+    releases: [],
+    summary:
+      "Rebuild bundled workspace code and synchronize published internal package metadata.",
+  };
+  if (!changesets.includes(generated)) changesets.push(generated);
+  const explicit = new Set(
+    seeds.flatMap(({ releases }) => releases.map(({ name }) => name))
+  );
+  const add = (name) => {
+    if (
+      explicit.has(name) ||
+      generated.releases.some((release) => release.name === name)
+    )
+      return false;
+    generated.releases.push({ name, type: "patch" });
+    return true;
+  };
+  const before = new Map(
+    entries.map(({ dir, packageJson }) => [dir, JSON.stringify(packageJson)])
+  );
+
+  // Peers are compatibility declarations, not build edges. Calculate versions
+  // with Changesets first, then reconcile peers and include every changed owner.
+  // Removing internal peers only from this in-memory provisional graph avoids
+  // Changesets interpreting stale canary metadata as an unintended major bump.
+  for (let iteration = 0; iteration < entries.length * 4 + 4; iteration++) {
+    const provisional = {
+      ...packages,
+      packages: entries.map((entry) => ({
+        ...entry,
+        packageJson: {
+          ...entry.packageJson,
+          peerDependencies: Object.fromEntries(
+            Object.entries(entry.packageJson.peerDependencies ?? {}).filter(
+              ([name]) => !names.has(name)
+            )
+          ),
+        },
+      })),
+    };
+    const plan = assemble(changesets, provisional, config, pre);
+    const releases = new Map(
+      plan.releases
+        .filter(({ type }) => type !== "none")
+        .map((release) => [release.name, release])
+    );
+    const versions = new Map(
+      entries.map(({ packageJson: pkg }) => [
+        pkg.name,
+        releases.get(pkg.name)?.newVersion ?? pkg.version,
+      ])
+    );
+    let changed = false;
+    for (const [owner, inputs] of Object.entries(bundledInputs)) {
+      if (names.has(owner) && inputs.some((input) => releases.has(input)))
+        changed = add(owner) || changed;
+    }
+    for (const { packageJson: pkg } of entries) {
+      for (const [name, currentRange] of Object.entries(
+        pkg.peerDependencies ?? {}
+      )) {
+        if (!names.has(name)) continue;
+        const version = versions.get(name);
+        const range = internalMetadata(pkg, versions).peerDependencies[name];
+        if (
+          semver.satisfies(version, range) &&
+          !currentRange.startsWith("workspace:")
+        )
+          continue;
+        const base = pre?.initialVersions?.[name] ?? version;
+        const stable = (value) =>
+          `${semver.major(value)}.${semver.minor(value)}.${semver.patch(value)}`;
+        const old = currentRange.startsWith("workspace:")
+          ? `^${stable(base)}`
+          : currentRange;
+        if (
+          semver.major(version) !== semver.major(base) &&
+          !semver.satisfies(version, range)
+        ) {
+          throw new Error(
+            `${pkg.name}: explicitly declare compatibility with ${name}@${version} before releasing a new major`
+          );
+        }
+        const supported = semver.prerelease(version)
+          ? `^${stable(version)}-${pre.tag}.0`
+          : `^${version}`;
+        const current = entries.find(
+          ({ packageJson }) => packageJson.name === name
+        ).packageJson.version;
+        const currentCanary =
+          semver.prerelease(current) && pre?.mode === "pre"
+            ? `^${stable(current)}-${pre.tag}.0`
+            : undefined;
+        pkg.peerDependencies[name] = [
+          ...new Set(
+            [...old.split(" || "), currentCanary, supported].filter(Boolean)
+          ),
+        ].join(" || ");
+        changed = add(pkg.name) || changed;
+      }
+    }
+    if (changed) continue;
+    const finalPlan = assemble(changesets, packages, config, pre);
+    for (const release of finalPlan.releases.filter(
+      ({ type }) => type !== "none"
+    )) {
+      if (release.newVersion !== versions.get(release.name))
+        throw new Error(`Unresolved release propagation for ${release.name}`);
+    }
+    const errors = metadataErrors(
+      entries.map(({ packageJson }) => ({
+        ...packageJson,
+        version: versions.get(packageJson.name),
+      }))
+    );
+    // Changesets updates normal internal dependency ranges during versioning.
+    const peerErrors = errors.filter((error) =>
+      error.includes(" peerDependencies.")
+    );
+    if (peerErrors.length) throw new Error(peerErrors.join("\n"));
+    for (const { dir, packageJson } of entries) {
+      if (JSON.stringify(packageJson) !== before.get(dir))
+        json(join(dir, "package.json"), packageJson);
+    }
+    if (generated.releases.length) {
+      generated.releases.sort((a, b) => a.name.localeCompare(b.name));
+      writeFileSync(
+        join(root, ".changeset", `${id}.md`),
+        `---\n${generated.releases.map(({ name, type }) => `"${name}": ${type}`).join("\n")}\n---\n\n${generated.summary}\n`
+      );
+    }
+    console.log(
+      `Prepared release propagation: ${[...releases.keys()].join(", ")}`
+    );
+    return finalPlan;
+  }
+  throw new Error("Release propagation did not converge");
+}

--- a/libraries/typescript/scripts/release-propagation.test.mjs
+++ b/libraries/typescript/scripts/release-propagation.test.mjs
@@ -1,0 +1,311 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import test from "node:test";
+import {
+  prepareRelease,
+  packageEntries,
+  metadataErrors,
+} from "./release-propagation.mjs";
+
+const require = createRequire(import.meta.url);
+const cli = join(
+  require.resolve("@changesets/cli/package.json"),
+  "..",
+  "bin.js"
+);
+const releaseScript = new URL("./release-channel.mjs", import.meta.url)
+  .pathname;
+const versionScript = new URL("./version-packages.mjs", import.meta.url)
+  .pathname;
+const config = JSON.parse(
+  readFileSync(new URL("../.changeset/config.json", import.meta.url), "utf8")
+);
+
+function json(file, value) {
+  writeFileSync(file, JSON.stringify(value, null, 2) + "\n");
+}
+function fixture(t, seed = "@mcp-use/agent", stale = true) {
+  const root = mkdtempSync(join(tmpdir(), "propagation-test-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  mkdirSync(join(root, ".changeset"));
+  json(join(root, "package.json"), {
+    name: "fixture",
+    private: true,
+    workspaces: ["packages/*"],
+  });
+  json(join(root, ".changeset/config.json"), { ...config, changelog: false });
+  const manifests = [
+    [
+      "server",
+      {
+        name: "mcp-use",
+        version: "2.5.0-canary.7",
+        dependencies: {
+          "@mcp-use/inspector": "workspace:*",
+          "@mcp-use/cli": "workspace:*",
+        },
+      },
+    ],
+    [
+      "inspector",
+      {
+        name: "@mcp-use/inspector",
+        version: "20.3.8-canary.0",
+        dependencies: {},
+        peerDependencies: {
+          "mcp-use": stale ? "^2.4.4-canary.0" : "^2.5.0-canary.0",
+          "@mcp-use/agent": "^2.0.16-canary.0",
+          "@mcp-use/client": "^2.3.1-canary.0",
+        },
+        peerDependenciesMeta: {
+          "mcp-use": { optional: true },
+          "@mcp-use/agent": { optional: true },
+          "@mcp-use/client": { optional: true },
+        },
+        devDependencies: {
+          "@mcp-use/agent": "workspace:*",
+          "@mcp-use/client": "workspace:*",
+        },
+      },
+    ],
+    ["agent", { name: "@mcp-use/agent", version: "2.0.16-canary.4" }],
+    ["client", { name: "@mcp-use/client", version: "2.3.1-canary.0" }],
+    [
+      "cli",
+      {
+        name: "@mcp-use/cli",
+        version: "4.1.12-canary.3",
+        devDependencies: { "@mcp-use/tunnel": "workspace:*" },
+      },
+    ],
+    ["tunnel", { name: "@mcp-use/tunnel", version: "1.0.1-canary.0" }],
+  ];
+  for (const [dir, manifest] of manifests) {
+    mkdirSync(join(root, "packages", dir), { recursive: true });
+    json(join(root, "packages", dir, "package.json"), manifest);
+  }
+  json(join(root, ".changeset/pre.json"), {
+    mode: "pre",
+    tag: "canary",
+    changesets: [],
+    initialVersions: {
+      "mcp-use": "2.4.3",
+      "@mcp-use/inspector": "20.3.7",
+      "@mcp-use/agent": "2.0.15",
+      "@mcp-use/client": "2.3.0",
+      "@mcp-use/cli": "4.1.11",
+      "@mcp-use/tunnel": "1.0.0",
+    },
+  });
+  writeFileSync(
+    join(root, ".changeset/user-change.md"),
+    `---\n"${seed}": patch\n---\n\nThe user's change.\n`
+  );
+  return root;
+}
+function version(root) {
+  const result = spawnSync(process.execPath, [cli, "version"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr + result.stdout);
+  const manifests = packageEntries(root).map(({ packageJson }) => packageJson);
+  assert.deepEqual(metadataErrors(manifests), []);
+  return new Map(manifests.map((pkg) => [pkg.name, pkg]));
+}
+function state(root) {
+  return JSON.stringify([
+    packageEntries(root),
+    readdirSync(join(root, ".changeset"))
+      .sort()
+      .map((name) => [
+        name,
+        readFileSync(join(root, ".changeset", name), "utf8"),
+      ]),
+  ]);
+}
+
+for (const seed of ["@mcp-use/agent", "@mcp-use/client"]) {
+  test(`${seed}-only changeset rebuilds Inspector and releases mcp-use without runtime dependencies`, async (t) => {
+    const root = fixture(t, seed);
+    await prepareRelease(root, "canary");
+    const first = state(root);
+    await prepareRelease(root, "canary");
+    assert.equal(state(root), first, "preparation is idempotent");
+    const packages = version(root);
+    assert.notEqual(
+      packages.get("@mcp-use/inspector").version,
+      "20.3.8-canary.0"
+    );
+    assert.notEqual(packages.get("mcp-use").version, "2.5.0-canary.7");
+    assert.deepEqual(packages.get("@mcp-use/inspector").dependencies, {});
+    assert.equal(
+      packages.get("@mcp-use/inspector").peerDependenciesMeta["mcp-use"]
+        .optional,
+      true
+    );
+    const applied = state(root);
+    await prepareRelease(root, "canary");
+    assert.equal(
+      state(root),
+      applied,
+      "applied changesets do not retrigger releases"
+    );
+  });
+}
+
+test("a metadata-only repair releases Inspector even when no bundle input changed", async (t) => {
+  const root = fixture(t, "mcp-use");
+  await prepareRelease(root, "canary");
+  const packages = version(root);
+  assert.notEqual(
+    packages.get("@mcp-use/inspector").version,
+    "20.3.8-canary.0"
+  );
+  assert.equal(packages.get("@mcp-use/agent").version, "2.0.16-canary.4");
+});
+
+test("Tunnel rebuilds CLI and propagates its exact mcp-use dependency without an unrelated Inspector rebuild", async (t) => {
+  const root = fixture(t, "@mcp-use/tunnel", false);
+  await prepareRelease(root, "canary");
+  const packages = version(root);
+  assert.notEqual(packages.get("@mcp-use/cli").version, "4.1.12-canary.3");
+  assert.notEqual(packages.get("mcp-use").version, "2.5.0-canary.7");
+  assert.equal(packages.get("@mcp-use/inspector").version, "20.3.8-canary.0");
+});
+
+test("a canary minor crossing and explicit owner minor keep their requested versions", async (t) => {
+  const root = fixture(t, "mcp-use", false);
+  writeFileSync(
+    join(root, ".changeset/user-change.md"),
+    '---\n"mcp-use": minor\n"@mcp-use/inspector": minor\n---\n\nMinor changes.\n'
+  );
+  await prepareRelease(root, "canary");
+  const packages = version(root);
+  assert.match(
+    packages.get("@mcp-use/inspector").version,
+    /^20\.4\.0-canary\./
+  );
+  assert.match(packages.get("mcp-use").version, /^2\.5\.0-canary\./);
+});
+
+test("stable releases propagate bundle changes with independent version lines", async (t) => {
+  const root = fixture(t, "@mcp-use/agent", false);
+  rmSync(join(root, ".changeset/pre.json"));
+  for (const { dir, packageJson } of packageEntries(root)) {
+    packageJson.version = packageJson.version.split("-")[0];
+    for (const [name, range] of Object.entries(
+      packageJson.peerDependencies ?? {}
+    ))
+      packageJson.peerDependencies[name] = range.split("-")[0];
+    json(join(dir, "package.json"), packageJson);
+  }
+  await prepareRelease(root, "stable");
+  const packages = version(root);
+  assert.equal(packages.get("@mcp-use/agent").version, "2.0.17");
+  assert.equal(packages.get("@mcp-use/inspector").version, "20.3.9");
+  assert.equal(packages.get("mcp-use").version, "2.5.1");
+});
+
+test("snapshot rejects changed metadata hidden under an already-published version", (t) => {
+  const root = fixture(t);
+  const registry = Object.fromEntries(
+    packageEntries(root).map(({ packageJson: pkg }) => [
+      pkg.name,
+      {
+        "dist-tags": { canary: pkg.version },
+        versions: { [pkg.version]: pkg },
+      },
+    ])
+  );
+  const file = join(root, "packages/inspector/package.json");
+  const inspector = JSON.parse(readFileSync(file, "utf8"));
+  inspector.peerDependencies["mcp-use"] += " || ^2.5.0-canary.0";
+  json(file, inspector);
+  const registryFile = join(root, "registry.json");
+  json(registryFile, registry);
+  const result = spawnSync(
+    process.execPath,
+    [
+      releaseScript,
+      "snapshot",
+      "--channel",
+      "canary",
+      "--registry-file",
+      registryFile,
+    ],
+    { cwd: root, encoding: "utf8" }
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /changed published metadata but no new version/);
+});
+
+test("normal npm prerelease semantics reject the reported peer mismatch", () => {
+  assert.match(
+    metadataErrors([
+      { name: "mcp-use", version: "2.5.0-canary.7" },
+      {
+        name: "@mcp-use/inspector",
+        version: "20.3.8-canary.0",
+        peerDependencies: { "mcp-use": "^2.4.4-canary.0" },
+      },
+    ])[0],
+    /rejects 2\.5\.0-canary\.7/
+  );
+});
+
+test("Canary exit runs the production version wrapper and keeps stable peers compatible", async (t) => {
+  const root = fixture(t, "@mcp-use/agent");
+  await prepareRelease(root, "canary");
+  version(root);
+  const exit = spawnSync(process.execPath, [cli, "pre", "exit"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  assert.equal(exit.status, 0, exit.stderr);
+  mkdirSync(join(root, "node_modules/.bin"), { recursive: true });
+  symlinkSync(cli, join(root, "node_modules/.bin/changeset"));
+  const result = spawnSync(process.execPath, [versionScript], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr + result.stdout);
+  const manifests = packageEntries(root).map(({ packageJson }) => packageJson);
+  assert.deepEqual(metadataErrors(manifests), []);
+  assert.ok(manifests.every(({ version }) => !version.includes("canary")));
+  assert.deepEqual(
+    manifests.find(({ name }) => name === "@mcp-use/inspector").dependencies,
+    {}
+  );
+});
+
+test("moving mcp-use from the 2.4.4 Canary line to 2.5.0 republishes Inspector", async (t) => {
+  const root = fixture(t, "mcp-use");
+  const file = join(root, "packages/server/package.json");
+  const manifest = JSON.parse(readFileSync(file, "utf8"));
+  manifest.version = "2.4.4-canary.5";
+  json(file, manifest);
+  writeFileSync(
+    join(root, ".changeset/user-change.md"),
+    '---\n"mcp-use": minor\n---\n\nNew API.\n'
+  );
+  await prepareRelease(root, "canary");
+  const packages = version(root);
+  assert.match(packages.get("mcp-use").version, /^2\.5\.0-canary\./);
+  assert.notEqual(
+    packages.get("@mcp-use/inspector").version,
+    "20.3.8-canary.0"
+  );
+});

--- a/libraries/typescript/scripts/version-packages.mjs
+++ b/libraries/typescript/scripts/version-packages.mjs
@@ -3,6 +3,7 @@ import { readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import semver from "semver";
+import { prepareRelease } from "./release-propagation.mjs";
 
 const workspaceRoot = process.cwd();
 const changesetDirectory = join(workspaceRoot, ".changeset");
@@ -104,4 +105,8 @@ if (preState?.mode === "exit") {
   normalizeInternalPeerRanges();
 }
 
+await prepareRelease(
+  workspaceRoot,
+  preState?.mode === "pre" ? preState.tag : "stable"
+);
 runChangeset(["version"]);


### PR DESCRIPTION
Agent changes were published without rebuilding Inspector, and release preparation could update Inspector's framework peer range without assigning it a new version. Consequently `mcp-use@2.5.0-canary.7` selected an Inspector artifact whose peer range rejected that same framework version.

This adds automatic release propagation using Changesets' actual version planner. Inspector's Agent/Client build inputs and CLI's Tunnel build input are recorded separately from npm dependencies. A changeset for an input schedules its bundle owner; peer metadata changes schedule their owner; normal exact package dependencies propagate through Changesets. Inspector retains zero runtime dependencies and independent versions.

Before publishing, inspect packed manifests and reject metadata changes hidden under an existing version or incompatible internal peers. Check the same metadata after publishing. Include a repair changeset for Inspector so it ships the existing OpenRouter Responses API fix, and fix hidden-file upload of the Railway deployment marker.

Validation: 24 release-helper/regression tests pass, including actual Changesets versioning, Agent-only and Client-only changes, Tunnel-to-CLI propagation, the 2.4.4-to-2.5.0 Canary transition, repeated preparation, consumed changesets, stable release and prerelease exit. Versioned the current Canary tree in a separate checkout, completed the full build, passed packed-manifest validation against npm, and passed the existing clean-consumer release-install test. The release selects Inspector 20.3.8-canary.1 and mcp-use 2.5.0-canary.8. Inspector's browser bundle is 860 KB gzipped and its runtime dependencies remain empty. Knip now includes the release scripts so their build-only Changesets imports are checked.
