### PR TITLE
fix(views): separate UI origins from MCP endpoint identity

### DIFF
--- a/docs/v2/typescript/mcp-apps/content-security-policy.mdx
+++ b/docs/v2/typescript/mcp-apps/content-security-policy.mdx
@@ -24,6 +24,87 @@ When `MCP_ASSETS_URL` is unset, assets use the same origin as `MCP_URL` (or the 
 
 At **`mcp-use build`**, `MCP_ASSETS_URL` rewrites manifest paths to full `https://` URLs for static upload workflows.
 
+## Separate the UI origin from the MCP endpoint
+
+Set `view.domain` to the dedicated HTTPS origin you want ChatGPT to use, such as
+`https://wavebyvento.com`. The MCP endpoint is the URL clients connect to, such as
+`https://wave-by-vento.run.mcp-use.com/mcp`. These values serve different purposes.
+
+```env
+MCP_URL=https://wave-by-vento.run.mcp-use.com
+```
+
+```typescript
+import { MCPServer } from "mcp-use";
+import { z } from "zod";
+
+const server = new MCPServer({
+  name: "wave",
+  version: "1.0.0",
+  basePath: "/mcp",
+});
+
+export const showWave = server.tool(
+  {
+    name: "show-wave",
+    outputSchema: z.object({ message: z.string() }),
+    view: { name: "wave", domain: "https://wavebyvento.com" },
+  },
+  async () => ({
+    structuredContent: { message: "Hello from Wave" },
+    content: [{ type: "text", text: "Opened Wave" }],
+  }),
+);
+
+export default server;
+```
+
+Add the corresponding `views/wave/view.tsx` as described in [MCP Apps](/v2/typescript/mcp-apps).
+On `resources/read`, mcp-use emits host-specific `_meta.ui.domain`:
+
+| Host                                 | Domain output                                                                                                                  |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| ChatGPT and other non-Claude clients | `https://wavebyvento.com`                                                                                                      |
+| Claude                               | First 32 hexadecimal characters of SHA-256 of `https://wave-by-vento.run.mcp-use.com/mcp`, followed by `.claudemcpcontent.com` |
+
+Claude hashes the **full endpoint**, including `/mcp`, not the website origin or
+`MCP_ASSETS_URL`. This follows [Claude's domain handling contract](https://claude.com/docs/connectors/building/mcp-apps/cross-compatibility).
+ChatGPT expects a dedicated origin; `openai/widgetDomain` is a compatibility alias
+for `ui.domain`, not a way to repair a conflicting value. See the
+[OpenAI resource metadata reference](https://developers.openai.com/plugins/reference#component-resource-_meta-fields).
+
+### Endpoint resolution and migration
+
+- An origin-only `MCP_URL` combines with the server's `basePath` (default `/mcp`).
+- For View domain resolution, an `MCP_URL` with a path is treated as the full endpoint and hashed verbatim, including a trailing slash or query. With OAuth, keep `MCP_URL` origin-only: OAuth configuration separately requires an origin and appends `basePath`.
+- Without a valid `MCP_URL`, View reads use the request path and query with the forwarded origin, or the request origin when forwarded headers are absent. Configure `MCP_URL` when a proxy hides or rewrites the public path; only trust forwarded headers set by your proxy.
+- Older HTTP(S) `view.domain` values containing `/mcp` or another path are normalized to their origin. Set the intended UI origin explicitly when it differs from the endpoint origin.
+- Existing computed `*.claudemcpcontent.com` values remain unchanged for compatibility. They are Claude-specific and unsuitable for ChatGPT. Replace them with an HTTPS UI origin to use automatic host conversion.
+- An omitted `view.domain` keeps the host default. If no HTTP request or `MCP_URL` is available, Claude falls back to hashing the authored domain; configure the public endpoint for that case.
+
+The SDK identifies Claude by its advertised client name, with a User-Agent fallback
+when no client name is available. Unknown clients receive the UI origin. Domain
+normalization is not submission validation: use an HTTPS origin for ChatGPT and
+verify resource reads in each target host before submitting.
+
+### Preserve generated resource metadata
+
+Remove custom response helpers that overwrite `_meta.ui.domain` after `next()`.
+The SDK applies Claude's conversion before response middleware receives the result;
+a later overwrite replaces the generated value. Keep unrelated additions and preserve
+existing `ui` fields when merging metadata.
+
+Configure the domain through `view.domain`. Tool definition `_meta` and tool result
+`_meta` do not configure the View resource domain. Generated View resources emit
+`ui.domain` without an `openai/widgetDomain` alias. Manually registered resources and
+custom middleware remain author-controlled; if you emit both keys for ChatGPT, keep
+them consistent. Resource listings show the UI origin; Claude conversion happens on reads.
+
+`view.csp.frameDomains` separately allows **nested iframes inside the View**. It does
+not select the View's sandbox origin, identify the MCP endpoint, or fix domain
+validation. Declare it only when the View embeds another page. ChatGPT applies
+additional review to nested frames.
+
 ## CSP merge order
 
 On each `resources/read`, the framework merges CSP in this order (high → low priority):

--- a/docs/v2/typescript/server/migration.mdx
+++ b/docs/v2/typescript/server/migration.mdx
@@ -487,6 +487,12 @@ Native View documents are generated MCP resources. Do not register
 
 Move existing widget CSP domains to `view.csp`.
 
+Set `view.domain` to the HTTPS UI origin for ChatGPT. Claude resource reads derive
+the sandbox domain from the full MCP endpoint, using `MCP_URL` plus `basePath` or
+the public request URL. Remove response helpers that overwrite generated
+`_meta.ui.domain`. See [UI origin and endpoint migration](/v2/typescript/mcp-apps/content-security-policy#endpoint-resolution-and-migration)
+for legacy URL values, proxy configuration, and metadata precedence.
+
 ## Update authentication, proxies, and security
 
 Native v2 acts as an OAuth resource server backed by an external authorization

--- a/libraries/typescript/.changeset/tidy-views-domain-identity.md
+++ b/libraries/typescript/.changeset/tidy-views-domain-identity.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Separate View UI origins from MCP endpoint identity. Normalize HTTP(S) `view.domain` values to origins for ChatGPT and derive Claude resource domains from the full public MCP endpoint, including its path, using existing `MCP_URL` or request URL configuration. Preserve computed Claude domains and host defaults. Document migration, metadata precedence, proxy limitations, and nested-frame CSP in the SDK guide and repository agent skills.

--- a/libraries/typescript/packages/server/src/server.ts
+++ b/libraries/typescript/packages/server/src/server.ts
@@ -116,6 +116,7 @@ import {
   type SkillsSnapshot,
 } from "./skills/types.js";
 import { supportsViews } from "./views/capabilities.js";
+import { resolveMcpEndpoint } from "./views/origin.js";
 import type { ViewResourceFacts } from "./views/types.js";
 import {
   createViewPublicHandler,
@@ -2048,12 +2049,14 @@ export class MCPServer<TUser = never, TEnv extends Env = Env> {
           basePath,
           viewName
         );
-        // Claude serves view resources from a hashed sandbox origin derived
-        // from the authored domain. Applied on read only, matching v1.
+        // UI origin and MCP endpoint identity are separate. Claude hashes the
+        // full public endpoint, never the website or asset origin.
         const meta = await applyClaudeResourceDomain(
           buildResourceUiMeta(authorFacts, readOptions),
           requestClientInfo(ctx),
-          (req ?? metaOptions.request)?.headers.get("user-agent")
+          (req ?? metaOptions.request)?.headers.get("user-agent"),
+          resolveMcpEndpoint(req ?? metaOptions.request, basePath) ??
+            authorFacts?.domain
         );
         return {
           contents: [

--- a/libraries/typescript/packages/server/src/views/claude-domain.ts
+++ b/libraries/typescript/packages/server/src/views/claude-domain.ts
@@ -32,14 +32,13 @@ export function isClaudeClient(
 }
 
 /**
- * Derive the `*.claudemcpcontent.com` domain Claude expects for an authored
- * `view.domain`.
+ * Derive the `*.claudemcpcontent.com` domain Claude expects for an MCP endpoint.
  *
  * The subdomain is the first 32 hex characters of the SHA-256 digest of the
- * authored domain string verbatim, path included. Idempotent: a value that
+ * endpoint string verbatim, path included. Idempotent: a value that
  * already ends in the Claude suffix is returned unchanged.
  *
- * @param domain - Authored `view.domain` string, verbatim.
+ * @param domain - Full public MCP endpoint URL, verbatim, or a computed domain.
  * @returns The hashed Claude resource domain.
  */
 export async function computeClaudeResourceDomain(
@@ -72,12 +71,16 @@ export async function computeClaudeResourceDomain(
  * @param clientInfo - Client identity for the current request.
  * @param userAgent - HTTP user-agent fallback for legacy requests that carry
  * no per-request client identity.
+ * @param mcpEndpoint - Full public MCP endpoint, including its path. When
+ * unavailable, retains the legacy behavior of hashing the authored domain.
+ * An already computed Claude domain is preserved for compatibility.
  * @returns Resource `_meta` to send on the wire.
  */
 export async function applyClaudeResourceDomain(
   meta: Record<string, unknown>,
   clientInfo: Partial<Implementation> | undefined,
-  userAgent?: string | null
+  userAgent?: string | null,
+  mcpEndpoint?: string
 ): Promise<Record<string, unknown>> {
   const effectiveClientInfo =
     typeof clientInfo?.name === "string" ||
@@ -103,7 +106,11 @@ export async function applyClaudeResourceDomain(
     ...meta,
     [UI_META_KEY]: {
       ...(ui as Record<string, unknown>),
-      domain: await computeClaudeResourceDomain(domain),
+      domain: await computeClaudeResourceDomain(
+        domain.endsWith(CLAUDE_RESOURCE_DOMAIN_SUFFIX)
+          ? domain
+          : (mcpEndpoint ?? domain)
+      ),
     },
   };
 }

--- a/libraries/typescript/packages/server/src/views/origin.ts
+++ b/libraries/typescript/packages/server/src/views/origin.ts
@@ -87,6 +87,54 @@ export function resolveServerOrigin(request: Request): string {
 }
 
 /**
+ * Resolve the public MCP endpoint used for Claude's sandbox identity.
+ * An origin-only `MCP_URL` uses `basePath`; a URL with a path is already an
+ * endpoint and is kept verbatim. Otherwise use the request path and query
+ * with the forwarded/request origin. Asset URLs never identify the endpoint.
+ *
+ * @internal
+ */
+export function resolveMcpEndpoint(
+  request: Request | undefined,
+  basePath: string
+): string | undefined {
+  const mcpUrl = readEnv("MCP_URL");
+  if (mcpUrl !== undefined) {
+    try {
+      const url = new URL(mcpUrl);
+      if (url.protocol === "https:" || url.protocol === "http:") {
+        return url.pathname !== "/" || url.search !== ""
+          ? mcpUrl
+          : `${stripTrailingSlashes(mcpUrl)}${basePath}`;
+      }
+    } catch {
+      // Match server-origin resolution's fallback for malformed MCP_URL.
+    }
+  }
+  if (request === undefined) return undefined;
+  const url = new URL(request.url);
+  return `${resolveRequestOriginFromHeaders(request)}${url.pathname}${url.search}`;
+}
+
+/**
+ * Normalize an authored HTTP(S) view URL to an origin, without changing
+ * legacy host-specific domain strings. This is not host submission validation.
+ *
+ * @internal
+ */
+export function normalizeViewDomain(domain: string): string {
+  try {
+    const url = new URL(domain);
+    if (url.protocol === "https:" || url.protocol === "http:") {
+      return url.origin;
+    }
+  } catch {
+    // Preserve legacy host-specific strings, including computed Claude domains.
+  }
+  return domain;
+}
+
+/**
  * Extract the origin from an assets URL prefix (origin + optional path).
  */
 export function originFromAssetsBase(assetsBase: string): string {

--- a/libraries/typescript/packages/server/src/views/types.ts
+++ b/libraries/typescript/packages/server/src/views/types.ts
@@ -29,8 +29,13 @@ export interface ViewResourceFacts {
   /** Sandbox permissions the view needs → `_meta.ui.permissions`. */
   permissions?: UiPermissions;
   /**
-   * Dedicated origin hint for hosts that render views on a separate domain →
-   * `_meta.ui.domain`.
+   * Dedicated UI origin for ChatGPT and other hosts → `_meta.ui.domain`.
+   * Use an HTTPS origin such as `https://app.example.com`. HTTP(S) URL values
+   * are normalized to their origin for compatibility with older configs.
+   * On Claude resource reads, the framework instead hashes the full public
+   * MCP endpoint resolved from `MCP_URL` (origin + server `basePath`, or a full
+   * endpoint URL) or the forwarded/request URL. Omit to use the host default.
+   * Do not overwrite the generated domain in response middleware.
    */
   domain?: string;
   /** Ask the host to draw a border around the view → `_meta.ui.prefersBorder`. */

--- a/libraries/typescript/packages/server/src/views/wire.ts
+++ b/libraries/typescript/packages/server/src/views/wire.ts
@@ -10,6 +10,7 @@ import {
 import { buildMergedResourceCsp, type BuildCspOptions } from "./csp-env.js";
 import {
   hasExplicitAssetsBase,
+  normalizeViewDomain,
   originFromAssetsBase,
   resolveAssetsBase,
   resolveServerOrigin,
@@ -164,7 +165,7 @@ export function buildResourceUiMeta(
     ui["permissions"] = authorFacts.permissions;
   }
   if (authorFacts?.domain !== undefined) {
-    ui["domain"] = authorFacts.domain;
+    ui["domain"] = normalizeViewDomain(authorFacts.domain);
   }
   if (authorFacts?.prefersBorder !== undefined) {
     ui["prefersBorder"] = authorFacts.prefersBorder;

--- a/libraries/typescript/packages/server/tests/views.test.ts
+++ b/libraries/typescript/packages/server/tests/views.test.ts
@@ -8,6 +8,7 @@ import {
 } from "@modelcontextprotocol/client";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 import {
   afterAll,
   afterEach,
@@ -526,7 +527,7 @@ describe("views server core (e2e over HTTP)", () => {
     });
   });
 
-  it("hashes ui.domain on resources/read for Claude clients", async () => {
+  it("hashes the full MCP endpoint on resources/read for Claude clients", async () => {
     const read = await claudeClient.readResource({
       uri: "ui://views/product-search-result.html",
     });
@@ -534,14 +535,14 @@ describe("views server core (e2e over HTTP)", () => {
       | Record<string, unknown>
       | undefined;
     expect(ui?.["domain"]).toBe(
-      "36009c725adb9960af4aebe6278959e8.claudemcpcontent.com"
+      `${createHash("sha256").update(url).digest("hex").slice(0, 32)}.claudemcpcontent.com`
     );
     // Only the domain is rewritten; the rest of _meta.ui is untouched.
     expect(ui?.["permissions"]).toEqual({ clipboardWrite: {} });
     expect(ui?.["prefersBorder"]).toBe(true);
   });
 
-  it("hashes ui.domain on resources/read for Claude clients on the legacy wire", async () => {
+  it("hashes the full MCP endpoint on resources/read for Claude clients on the legacy wire", async () => {
     const read = await legacyClaudeClient.readResource({
       uri: "ui://views/product-search-result.html",
     });
@@ -549,7 +550,7 @@ describe("views server core (e2e over HTTP)", () => {
       | Record<string, unknown>
       | undefined;
     expect(ui?.["domain"]).toBe(
-      "36009c725adb9960af4aebe6278959e8.claudemcpcontent.com"
+      `${createHash("sha256").update(url).digest("hex").slice(0, 32)}.claudemcpcontent.com`
     );
   });
 

--- a/libraries/typescript/packages/server/tests/views/claude-domain.test.ts
+++ b/libraries/typescript/packages/server/tests/views/claude-domain.test.ts
@@ -5,6 +5,7 @@ import {
   computeClaudeResourceDomain,
   isClaudeClient,
 } from "../../src/views/claude-domain.js";
+import { buildResourceUiMeta } from "../../src/views/wire.js";
 
 describe("Claude resource domains", () => {
   it("detects Claude clients by advertised client name", () => {
@@ -117,5 +118,62 @@ describe("Claude resource domains", () => {
 
     expect(applied).toBe(meta);
     expect(applied["ui"]).not.toHaveProperty("domain");
+  });
+});
+
+describe("UI origin and MCP endpoint identity", () => {
+  it("uses the full endpoint for Claude independently of the website origin", async () => {
+    const meta = buildResourceUiMeta({ domain: "https://website.example.com" });
+    const result = await applyClaudeResourceDomain(
+      meta,
+      { name: "Claude" },
+      undefined,
+      "https://example.com/mcp"
+    );
+    expect(result["ui"]).toMatchObject({
+      domain: "c3d80a4ed901ee05b21755a88273b4a4.claudemcpcontent.com",
+    });
+    expect(meta["ui"]).toMatchObject({ domain: "https://website.example.com" });
+  });
+
+  it.each(["ChatGPT", "other-client"])(
+    "emits an exact origin for %s from a legacy endpoint value",
+    async (name) => {
+      const meta = buildResourceUiMeta({
+        domain: "https://example.com/mcp?legacy=1#fragment",
+      });
+      const result = await applyClaudeResourceDomain(
+        meta,
+        { name },
+        undefined,
+        "https://example.com/mcp"
+      );
+      expect(result["ui"]).toMatchObject({ domain: "https://example.com" });
+      expect(result).not.toHaveProperty("openai/widgetDomain");
+    }
+  );
+
+  it("preserves explicit computed Claude domains even when an endpoint is available", async () => {
+    const domain = "c3d80a4ed901ee05b21755a88273b4a4.claudemcpcontent.com";
+    const result = await applyClaudeResourceDomain(
+      { ui: { domain } },
+      { name: "Claude" },
+      undefined,
+      "https://different.example/mcp"
+    );
+    expect(result["ui"]).toEqual({ domain });
+  });
+
+  it("does not opt an undeclared view into a dedicated domain", async () => {
+    const meta = buildResourceUiMeta(undefined);
+    expect(
+      await applyClaudeResourceDomain(
+        meta,
+        { name: "Claude" },
+        undefined,
+        "https://example.com/mcp"
+      )
+    ).toBe(meta);
+    expect(meta["ui"]).not.toHaveProperty("domain");
   });
 });

--- a/libraries/typescript/packages/server/tests/views/domain-integration.test.ts
+++ b/libraries/typescript/packages/server/tests/views/domain-integration.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { MCPServer, registerViews } from "../../src/index.js";
+
+describe("host-specific view domains over HTTP", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it.each([
+    ["https://example.com", "https://website.example.com"],
+    ["https://example.com/mcp", "https://website.example.com"],
+    [undefined, "https://website.example.com"],
+    ["https://example.com/mcp", "https://website.example.com/mcp"],
+  ])(
+    "separates endpoint %s from authored UI URL %s",
+    async (mcpUrl, domain) => {
+      vi.stubEnv("MCP_URL", mcpUrl);
+      vi.stubEnv("MCP_ASSETS_URL", "https://cdn.example.com/assets");
+      const server = new MCPServer({ name: "domain-test", version: "1.0.0" });
+      server[registerViews]({ result: { kind: "inline", js: "", css: "" } });
+      server.tool(
+        {
+          name: "show-result",
+          outputSchema: z.object({ ok: z.boolean() }),
+          view: {
+            name: "result",
+            domain,
+            prefersBorder: true,
+            csp: { frameDomains: ["https://embed.example.com"] },
+          },
+          // Tool metadata is not a source of resource-domain configuration.
+          _meta: {
+            ui: { domain: "https://wrong.example/mcp" },
+            "openai/widgetDomain": "https://alias.example",
+          },
+        },
+        async () => ({ structuredContent: { ok: true }, content: [] })
+      );
+
+      async function request(method: string, clientName: string) {
+        const response = await server.fetch(
+          new Request("http://127.0.0.1:3000/mcp", {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+              accept: "application/json, text/event-stream",
+              "mcp-protocol-version": "2026-07-28",
+              "mcp-method": method,
+              ...(method === "resources/read"
+                ? { "mcp-name": "ui://views/result.html" }
+                : {}),
+              forwarded: "proto=https;host=example.com",
+            },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method,
+              params: {
+                ...(method === "resources/read"
+                  ? { uri: "ui://views/result.html" }
+                  : {}),
+                _meta: {
+                  "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                  "io.modelcontextprotocol/clientInfo": {
+                    name: clientName,
+                    version: "1.0.0",
+                  },
+                  "io.modelcontextprotocol/clientCapabilities": {},
+                },
+              },
+            }),
+          })
+        );
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.error).toBeUndefined();
+        return body.result;
+      }
+
+      try {
+        const listed = await request("resources/list", "ChatGPT");
+        expect(listed.resources[0]._meta.ui.domain).toBe(
+          "https://website.example.com"
+        );
+        // Interleave hosts to catch mutation or caching of request-specific values.
+        for (const client of ["ChatGPT", "Claude", "ChatGPT"]) {
+          const read = await request("resources/read", client);
+          const meta = read.contents[0]._meta;
+          expect(meta.ui.domain).toBe(
+            client === "Claude"
+              ? "c3d80a4ed901ee05b21755a88273b4a4.claudemcpcontent.com"
+              : "https://website.example.com"
+          );
+          expect(meta).not.toHaveProperty("openai/widgetDomain");
+          expect(meta.ui.prefersBorder).toBe(true);
+          expect(meta.ui.csp.frameDomains).toEqual([
+            "https://embed.example.com",
+          ]);
+        }
+      } finally {
+        await server.close();
+      }
+    }
+  );
+});

--- a/libraries/typescript/packages/server/tests/views/origin.test.ts
+++ b/libraries/typescript/packages/server/tests/views/origin.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   resolveAssetsBase,
+  resolveMcpEndpoint,
   resolveServerOrigin,
   resolveRequestOriginFromHeaders,
 } from "../../src/views/origin.js";
@@ -85,5 +86,56 @@ describe("resolveRequestOriginFromHeaders", () => {
         })
       )
     ).toBe("https://fruit.example.com");
+  });
+});
+
+describe("resolveMcpEndpoint", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it.each([
+    ["https://example.com", "/mcp", "https://example.com/mcp"],
+    ["https://example.com/", "/custom/mcp", "https://example.com/custom/mcp"],
+    ["https://example.com/mcp", "/mcp", "https://example.com/mcp"],
+    [
+      "https://example.com/proxy/mcp/",
+      "/mcp",
+      "https://example.com/proxy/mcp/",
+    ],
+    [
+      "https://example.com/mcp?tenant=1",
+      "/mcp",
+      "https://example.com/mcp?tenant=1",
+    ],
+    ["https://example.com", "/", "https://example.com/"],
+  ])("resolves MCP_URL %s with route %s", (value, basePath, expected) => {
+    vi.stubEnv("MCP_URL", value);
+    vi.stubEnv("MCP_ASSETS_URL", "https://cdn.example.com/assets");
+    expect(resolveMcpEndpoint(req("http://localhost:3000/mcp"), basePath)).toBe(
+      expected
+    );
+    expect(resolveMcpEndpoint(undefined, basePath)).toBe(expected);
+  });
+
+  it.each([undefined, "not-a-url"])(
+    "uses the forwarded origin with request path when MCP_URL is %s",
+    (value) => {
+      vi.stubEnv("MCP_URL", value);
+      expect(
+        resolveMcpEndpoint(
+          req("http://localhost:3000/custom/mcp?tenant=1", {
+            forwarded: "proto=https;host=public.example.com",
+          }),
+          "/custom/mcp"
+        )
+      ).toBe("https://public.example.com/custom/mcp?tenant=1");
+    }
+  );
+
+  it("uses the request endpoint without an override and has no stdio default", () => {
+    vi.stubEnv("MCP_URL", undefined);
+    expect(resolveMcpEndpoint(req("https://example.com/mcp"), "/mcp")).toBe(
+      "https://example.com/mcp"
+    );
+    expect(resolveMcpEndpoint(undefined, "/mcp")).toBeUndefined();
   });
 });

--- a/skills/chatgpt-app-builder/SKILL.md
+++ b/skills/chatgpt-app-builder/SKILL.md
@@ -13,7 +13,7 @@ Treat the installed `mcp-use` package, its exported types, generated declaration
 2. Scaffold a new stable project with `create-mcp-use-app@latest` and the appropriate template. Match the package version or dist-tag when working on beta, canary, or an existing versioned project.
 3. Read only the references needed for the task:
    - [Server](references/server.md) for tools, resources, prompts, MCP middleware, request context, and result envelopes.
-   - [Views](references/views.md) for interactive MCP Apps, React hooks, model context, host capabilities, assets, and CSP.
+   - [Views](references/views.md) for interactive MCP Apps, React hooks, model context, host capabilities, assets, CSP, and endpoint/UI domain handling.
    - [Authentication](references/auth.md) for OAuth providers, verified identity, scopes, permissions, and authorization.
    - [Skills over MCP](references/skills-over-mcp.md) when a server should ship reusable workflows alongside its tools.
    - [Advanced features](references/advanced-features.md) for OpenAPI, proxying, notifications, subscriptions, and elicitation.

--- a/skills/chatgpt-app-builder/references/views.md
+++ b/skills/chatgpt-app-builder/references/views.md
@@ -26,12 +26,7 @@ export default function ProductResults() {
   }
 
   const source = typeof meta?.source === "string" ? meta.source : undefined;
-  return (
-    <Results
-      items={toolOutput.items}
-      source={source}
-    />
-  );
+  return <Results items={toolOutput.items} source={source} />;
 }
 ```
 
@@ -70,3 +65,43 @@ Declare exact external origins in `view.csp`:
 - `resourceDomains` for scripts, styles, images, fonts, and media.
 - `frameDomains` for embedded frames.
 - `baseUriDomains` only for an intentional external base URI.
+
+## UI origin, endpoint identity, and host metadata
+
+For SDK versions with automatic endpoint-based Claude domains, configure the UI
+origin on the tool: `view: { name: "wave", domain: "https://wavebyvento.com" }`.
+Set `MCP_URL=https://wave-by-vento.run.mcp-use.com` and server `basePath: "/mcp"`.
+ChatGPT receives `ui.domain: "https://wavebyvento.com"`; Claude receives the first
+32 hex characters of SHA-256 of the full `https://wave-by-vento.run.mcp-use.com/mcp`
+endpoint plus `.claudemcpcontent.com`. Do not hash the website or asset origin.
+
+Inspect the installed SDK: older versions hash `view.domain` itself. Upgrade to
+endpoint-based handling before removing an existing compatibility helper. Do not
+invent `uiOrigin` or `mcpEndpoint` config fields.
+
+For View domain resolution, origin-only `MCP_URL` appends `basePath`; a URL with a
+path is the full endpoint, preserved verbatim. With OAuth, use origin-only `MCP_URL`
+because OAuth configuration requires it. Without `MCP_URL`, the SDK uses the request
+path/query and forwarded/request origin. Set the public URL explicitly when a proxy
+rewrites paths. `MCP_ASSETS_URL` controls assets, never Claude identity.
+
+HTTP(S) `view.domain` URLs normalize to origins. Use an HTTPS origin without `/mcp`
+for ChatGPT. Precomputed Claude domains remain supported but are Claude-only; replace
+them with the UI origin for cross-host apps. Omitting `view.domain` keeps host defaults.
+Without an HTTP request or `MCP_URL`, Claude falls back to the authored domain.
+
+Remove helpers that overwrite generated resource `_meta.ui.domain` after `next()`;
+they clobber Claude conversion. Preserve generated `ui` fields when adding unrelated
+metadata. Configure the resource through `view.domain`, not tool `_meta` or tool
+result `_meta`. Generated resources use standard `ui.domain` only. On manually authored
+ChatGPT resources, `openai/widgetDomain` is an alias, not an override for an invalid
+`ui.domain`; keep both consistent if both are emitted. Custom resources and response
+middleware remain author-controlled.
+
+`frameDomains` allows nested iframes inside the View. It does not set the View origin
+or fix domain validation. Add it only for actual nested embeds.
+
+Verify `resources/read` for ChatGPT and Claude, including an endpoint with `/mcp` and
+a UI origin on another host. Claude detection uses advertised client name, falling
+back to User-Agent when no name is present; unknown clients receive the UI origin.
+Do not claim host publishing validation from SDK tests alone.

--- a/skills/mcp-apps-builder/SKILL.md
+++ b/skills/mcp-apps-builder/SKILL.md
@@ -13,7 +13,7 @@ Treat the installed `mcp-use` package, its exported types, generated declaration
 2. Scaffold a new stable project with `create-mcp-use-app@latest` and the appropriate template. Match the package version or dist-tag when working on beta, canary, or an existing versioned project.
 3. Read only the references needed for the task:
    - [Server](references/server.md) for tools, resources, prompts, MCP middleware, request context, and result envelopes.
-   - [Views](references/views.md) for interactive MCP Apps, React hooks, model context, host capabilities, assets, and CSP.
+   - [Views](references/views.md) for interactive MCP Apps, React hooks, model context, host capabilities, assets, CSP, and endpoint/UI domain handling.
    - [Authentication](references/auth.md) for OAuth providers, verified identity, scopes, permissions, and authorization.
    - [Skills over MCP](references/skills-over-mcp.md) when a server should ship reusable workflows alongside its tools.
    - [Advanced features](references/advanced-features.md) for OpenAPI, proxying, notifications, subscriptions, and elicitation.

--- a/skills/mcp-apps-builder/references/views.md
+++ b/skills/mcp-apps-builder/references/views.md
@@ -26,12 +26,7 @@ export default function ProductResults() {
   }
 
   const source = typeof meta?.source === "string" ? meta.source : undefined;
-  return (
-    <Results
-      items={toolOutput.items}
-      source={source}
-    />
-  );
+  return <Results items={toolOutput.items} source={source} />;
 }
 ```
 
@@ -70,3 +65,43 @@ Declare exact external origins in `view.csp`:
 - `resourceDomains` for scripts, styles, images, fonts, and media.
 - `frameDomains` for embedded frames.
 - `baseUriDomains` only for an intentional external base URI.
+
+## UI origin, endpoint identity, and host metadata
+
+For SDK versions with automatic endpoint-based Claude domains, configure the UI
+origin on the tool: `view: { name: "wave", domain: "https://wavebyvento.com" }`.
+Set `MCP_URL=https://wave-by-vento.run.mcp-use.com` and server `basePath: "/mcp"`.
+ChatGPT receives `ui.domain: "https://wavebyvento.com"`; Claude receives the first
+32 hex characters of SHA-256 of the full `https://wave-by-vento.run.mcp-use.com/mcp`
+endpoint plus `.claudemcpcontent.com`. Do not hash the website or asset origin.
+
+Inspect the installed SDK: older versions hash `view.domain` itself. Upgrade to
+endpoint-based handling before removing an existing compatibility helper. Do not
+invent `uiOrigin` or `mcpEndpoint` config fields.
+
+For View domain resolution, origin-only `MCP_URL` appends `basePath`; a URL with a
+path is the full endpoint, preserved verbatim. With OAuth, use origin-only `MCP_URL`
+because OAuth configuration requires it. Without `MCP_URL`, the SDK uses the request
+path/query and forwarded/request origin. Set the public URL explicitly when a proxy
+rewrites paths. `MCP_ASSETS_URL` controls assets, never Claude identity.
+
+HTTP(S) `view.domain` URLs normalize to origins. Use an HTTPS origin without `/mcp`
+for ChatGPT. Precomputed Claude domains remain supported but are Claude-only; replace
+them with the UI origin for cross-host apps. Omitting `view.domain` keeps host defaults.
+Without an HTTP request or `MCP_URL`, Claude falls back to the authored domain.
+
+Remove helpers that overwrite generated resource `_meta.ui.domain` after `next()`;
+they clobber Claude conversion. Preserve generated `ui` fields when adding unrelated
+metadata. Configure the resource through `view.domain`, not tool `_meta` or tool
+result `_meta`. Generated resources use standard `ui.domain` only. On manually authored
+ChatGPT resources, `openai/widgetDomain` is an alias, not an override for an invalid
+`ui.domain`; keep both consistent if both are emitted. Custom resources and response
+middleware remain author-controlled.
+
+`frameDomains` allows nested iframes inside the View. It does not set the View origin
+or fix domain validation. Add it only for actual nested embeds.
+
+Verify `resources/read` for ChatGPT and Claude, including an endpoint with `/mcp` and
+a UI origin on another host. Claude detection uses advertised client name, falling
+back to User-Agent when no name is present; unknown clients receive the UI origin.
+Do not claim host publishing validation from SDK tests alone.

--- a/skills/mcp-builder/SKILL.md
+++ b/skills/mcp-builder/SKILL.md
@@ -13,7 +13,7 @@ Treat the installed `mcp-use` package, its exported types, generated declaration
 2. Scaffold a new stable project with `create-mcp-use-app@latest` and the appropriate template. Match the package version or dist-tag when working on beta, canary, or an existing versioned project.
 3. Read only the references needed for the task:
    - [Server](references/server.md) for tools, resources, prompts, MCP middleware, request context, and result envelopes.
-   - [Views](references/views.md) for interactive MCP Apps, React hooks, model context, host capabilities, assets, and CSP.
+   - [Views](references/views.md) for interactive MCP Apps, React hooks, model context, host capabilities, assets, CSP, and endpoint/UI domain handling.
    - [Authentication](references/auth.md) for OAuth providers, verified identity, scopes, permissions, and authorization.
    - [Skills over MCP](references/skills-over-mcp.md) when a server should ship reusable workflows alongside its tools.
    - [Advanced features](references/advanced-features.md) for OpenAPI, proxying, notifications, subscriptions, and elicitation.

--- a/skills/mcp-builder/references/views.md
+++ b/skills/mcp-builder/references/views.md
@@ -26,12 +26,7 @@ export default function ProductResults() {
   }
 
   const source = typeof meta?.source === "string" ? meta.source : undefined;
-  return (
-    <Results
-      items={toolOutput.items}
-      source={source}
-    />
-  );
+  return <Results items={toolOutput.items} source={source} />;
 }
 ```
 
@@ -70,3 +65,43 @@ Declare exact external origins in `view.csp`:
 - `resourceDomains` for scripts, styles, images, fonts, and media.
 - `frameDomains` for embedded frames.
 - `baseUriDomains` only for an intentional external base URI.
+
+## UI origin, endpoint identity, and host metadata
+
+For SDK versions with automatic endpoint-based Claude domains, configure the UI
+origin on the tool: `view: { name: "wave", domain: "https://wavebyvento.com" }`.
+Set `MCP_URL=https://wave-by-vento.run.mcp-use.com` and server `basePath: "/mcp"`.
+ChatGPT receives `ui.domain: "https://wavebyvento.com"`; Claude receives the first
+32 hex characters of SHA-256 of the full `https://wave-by-vento.run.mcp-use.com/mcp`
+endpoint plus `.claudemcpcontent.com`. Do not hash the website or asset origin.
+
+Inspect the installed SDK: older versions hash `view.domain` itself. Upgrade to
+endpoint-based handling before removing an existing compatibility helper. Do not
+invent `uiOrigin` or `mcpEndpoint` config fields.
+
+For View domain resolution, origin-only `MCP_URL` appends `basePath`; a URL with a
+path is the full endpoint, preserved verbatim. With OAuth, use origin-only `MCP_URL`
+because OAuth configuration requires it. Without `MCP_URL`, the SDK uses the request
+path/query and forwarded/request origin. Set the public URL explicitly when a proxy
+rewrites paths. `MCP_ASSETS_URL` controls assets, never Claude identity.
+
+HTTP(S) `view.domain` URLs normalize to origins. Use an HTTPS origin without `/mcp`
+for ChatGPT. Precomputed Claude domains remain supported but are Claude-only; replace
+them with the UI origin for cross-host apps. Omitting `view.domain` keeps host defaults.
+Without an HTTP request or `MCP_URL`, Claude falls back to the authored domain.
+
+Remove helpers that overwrite generated resource `_meta.ui.domain` after `next()`;
+they clobber Claude conversion. Preserve generated `ui` fields when adding unrelated
+metadata. Configure the resource through `view.domain`, not tool `_meta` or tool
+result `_meta`. Generated resources use standard `ui.domain` only. On manually authored
+ChatGPT resources, `openai/widgetDomain` is an alias, not an override for an invalid
+`ui.domain`; keep both consistent if both are emitted. Custom resources and response
+middleware remain author-controlled.
+
+`frameDomains` allows nested iframes inside the View. It does not set the View origin
+or fix domain validation. Add it only for actual nested embeds.
+
+Verify `resources/read` for ChatGPT and Claude, including an endpoint with `/mcp` and
+a UI origin on another host. Claude detection uses advertised client name, falling
+back to User-Agent when no name is present; unknown clients receive the UI origin.
+Do not claim host publishing validation from SDK tests alone.


### PR DESCRIPTION
## Changes

A View configured with a website origin currently hashes that origin for Claude, while configuring the full MCP URL leaks `/mcp` into ChatGPT's `ui.domain`. Separate those identities without adding public configuration: `view.domain` supplies the UI origin; the full public MCP endpoint supplies Claude's hash.

## Language / project scope

- [x] TypeScript (`mcp-use` server and tests)
- [x] SDK documentation and repository-owned agent skills

## Implementation details

- Normalize HTTP(S) `view.domain` values to their origin for resource listings and non-Claude reads.
- On Claude reads, hash the complete MCP endpoint (SHA-256, first 32 hex characters, `.claudemcpcontent.com`). Origin-only `MCP_URL` appends the existing `basePath`; a path-bearing `MCP_URL` is used verbatim. Otherwise resolve the forwarded/request origin with the request path and query. Asset URLs never determine the hash.
- Retain existing client-name detection and User-Agent fallback, omitted-domain behavior, precomputed Claude domains, and authored-domain fallback when no endpoint is available.
- Keep resource metadata sourced from `view` configuration. Conflicting tool-level `ui.domain` / `openai/widgetDomain` values do not override it. The current View API emits standard `ui.domain` only; it does not introduce a new alias merge or general validation framework.
- Update public TSDoc, v2 CSP/domain and migration guides, and the `mcp-builder`, `mcp-apps-builder`, and `chatgpt-app-builder` skills. Add a patch changeset.

Official contracts checked: [Claude domain handling](https://claude.com/docs/connectors/building/mcp-apps/cross-compatibility) hashes the full server URL, including `/mcp`; [OpenAI resource metadata](https://developers.openai.com/plugins/reference#component-resource-_meta-fields) defines `ui.domain` as an origin and `openai/widgetDomain` as its compatibility alias. `frameDomains` concerns nested iframe embeds, not the View's own domain.

## Supported configuration

```env
MCP_URL=https://wave-by-vento.run.mcp-use.com
```

```ts
const server = new MCPServer({ name: "wave", version: "1.0.0", basePath: "/mcp" });
// On the rendering tool, alongside its outputSchema:
view: { name: "wave", domain: "https://wavebyvento.com" }
```

ChatGPT receives `https://wavebyvento.com`. Claude receives the hash of `https://wave-by-vento.run.mcp-use.com/mcp`.

## Migration and limitations

Use an HTTPS UI origin in `view.domain` and remove response helpers that overwrite generated `_meta.ui.domain`. HTTP(S) legacy values containing a path are normalized. Precomputed Claude strings remain supported but are unsuitable for ChatGPT; replace them with the UI origin for cross-host use.

Custom resources and response middleware remain author-controlled and can still overwrite metadata. If manually emitting both ChatGPT domain keys, keep them consistent. Unknown clients receive the UI origin. Configure `MCP_URL` when proxy rewriting hides the public path; trust only proxy-controlled forwarding headers. With OAuth, keep `MCP_URL` origin-only because its existing configuration contract requires that form. This patch does not change OAuth URL validation or claim live host submission acceptance.

## Validation

- `pnpm --filter @mcp-use/client build`, `pnpm --filter @mcp-use/tunnel build`, and `pnpm --filter @mcp-use/cli build` passed (workspace prerequisites).
- Server `pnpm build` and `pnpm typecheck` passed.
- Server `pnpm exec vitest run tests/views/ tests/views.test.ts`: **99 tests passed** across 5 files, including modern and legacy HTTP Claude clients.
- Added regressions for independent website/endpoint origins, legacy `/mcp` UI values, endpoint overrides, custom paths, trailing slashes/query strings, forwarded origins, asset separation, unchanged metadata, precomputed domains, missing domains, conflicting tool aliases, and interleaved ChatGPT/Claude reads.
- ESLint and Prettier passed for affected files; all three updated skills passed `quick_validate.py`; `git diff --check` passed.
- Live ChatGPT/Claude rendering and publishing were not run. Initial local failures were missing workspace build artifacts and sandbox localhost restrictions, resolved before the passing test run.

## Review readiness

- [x] Scoped to domain identity and directly related guidance
- [x] Regression tests and patch changeset included
- [x] Existing open domain PRs checked; none found
- [x] Draft only; no merge or deployment

Targets `canary`, the source branch of this isolated worktree, to avoid including unrelated release commits in the diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separates a View's UI origin from its MCP endpoint identity so ChatGPT receives the website origin while Claude hashes the full public endpoint (including `/mcp`) for its sandbox domain.

- Normalizes HTTP(S) `view.domain` values to their origin for resource listing and non-Claude reads.
- On Claude reads, hashes the complete MCP endpoint resolved from `MCP_URL` (plus `basePath`) or the forwarded/request URL; precomputed Claude domains remain supported.
- Tool-level `_meta`/`openai/widgetDomain` do not override generated resource metadata.

**Migration**

- Set `view.domain` to an HTTPS UI origin and remove response helpers that overwrite generated `_meta.ui.domain`.
- Keep `MCP_URL` origin-only with OAuth; a path-bearing `MCP_URL` is hashed verbatim.

<sup>Written for commit e6f14e2127a15991b89d1b8f86fe7fb61af48d14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

