### PR TITLE
fix(client): propagate SSE progress observer cancellation

### DIFF
--- a/libraries/typescript/.changeset/silent-sse-cancellation.md
+++ b/libraries/typescript/.changeset/silent-sse-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Propagate cancellation of observed SSE responses to the upstream HTTP stream.

--- a/libraries/typescript/packages/client/src/transport/http.ts
+++ b/libraries/typescript/packages/client/src/transport/http.ts
@@ -577,8 +577,8 @@ export class HttpConnector extends BaseConnector {
   }
 
   /**
-   * Tee an SSE response so v2 MRTR progress can be correlated even when the
-   * upstream SDK does not carry the original callback to retry request IDs.
+   * Observe SSE progress while preserving a single cancellation path to the
+   * upstream response body. The upstream SDK remains the only consumer.
    */
   private observeSseProgress(response: Response): Response {
     if (
@@ -587,44 +587,33 @@ export class HttpConnector extends BaseConnector {
     ) {
       return response;
     }
-    const [body, observed] = response.body.tee();
-    void (async () => {
-      const reader = observed.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const events = buffer.split(/\r?\n\r?\n/);
-          buffer = events.pop() ?? "";
-          for (const event of events) {
-            for (const line of event.split(/\r?\n/)) {
-              if (!line.startsWith("data:")) continue;
-              try {
-                const message = JSON.parse(line.slice(5).trim()) as {
-                  method?: string;
-                  params?: unknown;
-                };
-                if (message.method === "notifications/progress") {
-                  this.forwardRoundProgress(message.params);
-                }
-              } catch {
-                // Ignore malformed/non-JSON SSE data; the SDK remains authoritative.
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const observer = new TransformStream<Uint8Array, Uint8Array>({
+      transform: (chunk, controller) => {
+        buffer += decoder.decode(chunk, { stream: true });
+        const events = buffer.split(/\r?\n\r?\n/);
+        buffer = events.pop() ?? "";
+        for (const event of events) {
+          for (const line of event.split(/\r?\n/)) {
+            if (!line.startsWith("data:")) continue;
+            try {
+              const message = JSON.parse(line.slice(5).trim()) as {
+                method?: string;
+                params?: unknown;
+              };
+              if (message.method === "notifications/progress") {
+                this.forwardRoundProgress(message.params);
               }
+            } catch {
+              // Ignore malformed/non-JSON SSE data; the SDK remains authoritative.
             }
           }
         }
-      } catch (error) {
-        if (!(error instanceof DOMException && error.name === "AbortError")) {
-          logger.debug("Progress observer stream ended:", error);
-        }
-      } finally {
-        reader.releaseLock();
-      }
-    })();
-    return new Response(body, {
+        controller.enqueue(chunk);
+      },
+    });
+    return new Response(response.body.pipeThrough(observer), {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,

--- a/libraries/typescript/packages/client/tests/unit/transport/http-lifecycle.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/transport/http-lifecycle.test.ts
@@ -108,6 +108,37 @@ async function fixture() {
 }
 
 describe("HTTP lifecycle with a real legacy MCP session", () => {
+  it("propagates cancellation of an observed SSE response to its source", async () => {
+    const connector = new HttpConnector("http://127.0.0.1:1/mcp", {
+      protocolNegotiation: "legacy",
+    });
+    let cancelReason: unknown;
+    let resolveCancelled: () => void;
+    const cancelled = new Promise<void>((resolve) => {
+      resolveCancelled = resolve;
+    });
+    const source = new ReadableStream<Uint8Array>({
+      cancel(reason) {
+        cancelReason = reason;
+        resolveCancelled();
+      },
+    });
+    const response = new Response(source, {
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const observed = (
+      connector as unknown as {
+        observeSseProgress(response: Response): Response;
+      }
+    ).observeSseProgress(response);
+    const reason = new Error("consumer cancelled");
+    await observed.body?.cancel(reason);
+    await cancelled;
+
+    expect(cancelReason).toBe(reason);
+  });
+
   it("shares one session across concurrent connects and closes its stream on disconnect", async () => {
     const server = await fixture();
     const { connector } = server;

--- a/libraries/typescript/packages/client/tests/unit/transport/http-lifecycle.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/transport/http-lifecycle.test.ts
@@ -134,7 +134,22 @@ describe("HTTP lifecycle with a real legacy MCP session", () => {
     ).observeSseProgress(response);
     const reason = new Error("consumer cancelled");
     await observed.body?.cancel(reason);
-    await cancelled;
+    let cancellationTimeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        cancelled,
+        new Promise<never>((_, reject) => {
+          cancellationTimeout = setTimeout(
+            () => reject(new Error("source cancellation was not propagated")),
+            1_000
+          );
+        }),
+      ]);
+    } finally {
+      if (cancellationTimeout) {
+        clearTimeout(cancellationTimeout);
+      }
+    }
 
     expect(cancelReason).toBe(reason);
   });


### PR DESCRIPTION
## Summary

Closes #2506.

- replace the detached `ReadableStream.tee()` observer with an inline `TransformStream` pass-through
- retain the existing incremental SSE progress parsing and non-JSON tolerance
- add a cancellation-injection regression test proving cancellation of the SDK-facing body reaches the original response stream

## Design

`tee()` requires both branches to finish or cancel before it cancels its source. The previous observer branch could remain blocked in `reader.read()` after the caller canceled the returned response. `pipeThrough()` keeps one consumer-facing branch, so consumer cancellation propagates to the original HTTP body without a detached reader or duplicate stream queue.

The observer remains intentionally excluded for `subscriptions/listen`, whose SDK lifecycle owns its SSE reader and acknowledgement state. No protocol parsing or progress callback semantics are changed.

## Validation

```text
cd libraries/typescript
corepack pnpm --filter @mcp-use/client test:run
# 61 files / 374 tests passed
corepack pnpm --filter @mcp-use/client build
corepack pnpm exec prettier --check packages/client/src/transport/http.ts packages/client/tests/unit/transport/http-lifecycle.test.ts .changeset/silent-sse-cancellation.md
corepack pnpm exec eslint packages/client/src/transport/http.ts packages/client/tests/unit/transport/http-lifecycle.test.ts
git diff --check
```

## Risk boundary

This only changes ordinary `text/event-stream` responses wrapped by `HttpConnector`. The progress parser still forwards complete `data:` events and ignores malformed payloads. The local Node is 22.16.0 while the repo declares >=22.22.2; the focused and package suites passed, and CI will run the supported version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates cancellation of observed SSE responses to the upstream HTTP stream. Previously the detached `tee()` observer branch could stay blocked in `reader.read()` after the caller canceled the returned response; the inline `TransformStream` keeps a single consumer-facing branch so cancellation reaches the original HTTP body.

- Preserves existing incremental SSE progress parsing and non-JSON tolerance.
- Leaves `subscriptions/listen` excluded since its SDK lifecycle owns the SSE reader and acknowledgement state.
- Adds a regression test that cancels an observed response and asserts the source stream receives the same cancellation reason, failing fast if propagation stalls.

<sup>Written for commit 45985fb8faeea731ca2c76e171d754c99e3b3e08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

