### PR TITLE
fix(typescript): parse CRLF changesets in release tooling

### DIFF
--- a/libraries/typescript/.changeset/calm-crabs-handle-crlf.md
+++ b/libraries/typescript/.changeset/calm-crabs-handle-crlf.md
@@ -1,0 +1,5 @@
+---
+"mcp-use": patch
+---
+
+Handle CRLF line endings when release-channel tooling parses pending changesets.

--- a/libraries/typescript/scripts/release-channel.mjs
+++ b/libraries/typescript/scripts/release-channel.mjs
@@ -113,7 +113,7 @@ function releasesForChangesets(ids) {
     const contents = readFileSync(
       join(workspaceRoot, ".changeset", `${id}.md`),
       "utf8"
-    );
+    ).replaceAll("\r\n", "\n");
     const frontmatter = contents.match(/^---\n([\s\S]*?)\n---/u)?.[1] ?? "";
     for (const line of frontmatter.split("\n")) {
       const match = line.match(

--- a/libraries/typescript/scripts/release-channel.test.mjs
+++ b/libraries/typescript/scripts/release-channel.test.mjs
@@ -60,13 +60,19 @@ function run(root, registryFile, ...args) {
   );
 }
 
-function writeChangeset(root, id, releases, summary = "Test change.") {
+function writeChangeset(
+  root,
+  id,
+  releases,
+  summary = "Test change.",
+  lineEnding = "\n"
+) {
   const frontmatter = releases
     .map(({ name, type }) => `"${name}": ${type}`)
-    .join("\n");
+    .join(lineEnding);
   writeFileSync(
     join(root, ".changeset", `${id}.md`),
-    `---\n${frontmatter}\n---\n\n${summary}\n`
+    `---${lineEnding}${frontmatter}${lineEnding}---${lineEnding}${lineEnding}${summary}${lineEnding}`
   );
 }
 
@@ -255,85 +261,117 @@ test("ignores changesets already applied in prerelease mode", () => {
   assert.equal(result.stdout.trim(), "");
 });
 
-test("prepares internal peer ranges for pending Canary changes", () => {
+test("prepares internal peer ranges for LF and CRLF changesets", () => {
+  for (const lineEnding of ["\n", "\r\n"]) {
+    const { root, registryFile } = fixture({
+      localVersion: "2.0.4",
+      latest: "2.0.4",
+      canary: "2.0.5-canary.6",
+      published: ["2.0.4", "2.0.5-canary.6"],
+    });
+    mkdirSync(join(root, "packages", "client"), { recursive: true });
+    mkdirSync(join(root, "packages", "agent"), { recursive: true });
+    mkdirSync(join(root, "packages", "inspector"), { recursive: true });
+    writeFileSync(
+      join(root, "packages", "client", "package.json"),
+      JSON.stringify({
+        name: "@mcp-use/client",
+        version: "2.0.1",
+        peerDependencies: { "mcp-use": "workspace:*" },
+      })
+    );
+    writeFileSync(
+      join(root, "packages", "server", "package.json"),
+      JSON.stringify({
+        name: "mcp-use",
+        version: "2.0.5-canary.6",
+        peerDependencies: { "@mcp-use/client": "^2.0.1" },
+      })
+    );
+    writeFileSync(
+      join(root, "packages", "agent", "package.json"),
+      JSON.stringify({ name: "@mcp-use/agent", version: "2.0.2-canary.4" })
+    );
+    writeFileSync(
+      join(root, "packages", "inspector", "package.json"),
+      JSON.stringify({
+        name: "@mcp-use/inspector",
+        version: "20.0.5-canary.6",
+        peerDependencies: { "@mcp-use/agent": "^2.0.1" },
+      })
+    );
+    writeChangeset(
+      root,
+      "skills",
+      [
+        { name: "@mcp-use/agent", type: "patch" },
+        { name: "@mcp-use/client", type: "minor" },
+        { name: "mcp-use", type: "minor" },
+      ],
+      "Test change.",
+      lineEnding
+    );
+    writePreState(root, {
+      "@mcp-use/agent": "2.0.1",
+      "@mcp-use/client": "2.0.1",
+      "@mcp-use/inspector": "20.0.4",
+      "mcp-use": "2.0.4",
+    });
+
+    const result = run(root, registryFile, "prepare", "--channel", "canary");
+    assert.equal(result.status, 0, result.stderr);
+    const server = JSON.parse(
+      readFileSync(join(root, "packages", "server", "package.json"), "utf8")
+    );
+    assert.equal(
+      server.peerDependencies["@mcp-use/client"],
+      "^2.0.1 || ^2.1.0-canary.0"
+    );
+    const client = JSON.parse(
+      readFileSync(join(root, "packages", "client", "package.json"), "utf8")
+    );
+    assert.equal(
+      client.peerDependencies["mcp-use"],
+      "^2.0.4 || ^2.0.5-canary.0 || ^2.1.0-canary.0"
+    );
+    const inspector = JSON.parse(
+      readFileSync(join(root, "packages", "inspector", "package.json"), "utf8")
+    );
+    assert.equal(
+      inspector.peerDependencies["@mcp-use/agent"],
+      "^2.0.1 || ^2.0.2-canary.0"
+    );
+
+    const repeated = run(root, registryFile, "prepare", "--channel", "canary");
+    assert.equal(repeated.status, 0, repeated.stderr);
+    assert.equal(
+      readFileSync(join(root, "packages", "client", "package.json"), "utf8"),
+      `${JSON.stringify(client, null, 2)}\n`
+    );
+  }
+});
+
+test("checks Canary baselines for packages in CRLF changesets", () => {
   const { root, registryFile } = fixture({
-    localVersion: "2.0.4",
-    latest: "2.0.4",
-    canary: "2.0.5-canary.6",
-    published: ["2.0.4", "2.0.5-canary.6"],
+    localVersion: "2.0.5-canary.0",
+    latest: "2.0.5",
+    canary: "2.0.5-canary.0",
+    published: ["2.0.4", "2.0.5", "2.0.5-canary.0"],
   });
-  mkdirSync(join(root, "packages", "client"), { recursive: true });
-  mkdirSync(join(root, "packages", "agent"), { recursive: true });
-  mkdirSync(join(root, "packages", "inspector"), { recursive: true });
-  writeFileSync(
-    join(root, "packages", "client", "package.json"),
-    JSON.stringify({
-      name: "@mcp-use/client",
-      version: "2.0.1",
-      peerDependencies: { "mcp-use": "workspace:*" },
-    })
+  writeChangeset(
+    root,
+    "windows-change",
+    [{ name: "mcp-use", type: "patch" }],
+    "Windows-authored change.",
+    "\r\n"
   );
-  writeFileSync(
-    join(root, "packages", "server", "package.json"),
-    JSON.stringify({
-      name: "mcp-use",
-      version: "2.0.5-canary.6",
-      peerDependencies: { "@mcp-use/client": "^2.0.1" },
-    })
-  );
-  writeFileSync(
-    join(root, "packages", "agent", "package.json"),
-    JSON.stringify({ name: "@mcp-use/agent", version: "2.0.2-canary.4" })
-  );
-  writeFileSync(
-    join(root, "packages", "inspector", "package.json"),
-    JSON.stringify({
-      name: "@mcp-use/inspector",
-      version: "20.0.5-canary.6",
-      peerDependencies: { "@mcp-use/agent": "^2.0.1" },
-    })
-  );
-  writeChangeset(root, "skills", [
-    { name: "@mcp-use/agent", type: "patch" },
-    { name: "@mcp-use/client", type: "minor" },
-    { name: "mcp-use", type: "minor" },
-  ]);
-  writePreState(root, {
-    "@mcp-use/agent": "2.0.1",
-    "@mcp-use/client": "2.0.1",
-    "@mcp-use/inspector": "20.0.4",
-    "mcp-use": "2.0.4",
-  });
+  writePreState(root, { "mcp-use": "2.0.4" });
 
-  const result = run(root, registryFile, "prepare", "--channel", "canary");
-  assert.equal(result.status, 0, result.stderr);
-  const server = JSON.parse(
-    readFileSync(join(root, "packages", "server", "package.json"), "utf8")
-  );
-  assert.equal(
-    server.peerDependencies["@mcp-use/client"],
-    "^2.0.1 || ^2.1.0-canary.0"
-  );
-  const client = JSON.parse(
-    readFileSync(join(root, "packages", "client", "package.json"), "utf8")
-  );
-  assert.equal(
-    client.peerDependencies["mcp-use"],
-    "^2.0.4 || ^2.0.5-canary.0 || ^2.1.0-canary.0"
-  );
-  const inspector = JSON.parse(
-    readFileSync(join(root, "packages", "inspector", "package.json"), "utf8")
-  );
-  assert.equal(
-    inspector.peerDependencies["@mcp-use/agent"],
-    "^2.0.1 || ^2.0.2-canary.0"
-  );
-
-  const repeated = run(root, registryFile, "prepare", "--channel", "canary");
-  assert.equal(repeated.status, 0, repeated.stderr);
-  assert.equal(
-    readFileSync(join(root, "packages", "client", "package.json"), "utf8"),
-    `${JSON.stringify(client, null, 2)}\n`
+  const result = run(root, registryFile, "preflight", "--channel", "canary");
+  assert.notEqual(result.status, 0);
+  assert.match(
+    result.stderr,
+    /mcp-use canary baseline: 2\.0\.4 is below npm latest 2\.0\.5/u
   );
 });
 


### PR DESCRIPTION
## Summary

- normalize CRLF line endings before parsing changeset frontmatter
- exercise internal peer-range preparation with both LF and CRLF changesets
- add a regression test proving CRLF changesets participate in Canary baseline preflight
- include the required TypeScript changeset

The change stays at the local parsing boundary and does not alter release publication or workflow gates.

## Validation

- `pnpm test:release-channel` — 25 passed
- `pnpm exec prettier --check scripts/release-channel.mjs scripts/release-channel.test.mjs .changeset/calm-crabs-handle-crlf.md`
- `pnpm exec eslint scripts/release-channel.mjs scripts/release-channel.test.mjs`
- pre-commit checks passed

Closes #2527

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes release tooling so it recognizes changesets with CRLF line endings, which previously caused Windows-authored changes to be missed during Canary baseline checks.

- Normalizes CRLF to LF before parsing changeset frontmatter in `release-channel.mjs`.
- Adds tests covering internal peer-range prep and Canary baseline preflight for both LF and CRLF changesets.
- Includes a patch changeset for `mcp-use`.

Closes #2527.

<sup>Written for commit cc92e78626ff63c899cc8f5e04865d2acfb92097. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

