### PR TITLE
fix(cli): ignore the CLI test scratch fixture root

### DIFF
--- a/libraries/typescript/.gitignore
+++ b/libraries/typescript/.gitignore
@@ -72,3 +72,6 @@ test_app
 # Deno test artifacts
 deno-test-temp
 *.tgz
+
+# Scratch fixture copies made by the CLI tests
+.tmp

--- a/libraries/typescript/.prettierignore
+++ b/libraries/typescript/.prettierignore
@@ -13,6 +13,7 @@
 **/.tsup/**
 **/.vite/**
 **/.mcp-use/**
+**/.tmp/**
 **/playwright-report/**
 **/src/skills/vendor/*.min.js
 


### PR DESCRIPTION
Fixes #2523

# Pull Request Description

## Language / Project Scope

- [ ] TypeScript
- [ ] Python
- [ ] Documentation only
- [x] CI/CD or tooling

## Changes

`tests/cli/helpers.ts` copies fixtures into `tests/cli/.tmp`, and `removeDir` is best-effort by design. When a copy survives — a failed or interrupted `dev` test, or Vite still holding files — it became an untracked, Prettier-checked source file, because `.tmp` was in neither `.gitignore` nor `.prettierignore`. `pnpm format:check` then failed on generated fixtures until the directory was removed by hand.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. `libraries/typescript/.gitignore` — added `.tmp`, next to the existing `deno-test-temp` and `*.tgz` test-artifact entries.
2. `libraries/typescript/.prettierignore` — added `**/.tmp/**`, alongside the existing `**/.turbo/**`, `**/.vite/**` and `**/.mcp-use/**` globs.

Two lines plus comments. No source, test, or dependency changes, and no changeset, since nothing user-facing in a published package changes.

I did not harden `removeDir`: an interrupted run (Ctrl-C, crash) never reaches teardown, so the ignore entries are the reliable fix. Happy to add cleanup hardening on top if you would like both.

---

## TypeScript Checklist

### Packages Modified

- [ ] `docs`
- [x] `tests`
- [x] `cli`
- [ ] `create-mcp-use-app`
- [ ] `mcp-use` (server)
- [ ] `mcp-use` (client)
- [ ] `inspector`

### Pre-commit Checklist

- [x] Ran `pnpm lint:fix` to auto-fix linting issues
- [x] Ran `pnpm format` to format code with Prettier
- [ ] Ran `pnpm build` and build succeeds without errors
- [ ] Ran `pnpm changeset` to create a changeset (if this PR includes user-facing changes)
- [ ] Added or updated tests if needed
- [ ] Updated documentation in `docs/` folder if needed

`pnpm build` is not meaningful for two ignore-file entries, and no changeset is included because no published package behaviour changes. Say the word if you would rather have one anyway.

## Example Usage (Before)

```bash
# after a cli dev test failed and left a scratch copy behind
$ git status --short
?? libraries/typescript/packages/cli/tests/cli/.tmp/

$ pnpm format:check
[warn] packages/cli/tests/cli/.tmp/dev-demo-aabbccdd/src/index.ts
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
[ELIFECYCLE] Command failed with exit code 1.
```

## Example Usage (After)

```bash
$ git check-ignore -v libraries/typescript/packages/cli/tests/cli/.tmp
libraries/typescript/.gitignore:77:.tmp   libraries/typescript/packages/cli/tests/cli/.tmp

$ git status --short
(clean)

$ pnpm format:check
All matched files use Prettier code style!
```

## Documentation Updates

None.

## Testing

Reproduced on `main` at `2ef6367` by recreating the leftover state the tests produce — a fixture copy under `tests/cli/.tmp` with a rewritten `src/index.ts`, which is what `bindBasicToolToView` does:

- Before the change: `git check-ignore` did not match, `git status` showed `?? .../.tmp/`, and `pnpm format:check` exited 1 on the generated file.
- After the change: `git check-ignore` resolves via `.gitignore:77`, `git status` is clean, `pnpm format:check` reports all files formatted.

Also ran `pnpm lint` (clean) and the full CLI suite, `pnpm --filter @mcp-use/cli exec vitest run` — 302 passed across 24 files, confirming the ignore entries do not hide any fixture the tests rely on.

I originally hit this organically: a full `cli` suite run left three `dev-*` copies behind and the next `format:check` failed on all three.

Worth stating plainly: **CI was never broken by this.** `format:check` runs in `typescript-lint` and the test jobs declare `needs: typescript-lint`, so CI checks formatting before any test can create a leftover. This is a local-contributor papercut, which is why it is scoped as tooling.

## Backwards Compatibility

Fully backwards compatible. Ignore rules only, no runtime or published behaviour affected.

## Related Issues

Closes #2523

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops CLI test scratch copies in `tests/cli/.tmp` from breaking `pnpm format:check` or showing as untracked files after a failed or interrupted test. Adds the directory to `.gitignore`, `.prettierignore`, and `eslint.config.js` so leftovers are ignored by git, Prettier, and ESLint.

<sup>Written for commit ef4e50f4aa07c86f1e2189086261bdc10019d457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

