### PR TITLE
fix(client): replace SSE response tee with pass-through TransformStream to prevent socket leaks

### DIFF
--- a/libraries/typescript/.changeset/http-sse-transform-progress-lifecycle.md
+++ b/libraries/typescript/.changeset/http-sse-transform-progress-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Fix HTTP connection and socket leak on aborted requests in `HttpConnector.observeSseProgress` by replacing stream teeing with an in-line pass-through `TransformStream`.

--- a/libraries/typescript/packages/client/src/transport/http.ts
+++ b/libraries/typescript/packages/client/src/transport/http.ts
@@ -584,8 +584,9 @@ export class HttpConnector extends BaseConnector {
   }
 
   /**
-   * Tee an SSE response so v2 MRTR progress can be correlated even when the
-   * upstream SDK does not carry the original callback to retry request IDs.
+   * Observe an SSE response via an in-line pass-through TransformStream so v2 MRTR
+   * progress can be correlated without duplicating stream buffers or leaking sockets
+   * on aborted requests.
    */
   private observeSseProgress(response: Response): Response {
     if (
@@ -594,44 +595,33 @@ export class HttpConnector extends BaseConnector {
     ) {
       return response;
     }
-    const [body, observed] = response.body.tee();
-    void (async () => {
-      const reader = observed.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const events = buffer.split(/\r?\n\r?\n/);
-          buffer = events.pop() ?? "";
-          for (const event of events) {
-            for (const line of event.split(/\r?\n/)) {
-              if (!line.startsWith("data:")) continue;
-              try {
-                const message = JSON.parse(line.slice(5).trim()) as {
-                  method?: string;
-                  params?: unknown;
-                };
-                if (message.method === "notifications/progress") {
-                  this.forwardRoundProgress(message.params);
-                }
-              } catch {
-                // Ignore malformed/non-JSON SSE data; the SDK remains authoritative.
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const observer = new TransformStream<Uint8Array, Uint8Array>({
+      transform: (chunk, controller) => {
+        buffer += decoder.decode(chunk, { stream: true });
+        const events = buffer.split(/\r?\n\r?\n/);
+        buffer = events.pop() ?? "";
+        for (const event of events) {
+          for (const line of event.split(/\r?\n/)) {
+            if (!line.startsWith("data:")) continue;
+            try {
+              const message = JSON.parse(line.slice(5).trim()) as {
+                method?: string;
+                params?: unknown;
+              };
+              if (message.method === "notifications/progress") {
+                this.forwardRoundProgress(message.params);
               }
+            } catch {
+              // Ignore malformed/non-JSON SSE data; the SDK remains authoritative.
             }
           }
         }
-      } catch (error) {
-        if (!(error instanceof DOMException && error.name === "AbortError")) {
-          logger.debug("Progress observer stream ended:", error);
-        }
-      } finally {
-        reader.releaseLock();
-      }
-    })();
-    return new Response(body, {
+        controller.enqueue(chunk);
+      },
+    });
+    return new Response(response.body.pipeThrough(observer), {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,

--- a/libraries/typescript/packages/client/tests/unit/transport/http-sse-progress-lifecycle.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/transport/http-sse-progress-lifecycle.test.ts
@@ -7,18 +7,16 @@ describe("HttpConnector observeSseProgress TransformStream lifecycle", () => {
     const progressSpy = vi.spyOn(connector as any, "forwardRoundProgress");
 
     const encoder = new TextEncoder();
+    const chunk1 =
+      'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":50,"total":100}}\n\n';
+    const chunk2 =
+      'data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"done"}]}}\n\n';
+    const expectedFullText = chunk1 + chunk2;
+
     const source = new ReadableStream<Uint8Array>({
       start(controller) {
-        controller.enqueue(
-          encoder.encode(
-            'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":50,"total":100}}\n\n'
-          )
-        );
-        controller.enqueue(
-          encoder.encode(
-            'data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"done"}]}}\n\n'
-          )
-        );
+        controller.enqueue(encoder.encode(chunk1));
+        controller.enqueue(encoder.encode(chunk2));
         controller.close();
       },
     });
@@ -33,8 +31,7 @@ describe("HttpConnector observeSseProgress TransformStream lifecycle", () => {
 
     expect(progressSpy).toHaveBeenCalledTimes(1);
     expect(progressSpy).toHaveBeenCalledWith({ progress: 50, total: 100 });
-    expect(text).toContain("notifications/progress");
-    expect(text).toContain("done");
+    expect(text).toBe(expectedFullText);
   });
 
   it("propagates consumer cancellation upstream to the underlying stream source", async () => {
@@ -103,15 +100,15 @@ describe("HttpConnector observeSseProgress TransformStream lifecycle", () => {
     const connector = new HttpConnector("https://mcp.example.com/mcp");
     const progressSpy = vi.spyOn(connector as any, "forwardRoundProgress");
     const encoder = new TextEncoder();
+    const chunk1 = "data: invalid-json-payload\n\n";
+    const chunk2 =
+      'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":100}}\n\n';
+    const expectedFullText = chunk1 + chunk2;
 
     const source = new ReadableStream<Uint8Array>({
       start(controller) {
-        controller.enqueue(encoder.encode("data: invalid-json-payload\n\n"));
-        controller.enqueue(
-          encoder.encode(
-            'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":100}}\n\n'
-          )
-        );
+        controller.enqueue(encoder.encode(chunk1));
+        controller.enqueue(encoder.encode(chunk2));
         controller.close();
       },
     });
@@ -126,7 +123,7 @@ describe("HttpConnector observeSseProgress TransformStream lifecycle", () => {
 
     expect(progressSpy).toHaveBeenCalledTimes(1);
     expect(progressSpy).toHaveBeenCalledWith({ progress: 100 });
-    expect(text).toContain("invalid-json-payload");
+    expect(text).toBe(expectedFullText);
   });
 
   it("propagates stream read errors downstream to the consumer", async () => {

--- a/libraries/typescript/packages/client/tests/unit/transport/http-sse-progress-lifecycle.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/transport/http-sse-progress-lifecycle.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from "vitest";
+import { HttpConnector } from "../../../src/transport/http.js";
+
+describe("HttpConnector observeSseProgress TransformStream lifecycle", () => {
+  it("forwards progress notifications while delivering all SSE bytes to the consumer", async () => {
+    const connector = new HttpConnector("https://mcp.example.com/mcp");
+    const progressSpy = vi.spyOn(connector as any, "forwardRoundProgress");
+
+    const encoder = new TextEncoder();
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":50,"total":100}}\n\n'
+          )
+        );
+        controller.enqueue(
+          encoder.encode(
+            'data: {"jsonrpc":"2.0","result":{"content":[{"type":"text","text":"done"}]}}\n\n'
+          )
+        );
+        controller.close();
+      },
+    });
+
+    const response = new Response(source, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const observedResponse = (connector as any).observeSseProgress(response);
+    const text = await observedResponse.text();
+
+    expect(progressSpy).toHaveBeenCalledTimes(1);
+    expect(progressSpy).toHaveBeenCalledWith({ progress: 50, total: 100 });
+    expect(text).toContain("notifications/progress");
+    expect(text).toContain("done");
+  });
+
+  it("propagates consumer cancellation upstream to the underlying stream source", async () => {
+    const connector = new HttpConnector("https://mcp.example.com/mcp");
+    const encoder = new TextEncoder();
+    const cancelSpy = vi.fn();
+
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":1}}\n\n'
+          )
+        );
+      },
+      cancel(reason) {
+        cancelSpy(reason);
+      },
+    });
+
+    const response = new Response(source, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const observedResponse = (connector as any).observeSseProgress(response);
+    const reader = observedResponse.body!.getReader();
+
+    // Read the first chunk
+    const firstChunk = await reader.read();
+    expect(firstChunk.done).toBe(false);
+
+    // Cancel the consumer stream (as occurs on request abort or SDK teardown)
+    await reader.cancel("caller aborted request");
+
+    // Allow async pipe microtasks to settle
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+    expect(cancelSpy).toHaveBeenCalledWith("caller aborted request");
+  });
+
+  it("returns non-SSE responses directly without piping through TransformStream", async () => {
+    const connector = new HttpConnector("https://mcp.example.com/mcp");
+    const response = new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+
+    const observed = (connector as any).observeSseProgress(response);
+    expect(observed).toBe(response);
+  });
+
+  it("handles empty response bodies gracefully", async () => {
+    const connector = new HttpConnector("https://mcp.example.com/mcp");
+    const response = new Response(null, {
+      status: 204,
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const observed = (connector as any).observeSseProgress(response);
+    expect(observed).toBe(response);
+  });
+
+  it("handles malformed JSON in SSE events without disrupting stream delivery", async () => {
+    const connector = new HttpConnector("https://mcp.example.com/mcp");
+    const progressSpy = vi.spyOn(connector as any, "forwardRoundProgress");
+    const encoder = new TextEncoder();
+
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("data: invalid-json-payload\n\n"));
+        controller.enqueue(
+          encoder.encode(
+            'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"progress":100}}\n\n'
+          )
+        );
+        controller.close();
+      },
+    });
+
+    const response = new Response(source, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const observedResponse = (connector as any).observeSseProgress(response);
+    const text = await observedResponse.text();
+
+    expect(progressSpy).toHaveBeenCalledTimes(1);
+    expect(progressSpy).toHaveBeenCalledWith({ progress: 100 });
+    expect(text).toContain("invalid-json-payload");
+  });
+
+  it("propagates stream read errors downstream to the consumer", async () => {
+    const connector = new HttpConnector("https://mcp.example.com/mcp");
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error("upstream connection reset"));
+      },
+    });
+
+    const response = new Response(source, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const observedResponse = (connector as any).observeSseProgress(response);
+    await expect(observedResponse.text()).rejects.toThrow(
+      "upstream connection reset"
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2506

### Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

### Problem

In `@mcp-use/client` (`libraries/typescript/packages/client/src/transport/http.ts`), `HttpConnector.observeSseProgress` used `response.body.tee()` to extract progress notifications (`notifications/progress`).

Under the WHATWG Streams specification, a teed `ReadableStream` only closes its underlying resource source (the TCP socket and HTTP connection) when **both** branches are closed or canceled. Because the second branch was consumed in a detached, unawaited background loop (`void (async () => { while(true) await reader.read() })()`), any aborted request or consumer cancellation left the second reader hung indefinitely, leaking active TCP sockets and file descriptors.

### Solution

Replaced `response.body.tee()` and the uncoordinated background loop with an **in-line pass-through `TransformStream`**:

1. **Single Reader / Single Lifecycle**: The official SDK (`StreamableHTTPClientTransport`) is the sole stream consumer.
2. **In-Flight Inspection**: As chunks are pulled by the SDK, the `transform` hook inspects the text for `notifications/progress` events and immediately forwards them via `controller.enqueue(chunk)`.
3. **Native Cancellation Propagation**: When the SDK or caller cancels the returned stream (`await response.body.cancel()`) or when the request aborts via `AbortSignal`, WHATWG Streams automatically propagates cancellation upstream to the underlying HTTP source, immediately freeing the TCP socket and connection.
4. **Memory Optimization**: Eliminates dual-buffer memory allocation and backpressure drift caused by `tee()`.

### Testing

Added comprehensive unit test suite in `packages/client/tests/unit/transport/http-sse-progress-lifecycle.test.ts`:
- Verifies progress events are forwarded while delivering all raw SSE chunks intact to the consumer.
- Verifies that calling `await reader.cancel()` propagates cancellation upstream to the underlying stream source immediately.
- Verifies that non-SSE responses bypass the transform stream.
- Verifies graceful handling of empty response bodies, malformed JSON lines, and stream errors.

Ran:
```bash
pnpm --filter @mcp-use/client exec vitest run tests/unit/transport/
pnpm build
pnpm docs:api
pnpm lint
pnpm format:check
```
All suites passed with zero errors or warnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an HTTP socket leak in `@mcp-use/client`'s SSE progress observer by replacing `response.body.tee()` with an in-line pass-through `TransformStream`. Previously, aborted requests or consumer cancellation left a detached background reader hanging, leaking TCP sockets and file descriptors. Now the stream has a single reader, so cancellation propagates upstream immediately and frees the connection.

- Progress notifications are still forwarded to `forwardRoundProgress` while all raw SSE chunks pass through unchanged.
- Adds unit tests covering cancellation propagation, non-SSE passthrough, empty bodies, malformed JSON, stream errors, and exact full-stream text preservation.
- Includes a changeset for the `@mcp-use/client` patch release.

<sup>Written for commit c842d52d5310cd01ceb2c686a85c5c534263df02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

