### PR TITLE
fix(cli): reject an inline value on boolean flags instead of discarding it

### DIFF
--- a/libraries/typescript/.changeset/quiet-lamps-refuse.md
+++ b/libraries/typescript/.changeset/quiet-lamps-refuse.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/cli": patch
+---
+
+Reject an inline value on boolean CLI switches instead of silently discarding it. `mcp-use dev --tunnel=false` previously parsed as `--tunnel` and opened a public tunnel; it now fails with `--tunnel does not take a value`. The same applies to `--no-open`, `--no-inspector`, `--with-inspector`, `--source-maps`, `--inline`, `--help`, and `--version`. Flags that take a value continue to accept both `--flag value` and `--flag=value`.

--- a/libraries/typescript/.changeset/quiet-lamps-refuse.md
+++ b/libraries/typescript/.changeset/quiet-lamps-refuse.md
@@ -1,5 +1,5 @@
 ---
-"@mcp-use/cli": patch
+"@mcp-use/cli": minor
 ---
 
 Reject an inline value on boolean CLI switches instead of silently discarding it. `mcp-use dev --tunnel=false` previously parsed as `--tunnel` and opened a public tunnel; it now fails with `--tunnel does not take a value`. The same applies to `--no-open`, `--no-inspector`, `--with-inspector`, `--source-maps`, `--inline`, `--help`, and `--version`. Flags that take a value continue to accept both `--flag value` and `--flag=value`.

--- a/libraries/typescript/packages/cli/src/bin/args.ts
+++ b/libraries/typescript/packages/cli/src/bin/args.ts
@@ -52,12 +52,13 @@ export interface ParsedArgs {
 /**
  * Parse the `mcp-use` argv (everything after the node binary and script path).
  *
- * Supports `--flag value` and `--flag=value` forms. The first bare token is
- * taken as the subcommand.
+ * Supports `--flag value` and `--flag=value` forms for flags that take a
+ * value. Boolean switches take no value: `--tunnel=false` is rejected rather
+ * than read as `--tunnel`. The first bare token is taken as the subcommand.
  *
  * @param argv - Raw arguments, typically `process.argv.slice(2)`.
- * @throws Error on an unknown flag, a missing flag value, an out-of-range
- * port, or a second positional argument.
+ * @throws Error on an unknown flag, a missing flag value, a value passed to a
+ * boolean switch, an out-of-range port, or a second positional argument.
  *
  * @internal
  */
@@ -106,9 +107,16 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
       }
     }
 
+    // Set by `takeValue` so the boolean switches below, which never call it,
+    // can be told apart from value-taking flags.
+    let inlineConsumed = false;
+
     /** Consume the flag's value: inline (`=`) or the next argv token. */
     const takeValue = (): string => {
-      if (inline !== undefined) return inline;
+      if (inline !== undefined) {
+        inlineConsumed = true;
+        return inline;
+      }
       const next = argv[++i];
       if (next === undefined || next.startsWith("-")) {
         throw new Error(`Missing value for ${flag}`);
@@ -170,6 +178,13 @@ export function parseArgs(argv: readonly string[]): ParsedArgs {
           throw new Error(`Unexpected argument: ${flag}`);
         }
         args.command = flag;
+    }
+
+    // A boolean switch reaching here never called `takeValue`, so an inline
+    // value was silently discarded and the flag applied regardless. Rejecting
+    // it keeps `--tunnel=false` from opening a public tunnel.
+    if (inline !== undefined && !inlineConsumed) {
+      throw new Error(`${flag} does not take a value`);
     }
   }
 

--- a/libraries/typescript/packages/cli/tests/bin-args-boolean-values.test.ts
+++ b/libraries/typescript/packages/cli/tests/bin-args-boolean-values.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for boolean switches given an inline `=value` in the `mcp-use` bin.
+ *
+ * `parseArgs` splits `--flag=value` for every `--` token, but the boolean
+ * cases never read the inline value. `--tunnel=false` therefore used to parse
+ * as `--tunnel` and open a public tunnel — the inverse of what was asked, with
+ * no diagnostic, because unknown flags do throw and so acceptance reads as
+ * support. Boolean switches now reject a value instead.
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseArgs } from "../src/bin/args.js";
+
+describe("boolean switches reject an inline value", () => {
+  it("rejects --tunnel=false rather than opening a tunnel", () => {
+    expect(() => parseArgs(["dev", "--tunnel=false"])).toThrow(
+      "--tunnel does not take a value"
+    );
+    expect(() => parseArgs(["start", "--tunnel=true"])).toThrow(
+      "--tunnel does not take a value"
+    );
+  });
+
+  it("rejects a value on the remaining boolean switches", () => {
+    const cases: readonly string[] = [
+      "--no-open",
+      "--no-inspector",
+      "--with-inspector",
+      "--source-maps",
+      "--inline",
+      "--help",
+      "--version",
+    ];
+    for (const flag of cases) {
+      expect(() => parseArgs(["dev", `${flag}=false`])).toThrow(
+        `${flag} does not take a value`
+      );
+    }
+  });
+
+  it("still accepts boolean switches in bare form", () => {
+    expect(parseArgs(["dev", "--tunnel"]).tunnel).toBe(true);
+    expect(parseArgs(["dev", "--no-open"]).open).toBe(false);
+    expect(parseArgs(["dev", "--no-inspector"]).inspector).toBe(false);
+    expect(parseArgs(["dev", "--with-inspector"]).inspector).toBe(true);
+    expect(parseArgs(["build", "--source-maps"]).sourceMaps).toBe(true);
+    expect(parseArgs(["build", "--inline"]).inline).toBe(true);
+    expect(parseArgs(["dev", "--help"]).help).toBe(true);
+    expect(parseArgs(["dev", "--version"]).version).toBe(true);
+  });
+
+  it("still accepts inline values on flags that take one", () => {
+    expect(parseArgs(["start", "--port=8080"]).port).toBe(8080);
+    expect(parseArgs(["dev", "--host=0.0.0.0"]).host).toBe("0.0.0.0");
+    expect(parseArgs(["dev", "--path=./project"]).path).toBe("./project");
+    expect(parseArgs(["dev", "--entry=src/server.ts"]).entry).toBe(
+      "src/server.ts"
+    );
+    expect(parseArgs(["dev", "--mcp-dir=src/mcp"]).mcpDir).toBe("src/mcp");
+    expect(parseArgs(["dev", "--views-dir=src/views"]).viewsDir).toBe(
+      "src/views"
+    );
+  });
+
+  it("leaves an `=` inside a positional or a passthrough argument alone", () => {
+    expect(parseArgs(["dev=weird"]).command).toBe("dev=weird");
+    expect(
+      parseArgs(["typecheck", "--", "--extendedDiagnostics=false"]).passthrough
+    ).toEqual(["--extendedDiagnostics=false"]);
+  });
+
+  it("keeps reporting an unknown flag ahead of its inline value", () => {
+    expect(() => parseArgs(["dev", "--frobnicate=1"])).toThrow(
+      "Unknown option: --frobnicate"
+    );
+  });
+});


### PR DESCRIPTION
Fixes #2520

# Pull Request Description

## Language / Project Scope

- [x] TypeScript
- [ ] Python
- [ ] Documentation only
- [ ] CI/CD or tooling

## Changes

`parseArgs` split `--flag=value` for every `--`-prefixed token but the boolean cases never read the inline value, so `mcp-use dev --tunnel=false` parsed as `--tunnel` and opened a public tunnel — the inverse of what was asked, with no diagnostic. Boolean switches now reject an inline value.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. `takeValue` sets `inlineConsumed` when it reads the inline value.
2. After the switch, an unconsumed inline value throws `` `${flag} does not take a value` ``. Only the boolean cases can reach that, because they never call `takeValue`.
3. Docstring updated to state that boolean switches take no value, and to list the new throw.

No behaviour change for bare booleans, for `--flag value`, or for `--flag=value` on value-taking flags. No dependencies added or modified.

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [x] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [x] Ran `pnpm build` and build succeeds without errors
- [x] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [x] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

---

## Example Usage (Before)

```bash
$ mcp-use dev --tunnel=false
# `false` is discarded, the tunnel opens anyway:
mcp-use public MCP URL: https://<subdomain>.local.mcp-use.run/mcp
```

## Example Usage (After)

```bash
$ mcp-use dev --tunnel=false
--tunnel does not take a value

# omit the flag to run without a tunnel
$ mcp-use dev
```

## Documentation Updates

None. The behaviour change is described in the `parseArgs` TSDoc, which is where the `--flag=value` support was documented.

## Testing

New test file `libraries/typescript/packages/cli/tests/bin-args-boolean-values.test.ts`, 6 cases:

- `--tunnel=false` and `--tunnel=true` are rejected
- a value is rejected on `--no-open`, `--no-inspector`, `--with-inspector`, `--source-maps`, `--inline`, `--help`, `--version`
- bare boolean switches still parse as before
- inline values still work on `--port`, `--host`, `--path`, `--entry`, `--mcp-dir`, `--views-dir`
- an `=` inside a positional or after `--` is left alone
- an unknown flag is still reported ahead of its inline value

Commands run:

```bash
cd libraries/typescript
pnpm --filter @mcp-use/cli exec vitest run tests/bin-args-boolean-values.test.ts
pnpm --filter @mcp-use/cli exec vitest run
pnpm build && pnpm lint && pnpm format:check
```

Results: the new file is 6 passed, and 2 of those cases fail against unmodified `args.ts`, so the test does pin the regression. `pnpm build`, `pnpm lint` and `pnpm format:check` are clean.

The full `cli` suite is 301 passed, 1 failed. The failure is `tests/cli/dev.test.ts > runDev (views) > discards a candidate superseded while its server entry is evaluating`, which is unrelated to this change: it passes in isolation both with and without the patch, it never calls `parseArgs`, and `src/cli/dev.ts` imports only `resolveHost` and `resolvePort` from `bin/args.js`. It looks like the load-dependent `dev` flake previously discussed in #2273.

Also noticed while running the suite, and deliberately left out of this PR: `packages/cli/tests/cli/.tmp/` is not gitignored and holds unformatted generated fixtures, so `pnpm format:check` fails locally after any `cli` test run until the directory is removed. Happy to open a separate issue for that.

## Backwards Compatibility

Technically breaking for anyone passing `=value` to a boolean flag today, but that invocation currently does the opposite of what it says, so the affected scripts are already misbehaving. Shipped as a `patch` changeset for `@mcp-use/cli`; happy to relabel if you would rather treat it as a minor.

## Related Issues

Closes #2520

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`@mcp-use/cli` boolean flags now reject an inline `=value` instead of silently discarding it, so `--tunnel=false` fails rather than opening a public tunnel.

- Previously `parseArgs` split `--flag=value` for every `--` token, but boolean cases never read the inline value, so `--tunnel=false` parsed as `--tunnel` and opened a public tunnel.
- The parser now throws `--tunnel does not take a value` for all boolean switches, including `--no-open`, `--no-inspector`, `--with-inspector`, `--source-maps`, `--inline`, `--help`, and `--version`.
- Bare booleans, `--flag value`, and `--flag=value` on value-taking flags are unchanged.
- Adds a regression test for the rejected inline value in the existing `parseArgs` suite.
- Shipped as a `minor` changeset since it breaks previously accepted invocations.
- Closes #2520.

<sup>Written for commit 0fe7a35f601b6f47207eae17fa736a343a737925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

