### PR TITLE
fix(client): forward views shorthand, roots, and defaultRequestOptions in browser client

### DIFF
--- a/libraries/typescript/.changeset/browser-client-views-roots.md
+++ b/libraries/typescript/.changeset/browser-client-views-roots.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Fix `BrowserMCPClient` dropping `capabilities.views` shorthand resolution, `roots`, and `defaultRequestOptions` in `createConnectorFromConfig`, matching the node path. Browser-built MCP Apps now advertise the `io.modelcontextprotocol/ui` extension instead of raw `{ views: true }`, so upstream servers correctly serve interactive views.

--- a/libraries/typescript/packages/client/src/core/browser.ts
+++ b/libraries/typescript/packages/client/src/core/browser.ts
@@ -1,6 +1,10 @@
 import type { OAuthClientProvider } from "@modelcontextprotocol/client";
 import type { AutoOAuthOptions, CallbackConfig } from "./config.js";
-import { normalizeClientInfo, resolveCallbacks } from "./config.js";
+import {
+  normalizeClientInfo,
+  resolveCallbacks,
+  resolveClientOptions,
+} from "./config.js";
 import type { BaseConnector } from "../transport/base.js";
 import { HttpConnector } from "../transport/http.js";
 import {
@@ -94,6 +98,8 @@ export class BrowserMCPClient extends BaseMCPClient {
       gatewayUrl,
       serverId,
       reconnectionOptions,
+      roots,
+      defaultRequestOptions,
     } = serverConfig;
 
     if (!url) {
@@ -120,7 +126,7 @@ export class BrowserMCPClient extends BaseMCPClient {
       authProvider,
       detectMixedAuth,
       wrapTransport,
-      clientOptions,
+      clientOptions: resolveClientOptions(clientOptions),
       onSampling: resolved.onSampling,
       onElicitation: resolved.onElicitation,
       onNotification: resolved.onNotification,
@@ -130,6 +136,8 @@ export class BrowserMCPClient extends BaseMCPClient {
       gatewayUrl,
       serverId,
       reconnectionOptions,
+      roots,
+      defaultRequestOptions,
     };
 
     logger.debug(

--- a/libraries/typescript/packages/client/tests/unit/core/browser-client-config.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/core/browser-client-config.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { BrowserMCPClient } from "../../../src/core/browser.js";
+import type { BaseConnector } from "../../../src/transport/base.js";
+
+class TestBrowserClient extends BrowserMCPClient {
+  createConnector(config: Record<string, any>): BaseConnector {
+    return this.createConnectorFromConfig(config);
+  }
+}
+
+describe("BrowserMCPClient.createConnectorFromConfig", () => {
+  it("expands the capabilities.views shorthand into the MCP Apps extension", () => {
+    const client = new TestBrowserClient({});
+    const connector = client.createConnector({
+      url: "https://mcp.example.com",
+      clientOptions: {
+        capabilities: { views: true },
+      },
+    });
+
+    const options = (connector as unknown as { opts: Record<string, any> })
+      .opts;
+    expect(options.clientOptions.capabilities.extensions).toEqual({
+      "io.modelcontextprotocol/ui": {
+        mimeTypes: ["text/html;profile=mcp-app"],
+      },
+    });
+  });
+
+  it("preserves other capabilities when expanding the views shorthand", () => {
+    const client = new TestBrowserClient({});
+    const connector = client.createConnector({
+      url: "https://mcp.example.com",
+      clientOptions: {
+        capabilities: { roots: { listChanged: true }, views: true },
+      },
+    });
+
+    const options = (connector as unknown as { opts: Record<string, any> })
+      .opts;
+    expect(options.clientOptions.capabilities).toEqual({
+      roots: { listChanged: true },
+      extensions: {
+        "io.modelcontextprotocol/ui": {
+          mimeTypes: ["text/html;profile=mcp-app"],
+        },
+      },
+    });
+  });
+
+  it("forwards roots to the connector", () => {
+    const client = new TestBrowserClient({});
+    const connector = client.createConnector({
+      url: "https://mcp.example.com",
+      roots: [{ uri: "app://workspace", name: "Workspace" }],
+    });
+
+    expect(connector.getRoots()).toEqual([
+      { uri: "app://workspace", name: "Workspace" },
+    ]);
+  });
+
+  it("forwards defaultRequestOptions to the connector", () => {
+    const client = new TestBrowserClient({});
+    const connector = client.createConnector({
+      url: "https://mcp.example.com",
+      defaultRequestOptions: { timeout: 15000 },
+    });
+
+    const options = (connector as unknown as { opts: Record<string, any> })
+      .opts;
+    expect(options.defaultRequestOptions).toEqual({ timeout: 15000 });
+  });
+});


### PR DESCRIPTION
## Summary

`BrowserMCPClient.createConnectorFromConfig` dropped three config values that the Node path (and `config.ts` `createConnectorFromConfig`) already handles:

1. **`capabilities.views` shorthand** — was passed raw instead of being expanded via `resolveClientOptions()` into the `io.modelcontextprotocol/ui` extension with `mimeTypes: ["text/html;profile=mcp-app"]`. Browser-built MCP Apps advertised `{ views: true }` during initialize, so upstream servers checking `ctx.client.supportsViews()` returned `false` and declined to render interactive views.
2. **`roots`** — was never extracted from `serverConfig`, so client roots were never advertised (`connector.rootsCache` stayed empty).
3. **`defaultRequestOptions`** — was never forwarded, so custom default request timeouts / cancellation policies were ignored.

Fixes #2475.

## Changes

- `browser.ts`: wrap `clientOptions` with `resolveClientOptions()`, destructure and forward `roots` + `defaultRequestOptions` (mirrors `config.ts:349`).
- New test: `tests/unit/core/browser-client-config.test.ts` covering the views shorthand expansion, preservation of other capabilities, roots forwarding, and `defaultRequestOptions` forwarding.

## Verification

- `tsc --noEmit` — clean
- `vitest run` (packages/client) — **62 files, 377 tests, all passing**, including the browser-bundle entry test (no Node-only deps leaked into `dist/index-browser.js`)
- Changeset added (`@mcp-use/client`: patch)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `BrowserMCPClient.createConnectorFromConfig` dropping three config values that the Node path already forwards: the `capabilities.views` shorthand, `roots`, and `defaultRequestOptions`. Browser-built MCP Apps now advertise the `io.modelcontextprotocol/ui` extension instead of raw `{ views: true }`, so upstream servers correctly serve interactive views. Fixes #2475.

**Changes**
- Expands the views shorthand via `resolveClientOptions()` into the `io.modelcontextprotocol/ui` extension with `mimeTypes: ["text/html;profile=mcp-app"]`, preserving other capabilities.
- Forwards `roots` and `defaultRequestOptions` from `serverConfig` into the connector.
- Mirrors the existing `config.ts` implementation.
- Adds unit tests for views shorthand expansion, capability preservation, roots forwarding, and defaultRequestOptions forwarding.
- Includes a patch changeset for `@mcp-use/client`.

<sup>Written for commit a856a033f89fa80fdb3f55c36bb4918556be2539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

