### PR TITLE
fix(release): allow npm publish-time scanning to finish

### DIFF
--- a/.github/workflows/typescript-release.yml
+++ b/.github/workflows/typescript-release.yml
@@ -153,7 +153,9 @@ jobs:
         if: github.ref == 'refs/heads/canary' && steps.has-changesets.outputs.has_changesets == 'true'
         working-directory: libraries/typescript
         env:
-          VERIFY_ATTEMPTS: 12
+          # npm scans accepted publishes before making them installable. Allow
+          # twenty minutes, including the documented 5-15+ minute scan window.
+          VERIFY_ATTEMPTS: 120
           VERIFY_DELAY_SECONDS: 10
         run: pnpm release-channel verify --plan canary-release-plan.json
 
@@ -436,7 +438,7 @@ jobs:
           steps.check-release.outputs.should_publish == 'true'
         working-directory: libraries/typescript
         env:
-          VERIFY_ATTEMPTS: 12
+          VERIFY_ATTEMPTS: 120
           VERIFY_DELAY_SECONDS: 10
         run: pnpm release-channel verify --plan stable-release-plan.json
 

--- a/libraries/typescript/scripts/RELEASING.md
+++ b/libraries/typescript/scripts/RELEASING.md
@@ -26,6 +26,12 @@ published version is an error. All peer ranges must accept the exact versions in
 the release set using normal npm prerelease semantics. Registry verification
 checks the same metadata after publication, in addition to package files and tags.
 
+npm scans packages before making accepted publishes installable. Verification
+allows twenty minutes for availability (120 attempts, ten seconds apart), while
+still failing on a missing artifact or incompatible metadata. A successful publish
+command alone is not proof that consumers can install the release. See
+[npm's publish-time scanning announcement](https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/).
+
 When adding a package that embeds workspace code, add its build inputs to
 `bundledInputs` and a regression case in `release-propagation.test.mjs`. Do not add
 runtime dependencies just to influence release selection.

--- a/libraries/typescript/scripts/release-channel.mjs
+++ b/libraries/typescript/scripts/release-channel.mjs
@@ -447,7 +447,9 @@ async function verifyOnce(plan) {
 
 async function verify(planFile) {
   const plan = readJson(planFile);
-  const attempts = Number(process.env.VERIFY_ATTEMPTS ?? 12);
+  // An accepted npm publish can remain unavailable during publish-time scanning.
+  // https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/
+  const attempts = Number(process.env.VERIFY_ATTEMPTS ?? 120);
   const delaySeconds = Number(process.env.VERIFY_DELAY_SECONDS ?? 10);
   let lastError;
 


### PR DESCRIPTION
The release after #2504 successfully submitted Inspector and mcp-use to npm, but the existing verification window expired after approximately two minutes while mcp-use was still unavailable. npm now documents publish-time scanning that typically takes five minutes and can take fifteen minutes or more.

Allow 120 verification attempts, ten seconds apart, for both Canary and stable releases. Preserve all package, metadata and dist-tag checks; accepted publication must still become installable before deployment continues. This changes release automation only and does not publish new package versions.

Validation: all 24 release-helper and real-versioning regression tests pass. npm documentation: https://github.blog/changelog/2026-07-28-npm-publish-time-malware-scanning-and-dual-use-metadata/

Recovery validation: both submitted versions subsequently became available. Registry verification passes for `mcp-use@2.5.0-canary.8` and `@mcp-use/inspector@20.3.8-canary.1`; a clean npm install resolves a single framework version with no invalid Inspector peer. Standalone Inspector installs one package, retains `dependencies: {}`, and its `mountInspector` export imports successfully. The dev deployment completed via https://github.com/mcp-use/mcp-use/actions/runs/34486964289; both dev hostnames now serve JavaScript byte-identical to the published Inspector bundle, including the Agent routing fix. Release tags and prerelease records were restored for the two verified versions. The original release run remains failed at its short verification timeout; this PR prevents that premature timeout on subsequent releases.
