### PR TITLE
fix(client): propagate SSE observer cancellation

### DIFF
--- a/libraries/typescript/.changeset/silent-sse-cancellation.md
+++ b/libraries/typescript/.changeset/silent-sse-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@mcp-use/client": patch
+---
+
+Propagate cancellation of observed SSE responses to the upstream HTTP stream.

--- a/libraries/typescript/packages/client/src/transport/http.ts
+++ b/libraries/typescript/packages/client/src/transport/http.ts
@@ -577,8 +577,8 @@ export class HttpConnector extends BaseConnector {
   }
 
   /**
-   * Tee an SSE response so v2 MRTR progress can be correlated even when the
-   * upstream SDK does not carry the original callback to retry request IDs.
+   * Observe SSE progress while preserving a single cancellation path to the
+   * upstream response body. The upstream SDK remains the only consumer.
    */
   private observeSseProgress(response: Response): Response {
     if (
@@ -587,44 +587,33 @@ export class HttpConnector extends BaseConnector {
     ) {
       return response;
     }
-    const [body, observed] = response.body.tee();
-    void (async () => {
-      const reader = observed.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const events = buffer.split(/\r?\n\r?\n/);
-          buffer = events.pop() ?? "";
-          for (const event of events) {
-            for (const line of event.split(/\r?\n/)) {
-              if (!line.startsWith("data:")) continue;
-              try {
-                const message = JSON.parse(line.slice(5).trim()) as {
-                  method?: string;
-                  params?: unknown;
-                };
-                if (message.method === "notifications/progress") {
-                  this.forwardRoundProgress(message.params);
-                }
-              } catch {
-                // Ignore malformed/non-JSON SSE data; the SDK remains authoritative.
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const observer = new TransformStream<Uint8Array, Uint8Array>({
+      transform: (chunk, controller) => {
+        buffer += decoder.decode(chunk, { stream: true });
+        const events = buffer.split(/\r?\n\r?\n/);
+        buffer = events.pop() ?? "";
+        for (const event of events) {
+          for (const line of event.split(/\r?\n/)) {
+            if (!line.startsWith("data:")) continue;
+            try {
+              const message = JSON.parse(line.slice(5).trim()) as {
+                method?: string;
+                params?: unknown;
+              };
+              if (message.method === "notifications/progress") {
+                this.forwardRoundProgress(message.params);
               }
+            } catch {
+              // Ignore malformed/non-JSON SSE data; the SDK remains authoritative.
             }
           }
         }
-      } catch (error) {
-        if (!(error instanceof DOMException && error.name === "AbortError")) {
-          logger.debug("Progress observer stream ended:", error);
-        }
-      } finally {
-        reader.releaseLock();
-      }
-    })();
-    return new Response(body, {
+        controller.enqueue(chunk);
+      },
+    });
+    return new Response(response.body.pipeThrough(observer), {
       status: response.status,
       statusText: response.statusText,
       headers: response.headers,

--- a/libraries/typescript/packages/client/tests/unit/transport/http-lifecycle.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/transport/http-lifecycle.test.ts
@@ -108,6 +108,37 @@ async function fixture() {
 }
 
 describe("HTTP lifecycle with a real legacy MCP session", () => {
+  it("propagates cancellation of an observed SSE response to its source", async () => {
+    const connector = new HttpConnector("http://127.0.0.1:1/mcp", {
+      protocolNegotiation: "legacy",
+    });
+    let cancelReason: unknown;
+    let resolveCancelled: () => void;
+    const cancelled = new Promise<void>((resolve) => {
+      resolveCancelled = resolve;
+    });
+    const source = new ReadableStream<Uint8Array>({
+      cancel(reason) {
+        cancelReason = reason;
+        resolveCancelled();
+      },
+    });
+    const response = new Response(source, {
+      headers: { "content-type": "text/event-stream" },
+    });
+
+    const observed = (
+      connector as unknown as {
+        observeSseProgress(response: Response): Response;
+      }
+    ).observeSseProgress(response);
+    const reason = new Error("consumer cancelled");
+    await observed.body?.cancel(reason);
+    await cancelled;
+
+    expect(cancelReason).toBe(reason);
+  });
+
   it("shares one session across concurrent connects and closes its stream on disconnect", async () => {
     const server = await fixture();
     const { connector } = server;

--- a/libraries/typescript/packages/client/tests/unit/transport/http-lifecycle.test.ts
+++ b/libraries/typescript/packages/client/tests/unit/transport/http-lifecycle.test.ts
@@ -134,7 +134,22 @@ describe("HTTP lifecycle with a real legacy MCP session", () => {
     ).observeSseProgress(response);
     const reason = new Error("consumer cancelled");
     await observed.body?.cancel(reason);
-    await cancelled;
+    let cancellationTimeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        cancelled,
+        new Promise<never>((_, reject) => {
+          cancellationTimeout = setTimeout(
+            () => reject(new Error("source cancellation was not propagated")),
+            1_000
+          );
+        }),
+      ]);
+    } finally {
+      if (cancellationTimeout) {
+        clearTimeout(cancellationTimeout);
+      }
+    }
 
     expect(cancelReason).toBe(reason);
   });


### PR DESCRIPTION
## Summary

Fixes #2506.

`HttpConnector.observeSseProgress` previously used `ReadableStream.tee()`: the SDK consumed one branch while a detached observer consumed the other. Cancelling the SDK branch could leave the source response open until the observer completed, retaining an HTTP socket.

The observer is now an inline `TransformStream`. It forwards progress notifications while the SDK remains the single downstream consumer, so cancellation propagates back to the original response body.

## Design / boundary

- Reuses the existing SSE parsing and progress forwarding logic; no protocol behavior changes.
- Applies only to ordinary request/response SSE. `subscriptions/listen` remains untouched because the SDK owns its stream hooks and acknowledgement state.
- The regression test creates a source stream whose `cancel()` records the reason, then fails after one second if cancellation is not propagated.

## Validation

- `pnpm --filter @mcp-use/client test -- tests/unit/transport/http-lifecycle.test.ts` — 61 files / 374 tests passed
- `pnpm exec eslint packages/client/src/transport/http.ts packages/client/tests/unit/transport/http-lifecycle.test.ts`
- `pnpm --filter @mcp-use/client build`
- `pnpm exec prettier --check packages/client/src/transport/http.ts packages/client/tests/unit/transport/http-lifecycle.test.ts .changeset/silent-sse-cancellation.md`
- `git diff --check origin/main...HEAD`

The local Node version is 22.16.0 while the workspace declares `>=22.22.2`; the focused suite and build nevertheless completed successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2506 by changing `observeSseProgress` so cancelling an observed SSE response now closes the source HTTP stream. Previously the method used `ReadableStream.tee()`, which left the source response open until the detached observer finished; it now uses an inline `TransformStream`, keeping the SDK as the single downstream consumer so cancellation propagates upstream.

**Bug Fixes**
- Forwards progress inside `queueMicrotask` so observation stays off the transport's backpressure path, and a throwing progress handler no longer breaks response delivery.
- The change is limited to ordinary request/response SSE; `subscriptions/listen` is untouched because the SDK owns its stream hooks and acknowledgement state.
- Adds regression tests that assert source cancellation propagation, byte-for-byte SSE progress forwarding, and readable bytes when a progress handler throws.

<sup>Written for commit a0ebe5f6ed2a4f1064ec4b8745f8c212c7829a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mcp-use/mcp-use/pull/2532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

