### PR TITLE
chore(cli): ignore the CLI test scratch root

### DIFF
--- a/libraries/typescript/.gitignore
+++ b/libraries/typescript/.gitignore
@@ -72,3 +72,6 @@ test_app
 # Deno test artifacts
 deno-test-temp
 *.tgz
+
+# CLI test scratch copies (packages/cli/tests/cli/helpers.ts TMP_ROOT)
+packages/cli/tests/cli/.tmp/

--- a/libraries/typescript/.prettierignore
+++ b/libraries/typescript/.prettierignore
@@ -13,6 +13,7 @@
 **/.tsup/**
 **/.vite/**
 **/.mcp-use/**
+**/packages/cli/tests/cli/.tmp/**
 **/playwright-report/**
 **/src/skills/vendor/*.min.js
 


### PR DESCRIPTION
# Pull Request Description

## Language / Project Scope

Check all that apply:
- [ ] TypeScript
- [ ] Python
- [ ] Documentation only
- [x] CI/CD or tooling

## Changes

Closes #2523.

`packages/cli/tests/cli/helpers.ts` copies fixtures into `TMP_ROOT = tests/cli/.tmp` and removes them best effort, swallowing failures. That directory was in neither `libraries/typescript/.gitignore` nor `libraries/typescript/.prettierignore`, so a scratch copy that survives an interrupted or failed run becomes an untracked, prettier-checked source file: `git status` lists generated fixtures (each with a `node_modules/mcp-use` symlink), and `pnpm format:check` fails on files nobody wrote.

This adds the scratch root to both ignore files, next to the other generated paths (`deno-test-temp`, `.mcp-use`, `dist/`). The path is spelled out rather than a bare `.tmp` so only this directory is covered.

## Review Readiness

- [x] The PR is scoped to one issue or one clearly related change
- [x] The PR description explains the user-visible problem and the fix
- [x] The diff avoids unrelated formatting, generated files, and bulk rewrites
- [x] I verified the affected package/docs path with the commands listed below
- [x] I checked for existing open PRs that already solve the same issue

## Implementation Details

1. `libraries/typescript/.gitignore`: `packages/cli/tests/cli/.tmp/`, with a comment pointing at the helper that creates it.
2. `libraries/typescript/.prettierignore`: `**/packages/cli/tests/cli/.tmp/**`, next to the other build and generated entries.
3. No test or source change: the helper keeps its best-effort cleanup, which is correct while Vite may still hold files. This only stops the leftovers from being treated as sources.

## Verification

With a leftover scratch copy simulated at `packages/cli/tests/cli/.tmp/dev-demo-aabbccdd/index.ts`:

```
$ git check-ignore -v libraries/typescript/packages/cli/tests/cli/.tmp/dev-demo-aabbccdd/index.ts
libraries/typescript/.gitignore:77:packages/cli/tests/cli/.tmp/    ...
$ git status --short          # only the two ignore files, no untracked fixtures

# prettier, from libraries/typescript:
$ prettier --ignore-path /dev/null --check <that file>     # baseline
[warn] packages/cli/tests/cli/.tmp/dev-demo-aabbccdd/index.ts
$ prettier --ignore-path .prettierignore --check <that file>   # this PR
All matched files use Prettier code style!
```

Reverting only `.prettierignore` brings the warning back, so the entry is what excludes it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents leftover CLI test scratch copies from polluting the repo: interrupted runs left untracked fixtures in `packages/cli/tests/cli/.tmp` that broke `git status` and `prettier --check`. Adds that path to both ignore files; no test or source changes. Closes #2523.

<sup>Written for commit 964d90bf08ca5e0f237c2fd2afe67fdf31f7de17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

